### PR TITLE
bug(#203): `sed` understand slashes

### DIFF
--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -13,7 +13,6 @@ import qualified Data.ByteString.Char8 as B
 import Data.Char (intToDigit)
 import Data.Set (Set)
 import qualified Data.Set
-import Debug.Trace
 import GHC.IO (unsafePerformIO)
 import Matcher
 import Misc

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -121,7 +121,7 @@ buildTermFromFunction "sed" args subst prog = do
                 [pat, rep, ""] -> pure (pat, rep, False)
                 _ -> throwIO (userError "sed pattern must be in format s/pat/rep/[g]")
         _ -> throwIO (userError "sed pattern must start with s/")
-    -- Cut part from given string untill regular slash.
+    -- Cut part from given string until regular slash.
     nextUntilSlash :: B.ByteString -> B.ByteString -> Bool -> (B.ByteString, B.ByteString)
     nextUntilSlash input acc escape = case B.uncons input of
       Nothing -> (acc, B.empty)

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -13,6 +13,7 @@ import qualified Data.ByteString.Char8 as B
 import Data.Char (intToDigit)
 import Data.Set (Set)
 import qualified Data.Set
+import Debug.Trace
 import GHC.IO (unsafePerformIO)
 import Matcher
 import Misc
@@ -110,18 +111,27 @@ buildTermFromFunction "sed" args subst prog = do
           then replaceAll regex rep tgt
           else replaceFirst regex rep tgt
       sed next ptns
-
     parse :: B.ByteString -> IO (B.ByteString, B.ByteString, Bool)
     parse input =
       case B.stripPrefix "s/" input of
-        Just rest ->
-          let parts = B.split '/' rest
-           in case parts of
+        Just body ->
+          let (pat, rest) = nextUntilSlash body B.empty False
+              (rep, flag) = nextUntilSlash rest B.empty True
+           in case [pat, rep, flag] of
                 [pat, rep, "g"] -> pure (pat, rep, True)
                 [pat, rep, ""] -> pure (pat, rep, False)
-                [pat, rep] -> pure (pat, rep, False)
                 _ -> throwIO (userError "sed pattern must be in format s/pat/rep/[g]")
         _ -> throwIO (userError "sed pattern must start with s/")
+    -- Cut part from given string untill regular slash.
+    nextUntilSlash :: B.ByteString -> B.ByteString -> Bool -> (B.ByteString, B.ByteString)
+    nextUntilSlash input acc escape = case B.uncons input of
+      Nothing -> (acc, B.empty)
+      Just (h, rest)
+        | h == '\\' -> case B.uncons rest of
+            Just (h', rest') -> nextUntilSlash rest' ((if escape then acc else B.snoc acc '\\') `B.append` B.singleton h') escape
+            Nothing -> (if escape then acc else B.snoc acc '\\', B.empty)
+        | h == '/' -> (acc, rest)
+        | otherwise -> nextUntilSlash rest (B.snoc acc h) escape
 buildTermFromFunction "random-string" [arg] subst prog = do
   pat <- argToStrBytes arg subst prog
   str <- randomString pat

--- a/test-resources/rewriter-packs/custom/sed-with-slashes.yaml
+++ b/test-resources/rewriter-packs/custom/sed-with-slashes.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: |
+  Q -> [[
+    x -> "java/lang/Boolean"
+  ]]
+output: |-
+  Φ ↦ ⟦
+    x ↦ "java/lang/Integer"
+  ⟧
+rules:
+  custom:
+    - name: sed with slashes
+      pattern: '[[ x -> !e ]]'
+      result: '[[ x -> !e1 ]]'
+      where:
+        - meta: '!e1'
+          function: sed
+          args:
+            - '!e'
+            - '"s/java\\/lang\\/Boolean/java\\/lang\\/Integer/g"'

--- a/test-resources/rewriter-packs/custom/sed.yaml
+++ b/test-resources/rewriter-packs/custom/sed.yaml
@@ -6,7 +6,7 @@ input: |
     x -> "  he llo  ",
     y -> "1234567891011",
     z -> "Hello, 2025, 2026",
-    w -> "hi jeff"
+    w -> "hi (jeff)"
   ]]
 output: |-
   Φ ↦ ⟦
@@ -32,4 +32,4 @@ rules:
           args: ['!e10', '"s/([0-9]+)/$1!/g"']
         - meta: '!e21'
           function: sed
-          args: ['!e11', '"s/(hi) (jeff)/$2 $1"']
+          args: ['!e11', '"s/(hi) \\((jeff)\\)/$2 $1"']


### PR DESCRIPTION
Closes: #203 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of escaped slashes in sed substitution patterns, ensuring accurate parsing and replacement in complex cases.

* **New Features**
  * Added a new rewriter rule that demonstrates sed substitutions with escaped slashes for more flexible string transformations.

* **Tests**
  * Updated and added test cases to cover sed patterns with special characters and validate correct substitution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->