### PR TITLE
bug(#330): `--maxCycles` flag is implemented

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -92,10 +92,10 @@ argInputFile :: Parser (Maybe FilePath)
 argInputFile = optional (argument str (metavar "FILE" <> help "Path to input file"))
 
 optMaxDepth :: Parser Integer
-optMaxDepth = option auto (long "max-depth" <> metavar "DEPTH" <> help "Max amount of rewritng iterations with each rule" <> value 25 <> showDefault)
+optMaxDepth = option auto (long "max-depth" <> metavar "DEPTH" <> help "Maximum number of rewriting iterations per rule" <> value 25 <> showDefault)
 
 optMaxCycles :: Parser Integer
-optMaxCycles = option auto (long "max-cycles" <> metavar "CYCLES" <> help "Max amount of rewritng cycles with all rules" <> value 25 <> showDefault)
+optMaxCycles = option auto (long "max-cycles" <> metavar "CYCLES" <> help "Maximum number of rewriting cycles across all rules" <> value 25 <> showDefault)
 
 optInputFormat :: Parser IOFormat
 optInputFormat = option (parseIOFormat "input") (long "input" <> metavar "FORMAT" <> help "Program input format (phi, xmir)" <> value PHI <> showDefault)

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -60,6 +60,7 @@ data OptsDataize = OptsDataize
   { logLevel :: LogLevel,
     inputFormat :: IOFormat,
     maxDepth :: Integer,
+    maxCycles :: Integer,
     inputFile :: Maybe FilePath
   }
 
@@ -76,6 +77,7 @@ data OptsRewrite = OptsRewrite
     omitComments :: Bool,
     must :: Integer,
     maxDepth :: Integer,
+    maxCycles :: Integer,
     targetFile :: Maybe FilePath,
     inputFile :: Maybe FilePath
   }
@@ -90,7 +92,10 @@ argInputFile :: Parser (Maybe FilePath)
 argInputFile = optional (argument str (metavar "FILE" <> help "Path to input file"))
 
 optMaxDepth :: Parser Integer
-optMaxDepth = option auto (long "max-depth" <> metavar "DEPTH" <> help "Max amount of rewritng cycles" <> value 25 <> showDefault)
+optMaxDepth = option auto (long "max-depth" <> metavar "DEPTH" <> help "Max amount of rewritng iterations with each rule" <> value 25 <> showDefault)
+
+optMaxCycles :: Parser Integer
+optMaxCycles = option auto (long "max-cycles" <> metavar "CYCLES" <> help "Max amount of rewritng cycles with all rules" <> value 25 <> showDefault)
 
 optInputFormat :: Parser IOFormat
 optInputFormat = option (parseIOFormat "input") (long "input" <> metavar "FORMAT" <> help "Program input format (phi, xmir)" <> value PHI <> showDefault)
@@ -124,6 +129,7 @@ dataizeParser =
             <$> optLogLevel
             <*> optInputFormat
             <*> optMaxDepth
+            <*> optMaxCycles
             <*> argInputFile
         )
 
@@ -145,6 +151,7 @@ rewriteParser =
                     <|> option auto (long "must" <> metavar "N" <> help "Must-rewrite, stops execution if not exactly N rules applied (default 1 when specified without value, if 0 - flag is disabled)" <> value 0)
                 )
             <*> optMaxDepth
+            <*> optMaxCycles
             <*> optional (strOption (long "target" <> short 't' <> metavar "FILE" <> help "File to save output to"))
             <*> argInputFile
         )
@@ -183,12 +190,13 @@ runCLI args = handle handler $ do
   case cmd of
     CmdRewrite OptsRewrite {..} -> do
       validateMaxDepth maxDepth
+      validateMaxCycles maxCycles
       validateMust must
       logDebug (printf "Amount of rewriting cycles: %d" maxDepth)
       input <- readInput inputFile
       rules' <- getRules
       program <- parseProgram input inputFormat
-      rewritten <- rewrite' program rules' (RewriteContext program maxDepth buildTerm must)
+      rewritten <- rewrite' program rules' (RewriteContext program maxDepth maxCycles buildTerm must)
       logDebug (printf "Printing rewritten 𝜑-program as %s" (show outputFormat))
       prog <- printProgram rewritten outputFormat printMode
       output prog
@@ -234,21 +242,23 @@ runCLI args = handle handler $ do
             logInfo (printf "The result program was saved in '%s'" file)
     CmdDataize OptsDataize {..} -> do
       validateMaxDepth maxDepth
+      validateMaxCycles maxCycles
       input <- readInput inputFile
       prog <- parseProgram input inputFormat
-      dataized <- dataize prog (DataizeContext prog maxDepth buildTerm)
+      dataized <- dataize prog (DataizeContext prog maxDepth maxCycles buildTerm)
       maybe (throwIO CouldNotDataize) (putStrLn . prettyBytes) dataized
   where
+    validateIntArgument :: Integer -> (Integer -> Bool) -> String -> IO ()
+    validateIntArgument num cmp msg =
+      when
+        (cmp num)
+        (throwIO (InvalidRewriteArguments msg))
     validateMaxDepth :: Integer -> IO ()
