### PR TITLE
bug(#195): no braces in empty formation in sweet phi

### DIFF
--- a/src/Pretty.hs
+++ b/src/Pretty.hs
@@ -69,6 +69,7 @@ instance Pretty (Formatted Binding) where
         BiVoid attr -> attr : voids bds
         _ -> []
       inlineVoids :: [Attribute] -> Doc ann
+      inlineVoids [] = pretty attr <+> prettyArrow
       inlineVoids voids' = pretty attr <> lparen <> hsep (punctuate comma (map pretty voids')) <> rparen <+> prettyArrow
   pretty (Formatted (mode, BiTau attr expr)) = pretty attr <+> prettyArrow <+> pretty (Formatted (mode, expr))
   pretty (Formatted (_, BiMeta meta)) = prettyMeta meta

--- a/test/PrettySpec.hs
+++ b/test/PrettySpec.hs
@@ -53,7 +53,8 @@ spec = do
             ("Q -> Q.x(~0 -> Q.y)", "{Φ.x(\n  Φ.y\n)}"),
             ("Q -> Q.x(~0 -> 1)(~1 -> 2)(~2 -> 3)", "{Φ.x(\n  1,\n  2,\n  3\n)}"),
             ("Q -> Q.x(~0 -> 1)(~2 -> 2)(~1 -> 3)", "{Φ.x(\n  α0 ↦ 1,\n  α2 ↦ 2,\n  α1 ↦ 3\n)}"),
-            ("Q -> Φ.jeo.opcode.ldc(18, \"Reading \\\"\")", "{Φ.jeo.opcode.ldc(\n  18,\n  \"Reading \\\"\"\n)}")
+            ("Q -> Φ.jeo.opcode.ldc(18, \"Reading \\\"\")", "{Φ.jeo.opcode.ldc(\n  18,\n  \"Reading \\\"\"\n)}"),
+            ("Q -> [[ k -> [[]] ]]", "{⟦\n  k ↦ ⟦⟧\n⟧}")
           ]
     test prettyProgram' useCases
 


### PR DESCRIPTION
Closes: #195 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pretty-printing to correctly handle cases where there are no void attributes, ensuring consistent formatting.

* **Tests**
  * Added a test to verify correct pretty-printing of nested structures with empty lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->