### PR TITLE
bug(#227): `--must` option

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -25,7 +25,7 @@ data DataizeContext = DataizeContext
   }
 
 switchContext :: DataizeContext -> RewriteContext
-switchContext DataizeContext {..} = RewriteContext _program _maxDepth _buildTerm
+switchContext DataizeContext {..} = RewriteContext _program _maxDepth _buildTerm 0
 
 maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
 maybeBinding _ [] = (Nothing, [])

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -23,7 +23,7 @@ newtype Logger = Logger {level :: LogLevel}
 
 logger :: IORef Logger
 {-# NOINLINE logger #-}
-logger = unsafePerformIO (newIORef (Logger INFO))
+logger = unsafePerformIO (newIORef (Logger DEBUG))
 
 setLogLevel :: LogLevel -> IO ()
 setLogLevel lvl = writeIORef logger (Logger lvl)

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -23,7 +23,7 @@ newtype Logger = Logger {level :: LogLevel}
 
 logger :: IORef Logger
 {-# NOINLINE logger #-}
-logger = unsafePerformIO (newIORef (Logger DEBUG))
+logger = unsafePerformIO (newIORef (Logger INFO))
 
 setLogLevel :: LogLevel -> IO ()
 setLogLevel lvl = writeIORef logger (Logger lvl)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -178,6 +178,18 @@ spec = do
           ["rewrite", "--nothing", "--output=xmir", "--omit-listing"]
           ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>4 lines of phi</listing>", "  <o base=\"Q.y\" name=\"x\"/>"]
 
+    it "fails with --nothing and --must=2" $
+      withStdin "Q -> [[ ]]" $
+        testCLIFailed ["rewrite", "--nothing", "--must=2"] "it's expected exactly 2 rewriting cycles happened, but rewriting stopped after 1"
+
+    it "does not fail with --nothing and --must" $
+      withStdin "Q -> [[ ]]" $
+        testCLI ["rewrite", "--nothing", "--must"] ["Φ ↦ ⟦ ρ ↦ ∅ ⟧"]
+
+    it "fails with --normalize and --must" $
+      withStdin "Q -> [[ x -> [[ y -> 5 ]].y ]].x" $
+        testCLIFailed ["rewrite", "--normalize", "--must"] "it's expected exactly 1 rewriting cycles happened, but rewriting is still going"
+
   describe "dataize" $ do
     it "dataizes simple program" $
       withStdin "Q -> [[ D> 01- ]]" $

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -92,7 +92,7 @@ spec =
                   if normalize'
                     then pure normalizationRules
                     else pure []
-              rewritten <- rewrite' program rules' (RewriteContext program repeat' buildTermFromFunction)
+              rewritten <- rewrite' program rules' (RewriteContext program repeat' buildTermFromFunction 0)
               result' <- parseProgramThrows (output pack)
               unless (rewritten == result') $
                 expectationFailure


### PR DESCRIPTION
Closes: #227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `--must` option to the rewrite command, allowing users to enforce an exact number of rewrite cycles.
  * Enhanced error messages and enforcement when the required number of rewrite cycles is not met.

* **Bug Fixes**
  * Improved validation for rewrite command arguments to prevent negative values for the `--must` option.

* **Tests**
  * Added new test cases to verify correct behavior and error reporting for the `--must` option in various rewrite scenarios.

* **Other**
  * Default log level changed to `DEBUG` for more detailed logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->