### PR TITLE
bug(#137): use argument for input file instead of option

### DIFF
--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -96,7 +96,7 @@ spec = do
   describe "rewrites" $ do
     it "desugares with --nothing flag from file" $
       testCLI
-        ["rewrite", "--nothing", "--phi-input=test-resources/cli/desugar.phi"]
+        ["rewrite", "--nothing", "test-resources/cli/desugar.phi"]
         ["Φ ↦ ⟦\n  foo ↦ Φ.org.eolang,\n  ρ ↦ ∅\n⟧"]
 
     it "desugares with --nothing flag from stdin" $
@@ -109,7 +109,7 @@ spec = do
 
     it "normalizes with --normalize flag" $
       testCLI
-        ["rewrite", "--normalize", "--phi-input=test-resources/cli/normalize.phi"]
+        ["rewrite", "--normalize", "test-resources/cli/normalize.phi"]
         [ unlines
             [ "Φ ↦ ⟦",
               "  x ↦ ⟦",


### PR DESCRIPTION
Closes: #137 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated command-line interface to accept the input file as an optional positional argument instead of using the `--phi-input` option.
  - Renamed several command-line options and internal references for clarity, including changing `printFormat` to `outputFormat`.
  - Adjusted the order of command-line arguments for improved usability.

- **Tests**
  - Updated CLI tests to reflect the new way of specifying the input file as a positional argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->