### PR TITLE
bug(#251): pass on failed `matches`

### DIFF
--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -94,9 +94,9 @@ instance FromJSON Condition where
                     pure (In attr bd)
                   _ -> fail "'in' expects exactly two arguments",
               do
-                vals <- v .: "match"
+                vals <- v .: "matches"
                 case vals of
-                  [pat, exp] -> Match <$> parseJSON pat <*> parseJSON exp
+                  [pat, exp] -> Matches <$> parseJSON pat <*> parseJSON exp
                   _ -> fail "'match' expects exactly two arguments"
             ]
       )
@@ -142,7 +142,7 @@ data Condition
   | Eq Comparable Comparable
   | NF Expression
   | XI Expression
-  | Match String Expression
+  | Matches String Expression
   deriving (Generic, Show)
 
 data ExtraArgument

--- a/test-resources/condition-packs/match.yaml
+++ b/test-resources/condition-packs/match.yaml
@@ -1,7 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
-# SPDX-License-Identifier: MIT
----
-expression: '[[ x -> "Hello world" ]]'
-pattern: '[[ x -> !e ]]'
-condition:
-  match: ['Hello [a-z]+', '!e']

--- a/test-resources/condition-packs/matches.yaml
+++ b/test-resources/condition-packs/matches.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+expression: '[[ k -> [[ x -> "Hello world" ]] ]]'
+pattern: '[[ !a -> !e, !B ]]'
+condition:
+  matches: ['Hello [a-z]+', '!e']

--- a/test-resources/rewriter-packs/custom/does-not-fail-on-ambigous.yaml
+++ b/test-resources/rewriter-packs/custom/does-not-fail-on-ambigous.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: Q -> [[ k -> [[ x -> "hello" ]] ]]
+output: |-
+  Φ ↦ ⟦
+    k -> [[ x -> "hi" ]]
+  ⟧
+rules:
+  custom:
+    - name: custom
+      pattern: '[[ x -> !e ]]'
+      result: '[[ x -> "hi" ]]'
+      when:
+        matches: ['hello', '!e']

--- a/test/ConditionSpec.hs
+++ b/test/ConditionSpec.hs
@@ -7,17 +7,17 @@
 module ConditionSpec where
 
 import Ast (Expression, Program (Program))
-import Condition (meetCondition)
 import Control.Monad
 import Data.Aeson
 import Data.Yaml qualified as Y
 import GHC.Generics
-import Matcher (matchProgram)
 import Misc
-import Pretty (prettySubsts)
 import System.FilePath
 import Test.Hspec (Spec, describe, expectationFailure, it, runIO)
 import Yaml qualified
+import Matcher
+import Condition
+import Pretty
 
 data ConditionPack = ConditionPack
   { expression :: Expression,


### PR DESCRIPTION
Closes: #251