-    validateMaxDepth depth =
-      when
-        (depth <= 0)
-        (throwIO (InvalidRewriteArguments "--max-depth must be positive"))
+    validateMaxDepth depth = validateIntArgument depth (<= 0) "--max-depth must be positive"
+    validateMaxCycles :: Integer -> IO ()
+    validateMaxCycles cycles = validateIntArgument cycles (<= 0) "--max-cycles must be positive"
     validateMust :: Integer -> IO ()
-    validateMust must =
-      when
-        (must < 0)
-        (throwIO (InvalidRewriteArguments "--must must be positive"))
+    validateMust must = validateIntArgument must (< 0) "--must must be positive"
     readInput :: Maybe FilePath -> IO String
     readInput inputFile' = case inputFile' of
       Just pth -> do

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -21,11 +21,12 @@ import Yaml (normalizationRules)
 data DataizeContext = DataizeContext
   { _program :: Program,
     _maxDepth :: Integer,
+    _maxCycles :: Integer,
     _buildTerm :: BuildTermFunc
   }
 
 switchContext :: DataizeContext -> RewriteContext
-switchContext DataizeContext {..} = RewriteContext _program _maxDepth _buildTerm 0
+switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _buildTerm 0
 
 maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
 maybeBinding _ [] = (Nothing, [])

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -30,6 +30,7 @@ import qualified Yaml as Y
 data RewriteContext = RewriteContext
   { _program :: Program,
     _maxDepth :: Integer,
+    _maxCycles :: Integer,
     _buildTerm :: BuildTermFunc,
     _must :: Integer
   }
@@ -151,17 +152,17 @@ rewrite' prog rules ctx = _rewrite prog 1
   where
     _rewrite :: Program -> Integer -> IO Program
     _rewrite prog count = do
-      let depth = _maxDepth ctx
+      let cycles = _maxCycles ctx
           must = _must ctx
       if must /= 0 && count - 1 > must
         then throwIO (ContinueAfter must)
         else
-          if count - 1 == depth
+          if count - 1 == cycles
             then do
-              logDebug (printf "Max amount of rewriting cycles for all rules (%d) has been reached, rewriting is stopped" depth)
+              logDebug (printf "Max amount of rewriting cycles for all rules (%d) has been reached, rewriting is stopped" cycles)
               pure prog
             else do
-              logDebug (printf "Starting rewriting cycle for all rules: %d out of %d" count depth)
+              logDebug (printf "Starting rewriting cycle for all rules: %d out of %d" count cycles)
               rewritten <- rewrite prog rules ctx
               if rewritten == prog
                 then do

--- a/test-resources/cli/infinite.yaml
+++ b/test-resources/cli/infinite.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+name: infinite
+pattern: ⟦ x -> !e, !B ⟧
+result: ⟦ x -> 1, x -> !e, !B ⟧

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -207,6 +207,19 @@ spec = do
               content `shouldBe` "{⟦⟧}"
           )
 
+    it "rewrites with cycles" $
+      withStdin "Q -> [[ x -> 1 ]]" $
+        testCLI
+          ["rewrite", "--sweet", "--rule=test-resources/cli/infinite.yaml", "--max-depth=1", "--max-cycles=2"]
+          [ unlines
+              [ "{⟦",
+                "  x ↦ 1,",
+                "  x ↦ 1,",
+                "  x ↦ 1",
+                "⟧}"
+              ]
+          ]
+
   describe "dataize" $ do
     it "dataizes simple program" $
       withStdin "Q -> [[ D> 01- ]]" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 import Functions (buildTerm)
 
 defaultDataizeContext :: Program -> DataizeContext
-defaultDataizeContext prog = DataizeContext prog 25 buildTerm
+defaultDataizeContext prog = DataizeContext prog 25 1 buildTerm
 
 test :: (Eq a, Show a) => (Expression -> DataizeContext -> IO (Maybe a)) -> [(String, Expression, Expression, Maybe a)] -> Spec
 test func useCases =

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -96,7 +96,7 @@ spec =
                   if normalize'
                     then pure normalizationRules
                     else pure []
-              rewritten <- rewrite' program rules' (RewriteContext program repeat' buildTerm must')
+              rewritten <- rewrite' program rules' (RewriteContext program repeat' repeat' buildTerm must')
               result' <- parseProgramThrows (output pack)
               unless (rewritten == result') $
                 expectationFailure


### PR DESCRIPTION
Closes: #330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added a --max-cycles CLI option to cap rewrite cycles across all rules; supported in rewrite and dataize commands.
  * Enhanced debug logging around pattern matching, substitution building, and conditional checks to aid troubleshooting.
* Documentation
  * Improved help text for max-depth to clarify iteration behavior.
  * Updated validation messages: --max-depth must be positive, --max-cycles must be positive, --must must be positive.
* Tests
  * Added a CLI test validating cycle-limited rewriting with an infinite-rule scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->