### PR TITLE
bug(#202): remove todo

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -172,8 +172,6 @@ rootExpression expr _ = throwIO (UnsupportedExpression expr)
 -- The function returns tuple (X, Y), where
 -- - X: list of package parts
 -- - Y: root object expression
--- @todo #197:30min Make patterns with L> Package softer. Right now we expect L> Package only in the end
---  of the formation bindings list. That's not really correct since this binding may be anywhere. Let's fix it
 getPackage :: Expression -> IO ([String], Expression)
 getPackage (ExFormation [BiTau (AtLabel label) (ExFormation [bd, BiLambda "Package", BiVoid AtRho]), BiVoid AtRho]) = do
   (pckg, expr') <- getPackage (ExFormation [bd, BiLambda "Package", BiVoid AtRho])


### PR DESCRIPTION
Closes: #202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete internal TODO comments to tidy the codebase and improve maintainability.
  * No changes to features, behavior, performance, or compatibility; application functionality remains exactly the same.
  * No user action required; existing workflows, data, and configurations are unaffected.
  * Documentation, settings, and tests remain unchanged; this update is purely housekeeping with zero user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->