### PR TITLE
bug(#221): more flexible meta suffix

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -335,11 +335,11 @@ exHead =
                     Just '-' -> negate unsigned
                     _ -> unsigned
                 )
-        return (DataObject "number" (numToBts num)),
+        return (DataNumber (numToBts num)),
       lexeme $ do
         _ <- char '"'
         str <- manyTill (choice [escapedChar, noneOf ['\\', '"']]) (char '"')
-        return (DataObject "string" (strToBts str)),
+        return (DataString (strToBts str)),
       try (ExMeta <$> meta' 'e' "𝑒"),
       ExDispatch ExThis <$> fullAttribute
     ]

--- a/test-resources/rewriter-packs/custom/with-different-metas.yaml
+++ b/test-resources/rewriter-packs/custom/with-different-metas.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: Q -> [[ x -> "hello", y -> "world" ]]
+output: |-
+  Φ ↦ ⟦
+    z ↦ "hello world"
+  ⟧
+rules:
+  custom:
+    - name: concat with metas
+      pattern: '[[ x -> !e_hello, y -> !e_world ]]'
+      result: '[[ z -> !e_hello_world ]]'
+      where:
+        - meta: '!d-space'
+          function: dataize
+          args: ['" "']
+        - meta: '!d_HELLO'
+          function: dataize
+          args: ['!e_hello']
+        - meta: '!d-WORLD1'
+          function: dataize
+          args: ['!e_world']
+        - meta: '!e_hello_world'
+          function: concat
+          args:
+            - '!d_HELLO'
+            - '!d-space'
+            - '!d-WORLD1'

--- a/test-resources/rewriter-packs/custom/with-different-metas.yaml
+++ b/test-resources/rewriter-packs/custom/with-different-metas.yaml
@@ -9,21 +9,21 @@ output: |-
 rules:
   custom:
     - name: concat with metas
-      pattern: '[[ x -> !e_hello, y -> !e_world ]]'
-      result: '[[ z -> !e_hello_world ]]'
+      pattern: '[[ x -> !e_hello, y -> 𝑒-world, 𝐵-x ]]'
+      result: '[[ z -> !e_hello_world, 𝐵-x ]]'
       where:
         - meta: '!d-space'
           function: dataize
           args: ['" "']
-        - meta: '!d_HELLO'
+        - meta: 'δ_HELLO'
           function: dataize
           args: ['!e_hello']
         - meta: '!d-WORLD1'
           function: dataize
-          args: ['!e_world']
+          args: ['𝑒-world']
         - meta: '!e_hello_world'
           function: concat
           args:
-            - '!d_HELLO'
+            - 'δ_HELLO'
             - '!d-space'
             - '!d-WORLD1'

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -243,7 +243,8 @@ spec = do
         "[[x -> 1.00e+3, y -> 2.32e-4]]",
         "[[ x -> \"\\u0001\\u0001\"]]",
         "[[ x -> \"\\uD835\\uDF11\"]]",
-        "[[ x ↦ \"This plugin has \\x01\\x01\" ]]"
+        "[[ x ↦ \"This plugin has \\x01\\x01\" ]]",
+        "[[ !afoo -> !e1Some, !a-BAR -> !e_123someW, !Bhi123 ]]"
       ]
       (\expr -> it expr (parseExpression expr `shouldSatisfy` isRight))
 


### PR DESCRIPTION
Closes: #221 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broadened the accepted format for meta identifiers, allowing suffixes with underscores, dashes, digits, and letters.
  * Added a new YAML rewriter pack with a custom rule for concatenating metavariables.

* **Tests**
  * Added a new test case to verify parsing of expressions with the expanded meta identifier format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->