### PR TITLE
bug(#122): print program to XMIR

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -10,6 +10,7 @@ path = [
     "phino.cabal",
     "**.lock",
     "**.phi",
+    "**.xmir",
     ".pdd"
 ]
 precedence = "override"

--- a/phino.cabal
+++ b/phino.cabal
@@ -30,12 +30,14 @@ library
     Matcher,
     Builder,
     Replacer,
-    Printer,
     Rewriter,
     Yaml,
     Condition,
     Misc,
-    Logger
+    Logger,
+    Printer,
+    Pretty,
+    XMIR
   hs-source-dirs: src
   other-modules:
     Paths_phino
@@ -58,7 +60,8 @@ library
     prettyprinter,
     optparse-applicative,
     vector,
-    random
+    random,
+    xml-conduit ^>=1.10
   default-language: Haskell2010
 
 -- Executable using the library
@@ -89,6 +92,7 @@ test-suite spec
     ConditionSpec,
     YamlSpec,
     MiscSpec,
+    XMIRSpec,
     Paths_phino
   autogen-modules:
     Paths_phino
@@ -109,7 +113,8 @@ test-suite spec
     yaml,
     text,
     silently,
-    directory
+    directory,
+    xml-conduit ^>=1.10
   build-tool-depends:
     hspec-discover:hspec-discover
   default-language: Haskell2010

--- a/src/Condition.hs
+++ b/src/Condition.hs
@@ -7,11 +7,10 @@ import Ast
 import Builder (buildAttribute, buildBinding)
 import Data.Aeson (FromJSON)
 import qualified Data.Map.Strict as M
-import GHC.Generics
 import GHC.IO (unsafePerformIO)
 import Matcher
 import Misc (allPathsIn)
-import Printer (printCondition, printExpression, printSubstitutions)
+import Pretty (prettyExpression, prettySubsts)
 import Yaml (normalizationRules)
 import qualified Yaml as Y
 

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -17,7 +17,6 @@ import qualified Data.Map.Strict as Map
 import Matcher
 import Prettyprinter
 import Prettyprinter.Render.String (renderString)
-import Text.Printf (vFmt)
 
 prettyMeta :: String -> Doc ann
 prettyMeta meta = pretty "!" <> pretty meta

--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module Pretty
+  ( prettyExpression,
+    prettyProgram,
+    prettyAttribute,
+    prettySubsts,
+    prettyBinding,
+  )
+where
+
+import Ast
+import qualified Data.Map.Strict as Map
+import Matcher
+import Prettyprinter
+import Prettyprinter.Render.String (renderString)
+import Text.Printf (vFmt)
+
+prettyMeta :: String -> Doc ann
+prettyMeta meta = pretty "!" <> pretty meta
+
+prettyArrow :: Doc ann
+prettyArrow = pretty "↦"
+
+prettyDashedArrow :: Doc ann
+prettyDashedArrow = pretty "⤍"
+
+instance Pretty Attribute where
+  pretty (AtLabel name) = pretty name
+  pretty (AtAlpha index) = pretty "α" <> pretty index
+  pretty AtRho = pretty "ρ"
+  pretty AtPhi = pretty "φ"
+  pretty (AtMeta meta) = prettyMeta meta
+
+instance Pretty Binding where
+  pretty (BiTau attr expr) = pretty attr <+> prettyArrow <+> pretty expr
+  pretty (BiMeta meta) = prettyMeta meta
+  pretty (BiDelta bytes) = pretty "Δ" <+> prettyDashedArrow <+> pretty bytes
+  pretty (BiMetaDelta meta) = pretty "Δ" <+> prettyDashedArrow <+> prettyMeta meta
+  pretty (BiVoid attr) = pretty attr <+> prettyArrow <+> pretty "∅"
+  pretty (BiLambda func) = pretty "λ" <+> prettyDashedArrow <+> pretty func
+  pretty (BiMetaLambda meta) = pretty "λ" <+> prettyDashedArrow <+> prettyMeta meta
+
+instance {-# OVERLAPPING #-} Pretty [Binding] where
+  pretty bindings = vsep (punctuate comma (map pretty bindings))
+
+instance Pretty Expression where
+  pretty (ExFormation []) = pretty "⟦⟧"
+  pretty (ExFormation [binding]) = case binding of
+    BiTau _ _ -> vsep [pretty "⟦", indent 2 (pretty binding), pretty "⟧"]
+    _ -> pretty "⟦" <+> pretty binding <+> pretty "⟧"
+  pretty (ExFormation bindings) = vsep [pretty "⟦", indent 2 (pretty bindings), pretty "⟧"]
+  pretty ExThis = pretty "ξ"
+  pretty ExGlobal = pretty "Φ"
+  pretty ExTermination = pretty "⊥"
+  pretty (ExMeta meta) = prettyMeta meta
+  pretty (ExApplication expr tau) = pretty expr <> vsep [lparen, indent 2 (pretty tau), rparen]
+  pretty (ExDispatch expr attr) = pretty expr <> pretty "." <> pretty attr
+  pretty (ExMetaTail expr meta) = pretty expr <+> pretty "*" <+> prettyMeta meta
+
+instance Pretty Program where
+  pretty (Program expr) = pretty "Φ" <+> prettyArrow <+> pretty expr
+
+instance Pretty Tail where
+  pretty (TaApplication tau) = vsep [lparen, indent 2 (pretty tau), rparen]
+  pretty (TaDispatch attr) = pretty "." <> pretty attr
+
+instance Pretty MetaValue where
+  pretty (MvAttribute attr) = pretty attr
+  pretty (MvBytes bytes) = pretty bytes
+  pretty (MvBindings []) = pretty "[]"
+  pretty (MvBindings bindings) = vsep [pretty "[", indent 2 (pretty bindings), pretty "]"]
+  pretty (MvFunction func) = pretty func
+  pretty (MvExpression expr) = pretty expr
+  pretty (MvTail tails) = vsep (punctuate comma (map pretty tails))
+
+instance Pretty Subst where
+  pretty (Subst mp) =
+    vsep
+      [ lparen,
+        indent
+          2
+          ( vsep
+              ( punctuate
+                  comma
+                  ( map
+                      (\(key, value) -> prettyMeta key <+> pretty ">>" <+> pretty value)
+                      (Map.toList mp)
+                  )
+              )
+          ),
+        rparen
+      ]
+
+instance {-# OVERLAPPING #-} Pretty [Subst] where
+  pretty [] = pretty "[]"
+  pretty substs = vsep [pretty "[", indent 2 (vsep (punctuate comma (map pretty substs))), pretty "]"]
+
+render :: (Pretty a) => a -> String
+render printable = renderString (layoutPretty defaultLayoutOptions (pretty printable))
+
+prettyBinding :: Binding -> String
+prettyBinding = render
+
+prettyAttribute :: Attribute -> String
+prettyAttribute = render
+
+prettySubsts :: [Subst] -> String
+prettySubsts = render
+
+prettyExpression :: Expression -> String
+prettyExpression = render
+
+prettyProgram :: Program -> String
+prettyProgram = render

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -1,115 +1,21 @@
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE InstanceSigs #-}
-
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Printer (printExpression, printProgram, printSubstitutions, printCondition) where
+module Printer where
 
 import Ast
-import qualified Data.Map.Strict as Map
-import Matcher
-import Prettyprinter
-import Prettyprinter.Render.String (renderString)
-import Text.Printf (vFmt)
-import Yaml (Condition)
-import qualified Yaml as Y
+import Pretty (prettyProgram)
+import XMIR (programToXMIR, printXMIR)
 
-prettyMeta :: String -> Doc ann
-prettyMeta meta = pretty "!" <> pretty meta
+data PrintFormat = XMIR | PHI
+  deriving (Eq)
 
-prettyArrow :: Doc ann
-prettyArrow = pretty "↦"
+instance Show PrintFormat where
+  show XMIR = "xmir"
+  show PHI = "phi"
 
-prettyDashedArrow :: Doc ann
-prettyDashedArrow = pretty "⤍"
-
-instance Pretty Attribute where
-  pretty (AtLabel name) = pretty name
-  pretty (AtAlpha index) = pretty "α" <> pretty index
-  pretty AtRho = pretty "ρ"
-  pretty AtPhi = pretty "φ"
-  pretty (AtMeta meta) = prettyMeta meta
-
-instance Pretty Binding where
-  pretty (BiTau attr expr) = pretty attr <+> prettyArrow <+> pretty expr
-  pretty (BiMeta meta) = prettyMeta meta
-  pretty (BiDelta bytes) = pretty "Δ" <+> prettyDashedArrow <+> pretty bytes
-  pretty (BiMetaDelta meta) = pretty "Δ" <+> prettyDashedArrow <+> prettyMeta meta
-  pretty (BiVoid attr) = pretty attr <+> prettyArrow <+> pretty "∅"
-  pretty (BiLambda func) = pretty "λ" <+> prettyDashedArrow <+> pretty func
-  pretty (BiMetaLambda meta) = pretty "λ" <+> prettyDashedArrow <+> prettyMeta meta
-
-instance {-# OVERLAPPING #-} Pretty [Binding] where
-  pretty bindings = vsep (punctuate comma (map pretty bindings))
-
-instance Pretty Expression where
-  pretty (ExFormation []) = pretty "⟦⟧"
-  pretty (ExFormation [binding]) = case binding of
-    BiTau _ _ -> vsep [pretty "⟦", indent 2 (pretty binding), pretty "⟧"]
-    _ -> pretty "⟦" <+> pretty binding <+> pretty "⟧"
-  pretty (ExFormation bindings) = vsep [pretty "⟦", indent 2 (pretty bindings), pretty "⟧"]
-  pretty ExThis = pretty "ξ"
-  pretty ExGlobal = pretty "Φ"
-  pretty ExTermination = pretty "⊥"
-  pretty (ExMeta meta) = prettyMeta meta
-  pretty (ExApplication expr tau) = pretty expr <> vsep [lparen, indent 2 (pretty tau), rparen]
-  pretty (ExDispatch expr attr) = pretty expr <> pretty "." <> pretty attr
-  pretty (ExMetaTail expr meta) = pretty expr <+> pretty "*" <+> prettyMeta meta
-
-instance Pretty Program where
-  pretty (Program expr) = pretty "Φ" <+> prettyArrow <+> pretty expr
-
-instance Pretty Tail where
-  pretty (TaApplication tau) = vsep [lparen, indent 2 (pretty tau), rparen]
-  pretty (TaDispatch attr) = pretty "." <> pretty attr
-
-instance Pretty MetaValue where
-  pretty (MvAttribute attr) = pretty attr
-  pretty (MvBytes bytes) = pretty bytes
-  pretty (MvBindings []) = pretty "[]"
-  pretty (MvBindings bindings) = vsep [pretty "[", indent 2 (pretty bindings), pretty "]"]
-  pretty (MvFunction func) = pretty func
-  pretty (MvExpression expr) = pretty expr
-  pretty (MvTail tails) = vsep (punctuate comma (map pretty tails))
-
-instance Pretty Subst where
-  pretty (Subst mp) =
-    vsep
-      [ lparen,
-        indent
-          2
-          ( vsep
-              ( punctuate
-                  comma
-                  ( map
-                      (\(key, value) -> prettyMeta key <+> pretty ">>" <+> pretty value)
-                      (Map.toList mp)
-                  )
-              )
-          ),
-        rparen
-      ]
-
-instance Pretty Condition where
-  pretty (Y.NF expr) = pretty "NF(" <+> pretty expr <+> rparen
-
-instance {-# OVERLAPPING #-} Pretty [Subst] where
-  pretty :: [Subst] -> Doc ann
-  pretty [] = pretty "[]"
-  pretty substs = vsep [pretty "[", indent 2 (vsep (punctuate comma (map pretty substs))), pretty "]"]
-
-prettyPrint :: (Pretty a) => a -> String
-prettyPrint printable = renderString (layoutPretty defaultLayoutOptions (pretty printable))
-
-printCondition :: Condition -> String
-printCondition = prettyPrint
-
-printSubstitutions :: [Subst] -> String
-printSubstitutions = prettyPrint
-
-printExpression :: Expression -> String
-printExpression = prettyPrint
-
-printProgram :: Program -> String
-printProgram = prettyPrint
+printProgram :: Program -> PrintFormat -> IO String
+printProgram prog PHI = pure (prettyProgram prog)
+printProgram prog XMIR = do
+  xmir <- programToXMIR prog
+  pure (printXMIR xmir)

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -18,7 +18,7 @@ import Logger (logDebug)
 import Matcher (MetaValue (MvAttribute, MvBindings, MvExpression), Subst (Subst), combine, combineMany, matchProgram, substEmpty, substSingle)
 import Misc (ensuredFile)
 import Parser (parseProgram, parseProgramThrows)
-import Printer (printExpression, printProgram, printSubstitutions)
+import Pretty (prettyExpression, prettyProgram, prettySubsts)
 import Replacer (replaceProgram)
 import Text.Printf
 import qualified Yaml as Y
@@ -32,14 +32,14 @@ instance Show RewriteException where
   show CouldNotBuild {..} =
     printf
       "Couldn't build given expression with provided substitutions\n--Expression: %s\n--Substitutions: %s"
-      (printExpression expr)
-      (printSubstitutions substs)
+      (prettyExpression expr)
+      (prettySubsts substs)
   show CouldNotReplace {..} =
     printf
       "Couldn't replace expression in program by pattern\nProgram: %s\n--Pattern: %s\n--Result: %s"
-      (printProgram prog)
-      (printExpression ptn)
-      (printExpression res)
+      (prettyProgram prog)
+      (prettyExpression ptn)
+      (prettyExpression res)
 
 -- Build pattern and result expression and replace patterns to results in given program
 buildAndReplace :: Program -> Expression -> Expression -> [Subst] -> IO Program
@@ -83,6 +83,6 @@ rewrite program (rule : rest) = do
       pure program
     Just matched -> do
       let substs = extended matched
-      logDebug (printf "Rule has been matched, substitutions are:\n%s" (printSubstitutions substs))
+      logDebug (printf "Rule has been matched, substitutions are:\n%s" (prettySubsts substs))
       replaced substs
   rewrite prog rest

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -13,13 +13,10 @@ import qualified Data.Bifunctor
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (catMaybes, mapMaybe)
-import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
-import qualified Data.Text.Lazy.IO as TL
-import Prettyprinter (Pretty (pretty))
 import Pretty (prettyAttribute, prettyBinding, prettyExpression, prettyProgram)
 import Text.Printf (printf)
 import Text.XML

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module XMIR where
+
+import Ast
+import Control.Exception (throwIO)
+import Control.Exception.Base (Exception)
+import qualified Data.Bifunctor
+import Data.Map (Map)
+import qualified Data.Map as M
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Monoid ((<>))
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Text.Lazy.IO as TL
+import Prettyprinter (Pretty (pretty))
+import Pretty (prettyAttribute, prettyBinding, prettyExpression, prettyProgram)
+import Text.Printf (printf)
+import Text.XML
+
+data XMIRException
+  = UnsupportedExpression {expr :: Expression}
+  | UnsupportedBinding {binding :: Binding}
+  deriving (Exception)
+
+instance Show XMIRException where
+  show UnsupportedExpression {..} = printf "XMIR does not support such expression: %s" (prettyExpression expr)
+  show UnsupportedBinding {..} = printf "XMIR does not support such bindings: %s" (prettyBinding binding)
+
+toName :: String -> Name
+toName str = Name (T.pack str) Nothing Nothing
+
+element :: String -> [(String, String)] -> [Node] -> Element
+element name attrs children = do
+  let name' = toName name
+      attrs' = M.fromList (map (Data.Bifunctor.bimap toName T.pack) attrs)
+  Element name' attrs' children
+
+object :: [(String, String)] -> [Node] -> Node
+object attrs children = NodeElement (element "o" attrs children)
+
+expression :: Expression -> IO (String, [Node])
+expression ExThis = pure ("$", [])
+expression ExGlobal = pure ("Q", [])
+expression (ExFormation bds) = do
+  nested <- nestedBindings bds
+  pure ("", nested)
+expression (ExDispatch expr attr) = do
+  (base, children) <- expression expr
+  let attr' = prettyAttribute attr
+  if null base
+    then pure ('.' : attr', [object [] children])
+    else
+      if head base == '.' || not (null children)
+        then pure ('.' : attr', [object [("base", base)] children])
+        else pure (base ++ ('.' : attr'), children)
+expression (ExApplication expr (BiTau attr texpr)) = do
+  (base, children) <- expression expr
+  (base', children') <- expression texpr
+  let as = prettyAttribute attr
+      attrs =
+        if null base'
+          then [("as", as)]
+          else [("as", as), ("base", base')]
+  pure (base, object attrs children' : children)
+expression (ExApplication (ExFormation bds) tau) = throwIO (UnsupportedExpression (ExApplication (ExFormation bds) tau))
+expression expr = throwIO (UnsupportedExpression expr)
+
+nestedBindings :: [Binding] -> IO [Node]
+nestedBindings bds = catMaybes <$> mapM formationBinding bds
+
+formationBinding :: Binding -> IO (Maybe Node)
+formationBinding (BiTau (AtLabel label) (ExFormation bds)) = do
+  inners <- nestedBindings bds
+  pure (Just (object [("name", label)] inners))
+formationBinding (BiTau (AtLabel label) expr) = do
+  (base, children) <- expression expr
+  pure (Just (object [("name", label), ("base", base)] (reverse children)))
+formationBinding (BiDelta bytes) = pure (Just (NodeContent (T.pack bytes)))
+formationBinding (BiLambda func) = pure (Just (object [("name", "λ")] []))
+formationBinding (BiVoid AtRho) = pure Nothing
+formationBinding (BiVoid AtPhi) = pure (Just (object [("name", "φ"), ("base", "∅")] []))
+formationBinding (BiVoid (AtLabel label)) = pure (Just (object [("name", label), ("base", "∅")] []))
+formationBinding binding = throwIO (UnsupportedBinding binding)
+
+rootExpression :: Expression -> IO [Node]
+rootExpression (ExFormation []) = pure []
+rootExpression (ExFormation [bd, BiVoid AtRho]) = nestedBindings [bd]
+rootExpression expr = throwIO (UnsupportedExpression expr)
+
+programToXMIR :: Program -> IO Document
+programToXMIR (Program expr) = do
+  root <- rootExpression expr
+  pure
+    ( Document
+        (Prologue [] Nothing [])
+        ( element
+            "object"
+            [("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")]
+            ( NodeElement (element "listing" [] [NodeContent (T.pack (prettyProgram (Program expr)))])
+                : root
+            )
+        )
+        []
+    )
+
+-- Add indentation (2 spaces per level).
+indent :: Int -> TB.Builder
+indent n = TB.fromText (T.replicate n (T.pack "  "))
+
+newline :: TB.Builder
+newline = TB.fromString "\n"
+
+printElement :: Int -> Element -> TB.Builder
+printElement indentLevel (Element name attrs nodes)
+  | null nodes =
+      indent indentLevel
+        <> TB.fromString "<"
+        <> TB.fromText (nameLocalName name)
+        <> attrsText
+        <> TB.fromString "/>"
+        <> newline
+  | all isTextNode nodes =
+      indent indentLevel
+        <> TB.fromString "<"
+        <> TB.fromText (nameLocalName name)
+        <> attrsText
+        <> TB.fromString ">"
+        <> mconcat (map printRawText nodes)
+        <> TB.fromString "</"
+        <> TB.fromText (nameLocalName name)
+        <> TB.fromString ">"
+        <> newline
+  | otherwise =
+      indent indentLevel
+        <> TB.fromString "<"
+        <> TB.fromText (nameLocalName name)
+        <> attrsText
+        <> TB.fromString ">"
+        <> newline
+        <> mconcat (map (printNode (indentLevel + 1)) nodes)
+        <> indent indentLevel
+        <> TB.fromString "</"
+        <> TB.fromText (nameLocalName name)
+        <> TB.fromString ">"
+        <> newline
+  where
+    attrsText =
+      mconcat
+        [ TB.fromString " " <> TB.fromText (nameLocalName k) <> TB.fromString "=\"" <> TB.fromText v <> TB.fromString "\""
+          | (k, v) <- M.toList attrs
+        ]
+
+    isTextNode (NodeContent _) = True
+    isTextNode _ = False
+
+    printRawText (NodeContent t) = TB.fromText t
+    printRawText _ = mempty
+
+printNode :: Int -> Node -> TB.Builder
+printNode _ (NodeContent t) = TB.fromText t -- print text exactly as-is
+printNode i (NodeElement e) = printElement i e -- pretty-print elements
+printNode i (NodeComment t) = indent i <> TB.fromString "<!-- " <> TB.fromText t <> TB.fromString " -->" <> newline
+printNode _ _ = mempty
+
+printXMIR :: Document -> String
+printXMIR (Document _ root _) =
+  TL.unpack
+    ( TB.toLazyText
+        ( TB.fromString "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            <> newline
+            <> printElement 0 root
+        )
+    )

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 ---
 # yamllint disable rule:line-length
 snapshot:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/25.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -22,7 +22,8 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 #
-# extra-deps:
+extra-deps:
+  - xml-conduit-1.10.0.0@sha256:29fa134ed3f2b20bf3026de5116ef30cc14fab61b2d7c8efe261ba7ed217c1a9,3058
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@
 ---
 # yamllint disable rule:line-length
 snapshot:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/25.yaml
+  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test-resources/xmir/program.phi
+++ b/test-resources/xmir/program.phi
@@ -1,0 +1,27 @@
+Φ ↦ ⟦
+  x ↦ ⟦
+    y ↦ ⟦ Δ ⤍ 00-01 ⟧,
+    right ↦ ⟦
+      λ ⤍ Func,
+      x ↦ ∅
+    ⟧,
+    ρ ↦ ∅,
+    φ ↦ ∅,
+    void ↦ ∅,
+    global ↦ Φ,
+    this ↦ ξ,
+    this-disp-label ↦ ξ.org,
+    this-disp-idx ↦ ξ.α1,
+    global-disp-label ↦ Φ.org,
+    global-disp-idx ↦ Φ.α1,
+    formation-disp ↦ ⟦ attr ↦ ∅ ⟧.attr,
+    org-eolang ↦ Φ.org.eolang,
+    nested ↦ ⟦ attr ↦ ∅ ⟧.attr.other,
+    appl1 ↦ Φ.org(
+      as ↦ Φ.eolang
+    ),
+    appl2 ↦ ⟦⟧.attr(
+      xyz ↦ ξ, abc ↦ Φ, α1 ↦ ⟦⟧
+    )
+  ⟧
+⟧

--- a/test-resources/xmir/program.xmir
+++ b/test-resources/xmir/program.xmir
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <listing>Φ ↦ ⟦
+  x ↦ ⟦
+    y ↦ ⟦
+      Δ ⤍ 00-01,
+      ρ ↦ ∅
+    ⟧,
+    right ↦ ⟦
+      λ ⤍ Func,
+      x ↦ ∅,
+      ρ ↦ ∅
+    ⟧,
+    ρ ↦ ∅,
+    φ ↦ ∅,
+    void ↦ ∅,
+    global ↦ Φ,
+    this ↦ ξ,
+    this-disp-label ↦ ξ.org,
+    this-disp-idx ↦ ξ.α1,
+    global-disp-label ↦ Φ.org,
+    global-disp-idx ↦ Φ.α1,
+    formation-disp ↦ ⟦
+      attr ↦ ∅,
+      ρ ↦ ∅
+    ⟧.attr,
+    org-eolang ↦ Φ.org.eolang,
+    nested ↦ ⟦
+      attr ↦ ∅,
+      ρ ↦ ∅
+    ⟧.attr.other,
+    appl1 ↦ Φ.org(
+      as ↦ Φ.eolang
+    ),
+    appl2 ↦ ⟦ ρ ↦ ∅ ⟧.attr(
+      xyz ↦ ξ
+    )(
+      abc ↦ Φ
+    )(
+      α1 ↦ ⟦ ρ ↦ ∅ ⟧
+    )
+  ⟧,
+  ρ ↦ ∅
+⟧</listing>
+  <o name="x">
+    <o name="y">00-01</o>
+    <o name="right">
+      <o name="λ"/>
+      <o base="∅" name="x"/>
+    </o>
+    <o base="∅" name="φ"/>
+    <o base="∅" name="void"/>
+    <o base="Q" name="global"/>
+    <o base="$" name="this"/>
+    <o base="$.org" name="this-disp-label"/>
+    <o base="$.α1" name="this-disp-idx"/>
+    <o base="Q.org" name="global-disp-label"/>
+    <o base="Q.α1" name="global-disp-idx"/>
+    <o base=".attr" name="formation-disp">
+      <o>
+        <o base="∅" name="attr"/>
+      </o>
+    </o>
+    <o base="Q.org.eolang" name="org-eolang"/>
+    <o base=".other" name="nested">
+      <o base=".attr">
+        <o>
+          <o base="∅" name="attr"/>
+        </o>
+      </o>
+    </o>
+    <o base="Q.org" name="appl1">
+      <o as="as" base="Q.eolang"/>
+    </o>
+    <o base=".attr" name="appl2">
+      <o/>
+      <o as="xyz" base="$"/>
+      <o as="abc" base="Q"/>
+      <o as="α1"/>
+    </o>
+  </o>
+</object>

--- a/test/ConditionSpec.hs
+++ b/test/ConditionSpec.hs
@@ -14,7 +14,7 @@ import Data.Yaml qualified as Y
 import GHC.Generics
 import Matcher (matchProgram)
 import Misc
-import Printer (printSubstitutions)
+import Pretty (prettySubsts)
 import System.FilePath
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO)
 import Yaml qualified
@@ -42,6 +42,6 @@ spec = do
             (null met)
             ( expectationFailure $
                 "List of substitution after condition check must be not empty\nOriginal substitutions:\n"
-                  ++ printSubstitutions matched
+                  ++ prettySubsts matched
             )
       )

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -8,7 +8,7 @@ import Control.Monad (forM_)
 import Matcher (MetaValue (MvAttribute, MvExpression), substEmpty, substSingle)
 import Parser (parseProgramThrows)
 import Prettyprinter
-import Printer
+import Pretty
 import Test.Hspec (Example (Arg), Expectation, Spec, SpecWith, describe, it, runIO, shouldBe)
 
 test :: (Pretty a) => (a -> String) -> [(String, String, a)] -> SpecWith (Arg Expectation)
@@ -35,11 +35,11 @@ spec = do
               "Φ ↦ ⟦\n  Δ ⤍ 00-,\n  λ ⤍ F,\n  ρ ↦ ∅,\n  !B,\n  φ ↦ ⟦\n    y ↦ ∅,\n    ρ ↦ ∅\n  ⟧\n⟧"
             )
           ]
-    test printProgram useCases
+    test prettyProgram useCases
 
   describe "print substitution" $
     test
-      printSubstitutions
+      prettySubsts
       [ ("[()]", "[\n  (\n    \n  )\n]", [substEmpty]),
         ("[(!e >> Q.x)]", "[\n  (\n    !e >> Φ.x\n  )\n]", [substSingle "e" (MvExpression (ExDispatch ExGlobal (AtLabel "x")))]),
         ("[(!a >> x)]", "[\n  (\n    !a >> x\n  )\n]", [substSingle "a" (MvAttribute (AtLabel "x"))])

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -16,7 +16,7 @@ import Data.Yaml qualified as Yaml
 import GHC.Generics
 import Misc (allPathsIn, ensuredFile)
 import Parser (parseProgramThrows)
-import Printer (printProgram)
+import Pretty (prettyProgram)
 import Rewriter (rewrite)
 import System.FilePath (makeRelative, replaceExtension, (</>))
 import Test.Hspec (Spec, describe, expectationFailure, it, pending, runIO)
@@ -97,8 +97,8 @@ spec = do
               unless (rewritten == result') $
                 expectationFailure
                   ( "Wrong rewritten program. Expected:\n"
-                      ++ printProgram result'
+                      ++ prettyProgram result'
                       ++ "\nGot:\n"
-                      ++ printProgram rewritten
+                      ++ prettyProgram rewritten
                   )
       )

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -1,0 +1,19 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module XMIRSpec where
+
+import Test.Hspec (Spec, it, shouldBe, runIO)
+import XMIR
+import Misc (ensuredFile)
+import Parser (parseProgramThrows)
+import qualified Data.Text as T
+
+spec :: Spec
+spec = do
+  phi <- runIO $ readFile =<< ensuredFile "test-resources/xmir/program.phi"
+  xmir <- runIO $ readFile =<< ensuredFile "test-resources/xmir/program.xmir"
+  prog <- runIO (parseProgramThrows phi)
+  doc <- runIO $ programToXMIR prog
+  let xmir' = printXMIR doc
+  it "prints valid xmir" $ T.stripEnd (T.pack xmir) `shouldBe` T.stripEnd (T.pack xmir')


### PR DESCRIPTION
Ref: #122 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting output format (PHI or XMIR) when rewriting programs via a new command-line option.
  - Introduced pretty-printing and XMIR export functionality for programs.
  - Added new modules for pretty-printing and XMIR conversion.
- **Bug Fixes**
  - Improved CLI and output formatting consistency.
- **Tests**
  - Expanded test coverage to include XMIR output verification and updated tests for new output formats.
- **Chores**
  - Updated dependencies and configuration to include new modules and XML support.
  - Added new test resources for XMIR and PHI formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->