### PR TITLE
bug(#285): detect formations with first and last metas

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -64,8 +64,7 @@ data OptsDataize = OptsDataize
   }
 
 data OptsRewrite = OptsRewrite
-  {
-   logLevel :: LogLevel,
+  { logLevel :: LogLevel,
     rules :: [FilePath],
     inputFormat :: IOFormat,
     outputFormat :: IOFormat,

--- a/src/Replacer.hs
+++ b/src/Replacer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
@@ -6,13 +7,42 @@
 
 -- The goal of the module is to traverse though the Program with replacing
 -- pattern sub expression with target expressions
-module Replacer (replaceProgram, replaceProgramThrows) where
+module Replacer
+  ( replaceProgram,
+    replaceProgramThrows,
+    replaceProgramFast,
+    replaceProgramFastThrows,
+    ReplaceProgramThrowsFunc,
+    ReplaceProgramFunc,
+    ReplaceProgramContext (..),
+  )
+where
 
 import Ast
 import Control.Exception (Exception, throwIO)
+import Debug.Trace
 import Matcher (Tail (TaApplication, TaDispatch))
 import Pretty (prettyExpression, prettyProgram)
 import Text.Printf (printf)
+
+data ReplaceProgramContext = ReplaceProgramContext
+  { _program :: Program,
+    _maxDepth :: Integer
+  }
+
+data ReplaceExpressionContext = ReplaceExpressionContext
+  { _expression :: Expression,
+    _maxDepth :: Integer
+  }
+
+updateExpressionContext :: ReplaceExpressionContext -> Expression -> ReplaceExpressionContext
+updateExpressionContext ReplaceExpressionContext {..} expr = ReplaceExpressionContext expr _maxDepth
+
+type ReplaceProgramThrowsFunc = [Expression] -> [Expression] -> ReplaceProgramContext -> IO Program
+
+type ReplaceProgramFunc = [Expression] -> [Expression] -> ReplaceProgramContext -> Maybe Program
+
+type ReplaceExpressionFunc = [Expression] -> [Expression] -> ReplaceExpressionContext -> (Expression, [Expression], [Expression])
 
 newtype ReplaceException = CouldNotReplace {prog :: Program}
   deriving (Exception)
@@ -23,45 +53,100 @@ instance Show ReplaceException where
       "Couldn't replace expression in program, lists of patterns and targets has different lengths\nProgram: %s"
       (prettyProgram prog)
 
-replaceBindings :: [Binding] -> [Expression] -> [Expression] -> ([Binding], [Expression], [Expression])
-replaceBindings bds [] [] = (bds, [], [])
-replaceBindings [] ptns repls = ([], ptns, repls)
-replaceBindings (BiTau attr expr : bds) ptns repls =
-  let (expr', ptns', repls') = replaceExpression expr ptns repls
-      (bds', ptns'', repls'') = replaceBindings bds ptns' repls'
+replaceBindings :: [Binding] -> [Expression] -> [Expression] -> ReplaceExpressionContext -> ReplaceExpressionFunc -> ([Binding], [Expression], [Expression])
+replaceBindings bds [] [] _ _ = (bds, [], [])
+replaceBindings [] ptns repls _ _ = ([], ptns, repls)
+replaceBindings (BiTau attr expr : bds) ptns repls ctx func =
+  let (expr', ptns', repls') = func ptns repls (updateExpressionContext ctx expr)
+      (bds', ptns'', repls'') = replaceBindings bds ptns' repls' ctx func
    in (BiTau attr expr' : bds', ptns'', repls'')
-replaceBindings (bd : bds) ptns repls =
-  let (bds', ptns', repls') = replaceBindings bds ptns repls
+replaceBindings (bd : bds) ptns repls ctx func =
+  let (bds', ptns', repls') = replaceBindings bds ptns repls ctx func
    in (bd : bds', ptns', repls')
 
-replaceExpression :: Expression -> [Expression] -> [Expression] -> (Expression, [Expression], [Expression])
-replaceExpression expr [] [] = (expr, [], [])
-replaceExpression expr ptns repls =
-  let (ptn : ptnsRest) = ptns
+replaceExpression :: ReplaceExpressionFunc
+replaceExpression [] [] ReplaceExpressionContext {..} = (_expression, [], [])
+replaceExpression ptns repls ctx =
+  let ReplaceExpressionContext {..} = ctx
+      (ptn : ptnsRest) = ptns
       (repl : replsRest) = repls
-   in if expr == ptn
-        then replaceExpression repl ptnsRest replsRest
-        else case expr of
+   in if _expression == ptn
+        then replaceExpression ptnsRest replsRest (updateExpressionContext ctx repl)
+        else case _expression of
           ExDispatch inner attr ->
-            let (expr', ptns', repls') = replaceExpression inner ptns repls
+            let (expr', ptns', repls') = replaceExpression ptns repls (updateExpressionContext ctx inner)
              in (ExDispatch expr' attr, ptns', repls')
           ExApplication inner tau ->
-            let (expr', ptns', repls') = replaceExpression inner ptns repls
-                ([tau'], ptns'', repls'') = replaceBindings [tau] ptns' repls'
+            let (expr', ptns', repls') = replaceExpression ptns repls (updateExpressionContext ctx inner)
+                ([tau'], ptns'', repls'') = replaceBindings [tau] ptns' repls' ctx replaceExpression
              in (ExApplication expr' tau', ptns'', repls'')
           ExFormation bds ->
-            let (bds', ptns', repls') = replaceBindings bds ptns repls
+            let (bds', ptns', repls') = replaceBindings bds ptns repls ctx replaceExpression
              in (ExFormation bds', ptns', repls')
-          _ -> (expr, ptns, repls)
+          _ -> (_expression, ptns, repls)
 
-replaceProgram :: Program -> [Expression] -> [Expression] -> Maybe Program
-replaceProgram (Program expr) ptns repls
+replaceBindingsFast :: [Binding] -> [Expression] -> [Expression] -> [Binding]
+replaceBindingsFast bds [] [] = bds
+replaceBindingsFast bds ((ExFormation pbds) : rptns) ((ExFormation rbds) : rrepls) =
+  let replaced = replaceBindingsFast' bds pbds rbds
+   in replaceBindingsFast replaced rptns rrepls
+  where
+    replaceBindingsFast' :: [Binding] -> [Binding] -> [Binding] -> [Binding]
+    replaceBindingsFast' bds pattern replacement
+      | null pattern = replacement
+      | otherwise = findAndReplace bds pattern replacement
+    findAndReplace :: [Binding] -> [Binding] -> [Binding] -> [Binding]
+    findAndReplace [] _ _ = []
+    findAndReplace xs pattern replacement
+      | length xs < length pattern = xs
+      | take (length pattern) xs == pattern = replacement ++ findAndReplace (drop (length pattern) xs) pattern replacement
+      | otherwise = head xs : findAndReplace (tail xs) pattern replacement
+
+replaceExpressionFast :: ReplaceExpressionFunc
+replaceExpressionFast = replaceExpressionFast' 0
+  where
+    replaceExpressionFast' :: Integer -> ReplaceExpressionFunc
+    replaceExpressionFast' _ [] [] ReplaceExpressionContext {..} = (_expression, [], [])
+    replaceExpressionFast' depth ((ExFormation pbds) : rptns) ((ExFormation rbds) : rrepls) ctx =
+      let ReplaceExpressionContext {..} = ctx
+          ptns = ExFormation pbds : rptns
+          repls = ExFormation rbds : rrepls
+       in if depth == _maxDepth
+            then (_expression, [], [])
+            else case _expression of
+              ExFormation bds ->
+                let replaced = replaceBindingsFast bds ptns repls
+                    (bds', ptns', repls') = replaceBindings replaced ptns repls ctx (replaceExpressionFast' (depth + 1))
+                 in (ExFormation bds', ptns', repls')
+              ExDispatch inner attr ->
+                let (expr', ptns', repls') = replaceExpressionFast ptns repls (updateExpressionContext ctx inner)
+                 in (ExDispatch expr' attr, ptns', repls')
+              ExApplication inner (BiTau attr texpr) ->
+                let (expr', ptns', repls') = replaceExpressionFast ptns repls (updateExpressionContext ctx inner)
+                    (expr'', ptns'', repls'') = replaceExpressionFast ptns' repls' (updateExpressionContext ctx texpr)
+                 in (ExApplication expr' (BiTau attr expr''), ptns'', repls'')
+              _ -> (_expression, ptns, repls)
+
+replaceProgram' :: ReplaceExpressionFunc -> ReplaceProgramFunc
+replaceProgram' func ptns repls ReplaceProgramContext {_program = Program expr, ..}
   | length ptns == length repls =
-      let (expr', _, _) = replaceExpression expr ptns repls
+      let (expr', _, _) = func ptns repls (ReplaceExpressionContext expr _maxDepth)
        in Just (Program expr')
   | otherwise = Nothing
 
-replaceProgramThrows :: Program -> [Expression] -> [Expression] -> IO Program
-replaceProgramThrows prog ptns repls = case replaceProgram prog ptns repls of
+replaceProgram :: ReplaceProgramFunc
+replaceProgram = replaceProgram' replaceExpression
+
+replaceProgramThrows' :: ReplaceExpressionFunc -> ReplaceProgramThrowsFunc
+replaceProgramThrows' func ptns repls ctx = case replaceProgram' func ptns repls ctx of
   Just prog' -> pure prog'
-  _ -> throwIO (CouldNotReplace prog)
+  _ -> throwIO (CouldNotReplace (_program ctx))
+
+replaceProgramThrows :: ReplaceProgramThrowsFunc
+replaceProgramThrows = replaceProgramThrows' replaceExpression
+
+replaceProgramFast :: ReplaceProgramFunc
+replaceProgramFast = replaceProgram' replaceExpressionFast
+
+replaceProgramFastThrows :: ReplaceProgramThrowsFunc
+replaceProgramFastThrows = replaceProgramThrows' replaceExpressionFast

--- a/src/Replacer.hs
+++ b/src/Replacer.hs
@@ -20,7 +20,6 @@ where
 
 import Ast
 import Control.Exception (Exception, throwIO)
-import Debug.Trace
 import Matcher (Tail (TaApplication, TaDispatch))
 import Pretty (prettyExpression, prettyProgram)
 import Text.Printf (printf)

--- a/src/Replacer.hs
+++ b/src/Replacer.hs
@@ -119,7 +119,7 @@ replaceExpressionFast = replaceExpressionFast' 0
                 (expr'', ptns'', repls'') = replaceExpressionFast ptns' repls' (updateExpressionContext ctx texpr)
              in (ExApplication expr' (BiTau attr expr''), ptns'', repls'')
           _ -> (_expression, ptns, repls)
-    replaceExpressionFast' _ _ _ ctx@ReplaceExpressionContext{..} = (_expression, [], [])
+    replaceExpressionFast' _ ptns repls ctx@ReplaceExpressionContext{..} = (_expression, ptns, repls)
 
 replaceProgram' :: ReplaceExpressionFunc -> ReplaceProgramFunc
 replaceProgram' func ptns repls ReplaceProgramContext {_program = Program expr, ..}

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
@@ -18,7 +19,7 @@ import Matcher (MetaValue (MvAttribute, MvBindings, MvBytes, MvExpression), Subs
 import Misc (ensuredFile)
 import Parser (parseProgram, parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyAttribute, prettyBytes, prettyExpression, prettyExpression', prettyProgram, prettyProgram', prettySubsts)
-import Replacer (replaceProgram, replaceProgramThrows)
+import Replacer (ReplaceProgramContext (ReplaceProgramContext), ReplaceProgramThrowsFunc, replaceProgramFastThrows, replaceProgramThrows)
 import Rule (RuleContext (RuleContext), matchProgramWithRule)
 import qualified Rule as R
 import Term
@@ -52,13 +53,51 @@ instance Show MustException where
       must
 
 -- Build pattern and result expression and replace patterns to results in given program
-buildAndReplace :: Program -> Expression -> Expression -> [Subst] -> IO Program
-buildAndReplace program ptn res substs = do
+buildAndReplace' :: Expression -> Expression -> [Subst] -> ReplaceProgramThrowsFunc -> ReplaceProgramContext -> IO Program
+buildAndReplace' ptn res substs func ctx = do
   ptns <- buildExpressions ptn substs
   repls <- buildExpressions res substs
   let repls' = map fst repls
       ptns' = map fst ptns
-  replaceProgramThrows program ptns' repls'
+  func ptns' repls' ctx
+
+-- If pattern and replacement are appropriate for fast replacing - does it.
+-- Pattern and replacement expressions can be used in fast replacing only if
+-- 1. they are both formations
+-- 2. they start and end with the same meta bindings, e.g. [!B1, ..., !B2]
+-- 3. the does not have meta bindings between first and last meta bindings
+-- In such case we can just replace bindings one by one without building whole expression.
+-- You can find more details in this ticket: https://github.com/objectionary/phino/issues/321
+-- If we don't meet the conditions above - just do a regular replacing
+tryBuildAndReplaceFast :: Expression -> Expression -> [Subst] -> ReplaceProgramContext -> IO Program
+tryBuildAndReplaceFast (ExFormation pbds) (ExFormation rbds) substs ctx =
+  let pbds' = init (tail pbds)
+      rbds' = init (tail rbds)
+   in if startsAndEndsWithMeta pbds
+        && startsAndEndsWithMeta rbds
+        && head pbds == head rbds
+        && last pbds == last rbds
+        && not (hasMetaBindings pbds')
+        && not (hasMetaBindings rbds')
+        then do
+          logDebug "Applying fast replacing since 'pattern' and 'result' are suitable for this..."
+          buildAndReplace' (ExFormation pbds') (ExFormation rbds') substs replaceProgramFastThrows ctx
+        else do
+          logDebug "Applying regular replacing..."
+          buildAndReplace' (ExFormation pbds) (ExFormation rbds) substs replaceProgramThrows ctx
+  where
+    startsAndEndsWithMeta :: [Binding] -> Bool
+    startsAndEndsWithMeta bds =
+      length bds > 1
+        && isMetaBinding (head bds)
+        && isMetaBinding (last bds)
+    hasMetaBindings :: [Binding] -> Bool
+    isMetaBinding :: Binding -> Bool
+    isMetaBinding = \case
+      BiMeta _ -> True
+      _ -> False
+    hasMetaBindings = foldl (\acc bd -> acc || isMetaBinding bd) False
+tryBuildAndReplaceFast ptn res substs ctx = buildAndReplace' ptn res substs replaceProgramThrows ctx
 
 rewrite :: Program -> [Y.Rule] -> RewriteContext -> IO Program
 rewrite program [] _ = pure program
@@ -85,7 +124,7 @@ rewrite program (rule : rest) ctx = do
                   pure prog
                 else do
                   logDebug (printf "Rule '%s' has been matched, applying..." ruleName)
-                  prog' <- buildAndReplace prog ptn res matched
+                  prog' <- tryBuildAndReplaceFast ptn res matched (ReplaceProgramContext prog depth)
                   if prog == prog'
                     then do
                       logDebug (printf "Applied '%s', no changes made" ruleName)

--- a/test-resources/rewriter-packs/custom/replaces-formation-in-one-cycle.yaml
+++ b/test-resources/rewriter-packs/custom/replaces-formation-in-one-cycle.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+repeat: 1
+must: 1
+input: |
+  {[[
+    x -> "hello",
+    y -> "world",
+    z -> "!"
+  ]]}
+output: |
+  {[[
+    x -> ?,
+    y -> ?,
+    z -> ?
+  ]]}
+rules:
+  custom:
+    - name: tau to void
+      pattern: |
+        [[ !B1, !a -> !e, !B2 ]]
+      result: |
+        [[ !B1, !a -> ?, !B2 ]]

--- a/test/MatcherSpec.hs
+++ b/test/MatcherSpec.hs
@@ -251,7 +251,7 @@ spec = do
           defaultScope,
           [[("a", MvAttribute (AtLabel "y")), ("B", MvBindings [BiVoid (AtLabel "x")])]]
         ),
-        ( "[[!B1, !a -> ?, !B2]] => [[ x -> ?, y -> ?, z -> ? ]] => [(), (), ()]",
+        ( "[[!B1, !a -> ?, !B2]] => [[ x -> ?, y -> ?, z -> ? ]] => [(!B1 >> [[]], !a >> x, !B2 >> [[ y -> ?, z -> ? ]]), (...), (...)]",
           [BiMeta "B1", BiVoid (AtMeta "a"), BiMeta "B2"],
           [BiVoid (AtLabel "x"), BiVoid (AtLabel "y"), BiVoid (AtLabel "z")],
           defaultScope,

--- a/test/ReplacerSpec.hs
+++ b/test/ReplacerSpec.hs
@@ -110,10 +110,16 @@ spec = do
           [ExFormation [BiTau AtRho ExThis], ExFormation [BiTau AtPhi ExThis], ExFormation [BiTau AtDelta ExThis]],
           Just (Program (ExFormation [BiTau AtRho ExThis, BiTau AtPhi ExThis, BiTau AtDelta ExThis]))
         ),
-        ( "Q -> [[ ^ -> ? ]] => [[ !B1, !a -> ?, !B2 ]] => [[ !B1, !a -> [[ !a -> ? ]], !B2 ]] => [[ ^ -> [[ ^ -> [[ ^ -> [[ ^ -> ? ]] ]] ]] ]]",
+        ( "Q -> [[ ^ -> ? ]] => [[ !B1, !a -> ?, !B2 ]] => [[ !B1, !a -> [[ !a -> ? ]], !B2 ]] => Q -> [[ ^ -> [[ ^ -> [[ ^ -> [[ ^ -> ? ]] ]] ]] ]]",
           Program (ExFormation [BiVoid AtRho]),
           [ExFormation [BiVoid AtRho]],
           [ExFormation [BiTau AtRho (ExFormation [BiVoid AtRho])]],
           Just (Program (ExFormation [BiTau AtRho (ExFormation [BiTau AtRho (ExFormation [BiTau AtRho (ExFormation [BiVoid AtRho])])])]))
+        ),
+        ( "Q -> [[ ^ -> T ]](^ -> [[ ^ -> $]]).@ => [[ !B1, !a -> ?, !B2 ]] => [[ !B1, !a -> $, !B2 ]] => Q -> [[ ^ -> $ ]].@",
+          Program (ExDispatch (ExApplication (ExFormation [BiTau AtRho ExTermination]) (BiTau AtRho (ExFormation [BiTau AtRho ExThis]))) AtPhi),
+          [ExFormation [BiTau AtRho ExTermination], ExFormation [BiTau AtRho ExThis]],
+          [ExFormation [BiTau AtRho ExGlobal], ExFormation [BiVoid AtPhi]],
+          Just (Program (ExDispatch (ExApplication (ExFormation [BiTau AtRho ExGlobal]) (BiTau AtRho (ExFormation [BiVoid AtPhi]))) AtPhi))
         )
       ]


### PR DESCRIPTION
Closes: #285 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Fast-path replacement to accelerate common rewrite patterns.
  - Explicit depth-limit control for replacements to prevent runaway recursion.
  - Extended, pluggable replacement API for more flexible replacement strategies.
  - Improved error reporting that includes replacement context for easier debugging.

- Refactor
  - Replacement engine reworked to be context-driven and more composable without changing user-facing rewrite behavior.

- Tests
  - Added tests covering fast-path and complex cases.
  - Added a rewriter pack resource validating single-cycle formation replacement.

- Style
  - Minor CLI formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->