### PR TITLE
bug(#178): escape hex

### DIFF
--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -128,6 +128,8 @@ allPathsIn dir = do
 -- [64,20,0,0,0,0,0,0]
 -- >>> hexToBts "68-65-6C-6C-6F"
 -- [104,101,108,108,111]
+-- >>> hexToBts "01-01"
+-- [1,1]
 hexToBts :: String -> [Word8]
 hexToBts = map readHexByte . splitOnDash
   where
@@ -193,6 +195,8 @@ numToHex num = btsToHex (unpack (toLazyByteString (word64BE (doubleToWord num)))
 -- "68-"
 -- >>> strToHex "h\""
 -- "68-22"
+-- >>> strToHex "\x01\x01"
+-- "01-01"
 strToHex :: String -> String
 strToHex "" = "--"
 strToHex [ch] = btsToHex (unpack (U.fromString [ch])) ++ "-"
@@ -211,6 +215,8 @@ strToHex str = btsToHex (unpack (U.fromString str))
 -- ""
 -- >>> hexToStr "68-22"
 -- "h\\\""
+-- >>> hexToStr "01-01"
+-- "\\x01\\x01"
 hexToStr :: String -> String
 hexToStr "--" = ""
 hexToStr [] = ""

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -242,7 +242,8 @@ spec = do
         "⟦x ↦ Φ.org.eolang(z ↦ ξ.f, x ↦ α0, φ ↦ ρ, t ↦ φ, first ↦ ⟦ λ ⤍ Function_name, Δ ⤍ 42- ⟧)⟧",
         "[[x -> 1.00e+3, y -> 2.32e-4]]",
         "[[ x -> \"\\u0001\\u0001\"]]",
-        "[[ x -> \"\\uD835\\uDF11\"]]"
+        "[[ x -> \"\\uD835\\uDF11\"]]",
+        "[[ x ↦ \"This plugin has \\x01\\x01\" ]]"
       ]
       (\expr -> it expr (parseExpression expr `shouldSatisfy` isRight))
 


### PR DESCRIPTION
Ref: #178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing `\x` hexadecimal escape sequences in strings.
  
* **Documentation**
  * Added example usages for hex and string conversion functions in the documentation.

* **Tests**
  * Introduced new test cases to verify correct parsing of hex escape sequences in string expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->