### PR TITLE
bug(#273): added phi tau binding

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -142,6 +142,9 @@ formationBinding (BiTau (AtLabel label) (ExFormation bds)) ctx = do
 formationBinding (BiTau (AtLabel label) expr) ctx = do
   (base, children) <- expression expr ctx
   pure (Just (object [("name", label), ("base", base)] children))
+formationBinding (BiTau AtPhi expr) ctx = do
+  (base, children) <- expression expr ctx
+  pure (Just (object [("name", "φ"), ("base", base)] children))
 formationBinding (BiTau AtRho _) _ = pure Nothing
 formationBinding (BiDelta bytes) _ = pure (Just (NodeContent (T.pack (prettyBytes bytes))))
 formationBinding (BiLambda func) _ = pure (Just (object [("name", "λ")] []))

--- a/test-resources/xmir-parsing-packs/with-phi.yaml
+++ b/test-resources/xmir-parsing-packs/with-phi.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="@" base="$.@"/>
+    </o>
+  </object>
+phi: '{[[ app -> [[ @ -> $.@ ]] ]]}'


### PR DESCRIPTION
Closes: #273 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for the `AtPhi` attribute in formation bindings, enhancing how certain expressions are processed and displayed.
* **Tests**
  * Added a new test resource to verify correct handling of the `AtPhi` attribute in parsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->