### PR TITLE
bug(#237): capture groups

### DIFF
--- a/phino.cabal
+++ b/phino.cabal
@@ -66,7 +66,7 @@ library
     xml-conduit ^>=1.10,
     time ^>=1.12,
     transformers,
-    regex-tdfa,
+    regex-pcre-builtin,
     array
   default-language: Haskell2010
 

--- a/test-resources/rewriter-packs/custom/sed.yaml
+++ b/test-resources/rewriter-packs/custom/sed.yaml
@@ -1,21 +1,35 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-input: Q -> [[ x -> "  he llo  ", y -> "abcdefabc" ]]
+input: |
+  Q -> [[
+    x -> "  he llo  ",
+    y -> "1234567891011",
+    z -> "Hello, 2025, 2026",
+    w -> "hi jeff"
+  ]]
 output: |-
   Φ ↦ ⟦
     x ↦ "hello",
-    y ↦ "qwedefabc"
+    y ↦ "11!",
+    z ↦ "Hello, 2025!, 2026!",
+    w ↦ "jeff hi"
   ⟧
 rules:
   custom:
     - name: concat from expression
-      pattern: '[[ x -> !e1, y -> !e2 ]]'
-      result: '[[ x -> !e3, y -> !e4 ]]'
+      pattern: '[[ x -> !e1, y -> !e2, z -> !e10, w -> !e11 ]]'
+      result: '[[ x -> !e3, y -> !e4, z -> !e20, w -> !e21 ]]'
       where:
         - meta: '!e3'
           function: sed
           args: ['!e1', '"s/\\s+//g"']
         - meta: '!e4'
           function: sed
-          args: ['!e2', '"s/abc/qwe/"']
+          args: ['!e2', '"s/(1)(2)(3)(4)(5)(6)(7)(8)(9)(10)(11)/$11!/g"']
+        - meta: '!e20'
+          function: sed
+          args: ['!e10', '"s/([0-9]+)/$1!/g"']
+        - meta: '!e21'
+          function: sed
+          args: ['!e11', '"s/(hi) (jeff)/$2 $1"']

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -15,7 +15,7 @@ import Data.Yaml qualified as Yaml
 import GHC.Generics
 import Misc (allPathsIn, ensuredFile)
 import Parser (parseProgramThrows)
-import Pretty (prettyProgram)
+import Pretty (prettyProgram', PrintMode (SWEET))
 import System.FilePath (makeRelative, replaceExtension, (</>))
 import Test.Hspec (Spec, describe, expectationFailure, it, pending, runIO)
 import Yaml (normalizationRules)
@@ -97,8 +97,8 @@ spec =
               unless (rewritten == result') $
                 expectationFailure
                   ( "Wrong rewritten program. Expected:\n"
-                      ++ prettyProgram result'
+                      ++ prettyProgram' result' SWEET
                       ++ "\nGot:\n"
-                      ++ prettyProgram rewritten
+                      ++ prettyProgram' rewritten SWEET
                   )
       )


### PR DESCRIPTION
Closes: #237 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regex pattern handling in the "sed" function, now supporting Perl-style backreferences and stricter error reporting.
  * Enhanced replacement logic to correctly substitute captured groups in replacements.

* **Tests**
  * Expanded test coverage for the "sed" function, including more complex regex patterns and additional transformation cases.
  * Updated test formatting for clearer output comparison.

* **Chores**
  * Switched regex library dependency to improve compatibility and regex feature support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->