### PR TITLE
bug(#316): `--depth-sensitive` flag is introduced

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -22,11 +22,12 @@ data DataizeContext = DataizeContext
   { _program :: Program,
     _maxDepth :: Integer,
     _maxCycles :: Integer,
+    _depthSensitive :: Bool,
     _buildTerm :: BuildTermFunc
   }
 
 switchContext :: DataizeContext -> RewriteContext
-switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _buildTerm 0
+switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _depthSensitive _buildTerm 0
 
 maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
 maybeBinding _ [] = (Nothing, [])

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -217,6 +217,12 @@ spec = do
                 "⟧}"
               ]
           ]
+    
+    it "fails with --depth-sensitive" $
+      withStdin "Q -> [[ x -> \"x\"]]" $
+        testCLIFailed
+          ["rewrite", "--depth-sensitive", "--max-depth=1", "--max-cycles=1", "--rule=test-resources/cli/infinite.yaml"]
+          "[ERROR]: With option --depth-sensitive it's expected rewriting iterations amount does not reach the limit: --max-depth=1"
 
   describe "dataize" $ do
     it "dataizes simple program" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 import Functions (buildTerm)
 
 defaultDataizeContext :: Program -> DataizeContext
-defaultDataizeContext prog = DataizeContext prog 25 1 buildTerm
+defaultDataizeContext prog = DataizeContext prog 25 1 False buildTerm
 
 test :: (Eq a, Show a) => (Expression -> DataizeContext -> IO (Maybe a)) -> [(String, Expression, Expression, Maybe a)] -> Spec
 test func useCases =

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -96,7 +96,7 @@ spec =
                   if normalize'
                     then pure normalizationRules
                     else pure []
-              rewritten <- rewrite' program rules' (RewriteContext program repeat' repeat' buildTerm must')
+              rewritten <- rewrite' program rules' (RewriteContext program repeat' repeat' False buildTerm must')
               result' <- parseProgramThrows (output pack)
               unless (rewritten == result') $
                 expectationFailure


### PR DESCRIPTION
Close: #316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a --depth-sensitive CLI flag for rewrite and dataize commands.
  - When enabled, the process exits with an error if max-depth or max-cycles limits are reached.
  - Enhanced logging for rewrite to report both total cycles and per-rule depth.

- Tests
  - Added a CLI test asserting failure behavior with --depth-sensitive and low limits.
  - Updated tests to accommodate the new depth sensitivity option in execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->