### PR TITLE
bug(#61): don't fail on non match

### DIFF
--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -24,17 +24,11 @@ import qualified Yaml as Y
 import qualified Data.Map.Strict as M
 
 data RewriteException
-  = CouldNotMatch {pattern :: Expression, program :: Program}
-  | CouldNotBuild {expr :: Expression, substs :: [Subst]}
+  = CouldNotBuild {expr :: Expression, substs :: [Subst]}
   | CouldNotReplace {prog :: Program, ptn :: Expression, res :: Expression}
   deriving (Exception)
 
 instance Show RewriteException where
-  show CouldNotMatch {..} =
-    printf
-      "Couldn't find given pattern in provided program\n--Pattern: %s\n--Program: %s"
-      (printExpression pattern)
-      (printProgram program)
   show CouldNotBuild {..} =
     printf
       "Couldn't build given expression with provided substitutions\n--Expression: %s\n--Substitutions: %s"
@@ -120,7 +114,7 @@ applyRules program [rule] = do
   let ptn = Y.pattern rule
       res = Y.result rule
   case matchProgram ptn program of
-    [] -> throwIO (CouldNotMatch ptn program)
+    [] -> pure program
     substs -> do
       let replaced = buildAndReplace program ptn res
       case Y.when rule of

--- a/test-resources/rewriter-packs/desugares-without-match.yaml
+++ b/test-resources/rewriter-packs/desugares-without-match.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: |
+  {[[
+    foo ↦ ⟦
+      x -> 4294967295
+    ⟧
+  ]]}
+output: |-
+  Φ ↦ ⟦
+    foo ↦ ⟦
+      x ↦ Φ.org.eolang.number(
+        α0 ↦ Φ.org.eolang.bytes(
+          α0 ↦ ⟦ Δ ⤍ 41-EF-FF-FF-FF-E0-00-00 ⟧
+        )
+      )
+    ⟧
+  ⟧
+rules:
+  custom:
+    - pattern: Φ.x.y.z
+      result: Φ.a.b.c


### PR DESCRIPTION
Ref: #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in the rewriting process: when no pattern matches are found, the program now remains unchanged instead of raising an error.

- **Tests**
  - Added a new test resource to verify desugaring behavior when no pattern matches occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->