### PR TITLE
bug(#140): omit listing

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -61,6 +61,7 @@ data OptsRewrite = OptsRewrite
     normalize :: Bool,
     nothing :: Bool,
     shuffle :: Bool,
+    omitListing :: Bool,
     maxDepth :: Integer
   }
 
@@ -82,6 +83,7 @@ rewriteParser =
             <*> switch (long "normalize" <> help "Use built-in normalization rules")
             <*> switch (long "nothing" <> help "Just desugar provided 𝜑-program")
             <*> switch (long "shuffle" <> help "Shuffle rules before applying")
+            <*> switch (long "omit-listing" <> help "Omit full program listing in XMIR output")
             <*> option auto (long "max-depth" <> metavar "DEPTH" <> help "Max amount of rewritng cycles" <> value 25 <> showDefault)
         )
 
@@ -199,5 +201,5 @@ runCLI args = handle handler $ do
         printProgram :: Program -> IOFormat -> PrintMode -> IO String
         printProgram prog PHI mode = pure (prettyProgram' prog mode)
         printProgram prog XMIR mode = do
-          xmir <- programToXMIR prog mode
+          xmir <- programToXMIR prog mode omitListing
           pure (printXMIR xmir)

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -166,11 +166,15 @@ time now = do
       nanos = floor (fractional * 1_000_000_000) :: Int
   base ++ "." ++ printf "%09d" nanos ++ "Z"
 
-programToXMIR :: Program -> PrintMode -> IO Document
-programToXMIR (Program expr) mode = do
+programToXMIR :: Program -> PrintMode -> Bool -> IO Document
+programToXMIR (Program expr) mode omitListing = do
   (pckg, expr') <- getPackage expr
   root <- rootExpression expr'
   now <- getCurrentTime
+  let phi = prettyProgram' (Program expr) mode
+      listing = if omitListing
+        then show (length (lines phi)) ++ " lines of phi"
+        else phi
   pure
     ( Document
         (Prologue [] Nothing [])
@@ -184,7 +188,7 @@ programToXMIR (Program expr) mode = do
               ("version", showVersion version),
               ("xsi:noNamespaceSchemaLocation", "https://raw.githubusercontent.com/objectionary/eo/refs/heads/gh-pages/XMIR.xsd")
             ]
-            ( NodeElement (element "listing" [] [NodeContent (T.pack (prettyProgram' (Program expr) mode))])
+            ( NodeElement (element "listing" [] [NodeContent (T.pack listing)])
                 : root
                 : metasWithPackage (intercalate "." pckg)
             )

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -175,3 +175,9 @@ spec = do
                 "⟧}"
               ]
           ]
+
+    it "rewrites as XMIR with omit-listing flag" $
+      withStdin "Q -> [[ x -> Q.y ]]" $
+        testCLI
+          ["rewrite", "--nothing", "--output=xmir", "--omit-listing"]
+          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>4 lines of phi</listing>", "  <o base=\"Q.y\" name=\"x\"/>"]


### PR DESCRIPTION
Closes: #140 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line option to omit the full program listing from XMIR output, replacing it with a summary of the number of lines.
* **Tests**
  * Introduced a new test case to verify XMIR output when the omit-listing option is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->