### PR TITLE
bug(#182): replace dashes in XMIR

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -270,10 +270,17 @@ printElement indentLevel (Element name attrs nodes)
     printRawText (NodeContent t) = TB.fromText t
     printRawText _ = mempty
 
+-- >>> printNode 0 (NodeComment (T.pack "--hello--"))
+-- "<!-- &#45;&#45;hello&#45;&#45; -->\n"
 printNode :: Int -> Node -> TB.Builder
 printNode _ (NodeContent t) = TB.fromText t -- print text exactly as-is
 printNode i (NodeElement e) = printElement i e -- pretty-print elements
-printNode i (NodeComment t) = indent i <> TB.fromString "<!-- " <> TB.fromText t <> TB.fromString " -->" <> newline
+printNode i (NodeComment t) =
+  indent i
+    <> TB.fromString "<!-- "
+    <> TB.fromText (T.replace "--" "&#45;&#45;" t)
+    <> TB.fromString " -->"
+    <> newline
 printNode _ _ = mempty
 
 printXMIR :: Document -> String


### PR DESCRIPTION
Ref: #182 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of XML comments to prevent invalid syntax by replacing double hyphens ("--") within comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->