### PR TITLE
bug(#105): add `resources` directory to tar

### DIFF
--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: resources
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  check-resources:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: |-
+          # Create source distribution
+          echo "Running: cabal sdist"
+          cabal sdist
+
+          # Get package name and version from .cabal file
+          PKG_NAME=$(awk '/^name:/ { print $2 }' *.cabal)
+          PKG_VERSION=$(awk '/^version:/ { print $2 }' *.cabal)
+
+          # Build expected tarball path
+          TARBALL="dist-newstyle/sdist/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+
+          # Check if tarball was created
+          if [ ! -f "$TARBALL" ]; then
+            echo "ERROR: Tarball $TARBALL not found."
+            exit 1
+          fi
+
+          # Check if resources directory is inside the tarball
+          echo "Checking if 'resources/' directory is included in $TARBALL"
+          if ! tar -tzf "$TARBALL" | grep -q "^${PKG_NAME}-${PKG_VERSION}/resources/"; then
+            echo "ERROR: 'resources/' directory not found in the tarball!"
+            echo "Make sure 'extra-source-files: resources/*' is present in your .cabal file."
+            exit 1
+          fi
+
+          echo "Success: 'resources/' directory is present in the tarball."

--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -34,8 +34,7 @@ jobs:
           fi
 
           # Check if resources directory is inside the tarball
-          echo "Checking if 'resources/' directory is included in $TARBALL"
-          if ! tar -tzf "$TARBALL" | grep -q "^${PKG_NAME}-${PKG_VERSION}/resources/"; then
+          if ! tar -tzf "$TARBALL" 2>/dev/null | grep -q "^${PKG_NAME}-${PKG_VERSION}/resources/"; then
             echo "ERROR: 'resources/' directory not found in the tarball!"
             echo "Make sure 'extra-source-files: resources/*' is present in your .cabal file."
             exit 1

--- a/.github/workflows/resources.yml
+++ b/.github/workflows/resources.yml
@@ -21,8 +21,8 @@ jobs:
           cabal sdist
 
           # Get package name and version from .cabal file
-          PKG_NAME=$(awk '/^name:/ { print $2 }' *.cabal)
-          PKG_VERSION=$(awk '/^version:/ { print $2 }' *.cabal)
+          PKG_NAME=$(awk '/^name:/ { print $2 }' ./*.cabal)
+          PKG_VERSION=$(awk '/^version:/ { print $2 }' ./*.cabal)
 
           # Build expected tarball path
           TARBALL="dist-newstyle/sdist/${PKG_NAME}-${PKG_VERSION}.tar.gz"

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -21,7 +21,7 @@ jobs:
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
-          sed -E -i "s/phino-[0-9.]+/phino-${latest}/g" README.md
+          sed -E -i "s/phino-[0-9.]+/phino-0.${latest}/g" README.md
       - uses: peter-evans/create-pull-request@v7
         with:
           sign-commits: true

--- a/phino.cabal
+++ b/phino.cabal
@@ -13,6 +13,7 @@ maintainer:         mtrunnikov@gmail.com
 copyright:          2025 Objectionary.com
 category:           Language, Code Analysis
 build-type:         Simple
+extra-source-files: resources/*.yaml
 
 source-repository head
   type: git

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -38,8 +38,7 @@ withVoidRho :: [Binding] -> [Binding]
 withVoidRho bds = withVoidRho' bds False
   where
     withVoidRho' :: [Binding] -> Bool -> [Binding]
-    withVoidRho' [] True = []
-    withVoidRho' [] False = [BiVoid AtRho]
+    withVoidRho' [] hasRho = [BiVoid AtRho | not hasRho]
     withVoidRho' (bd : bds) hasRho = 
       case bd of
         BiMeta _ -> bd : bds

--- a/test-resources/rewriter-packs/basic/copy-simple.yaml
+++ b/test-resources/rewriter-packs/basic/copy-simple.yaml
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-skip: true
 rules:
   basic: ['copy']
 input: |
-  Φ ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ξ) ⟧
+  Φ ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ⟦⟧) ⟧
 output: |-
-  Φ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ξ) ⟧ ⟧ ⟧
+  Φ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧

--- a/test-resources/rewriter-packs/basic/copy-with-tail.yaml
+++ b/test-resources/rewriter-packs/basic/copy-with-tail.yaml
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-skip: true
 rules:
   basic: ['copy']
 input: |
-  Φ ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ξ).a ⟧
+  Φ ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ⟦⟧).a ⟧
 output: |-
-  Φ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ ξ).a ⟧ ⟧.a ⟧
+  Φ ↦ ⟦ a ↦ ⟦ b ↦ ⟦ ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧.a, ρ ↦ ∅ ⟧

--- a/test/ConditionSpec.hs
+++ b/test/ConditionSpec.hs
@@ -17,12 +17,12 @@ import Misc
 import Printer (printSubstitutions)
 import System.FilePath
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO)
-import Yaml qualified as Y
+import Yaml qualified
 
 data ConditionPack = ConditionPack
   { expression :: Expression,
     pattern :: Expression,
-    condition :: Y.Condition
+    condition :: Yaml.Condition
   }
   deriving (Generic, FromJSON, Show)
 


### PR DESCRIPTION
Closes: #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a workflow to verify the inclusion of the resources directory in package distributions.
	- Updated package configuration to include YAML files from the resources directory in distributions.
- **Refactor**
	- Simplified internal logic for handling empty lists in a helper function without changing behavior.
	- Updated import aliases for clarity in test files.
- **Tests**
	- Enabled and updated test cases to use explicit empty objects and mappings, adjusting expected outputs accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->