### PR TITLE
bug(#240): does not print `--help` option twice

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -166,8 +166,8 @@ rewriteParser =
 commandParser :: Parser Command
 commandParser =
   hsubparser
-    ( command "rewrite" (info (rewriteParser <**> helper) (progDesc "Rewrite the program"))
-        <> command "dataize" (info (dataizeParser <**> helper) (progDesc "Dataize the program"))
+    ( command "rewrite" (info rewriteParser (progDesc "Rewrite the program"))
+        <> command "dataize" (info dataizeParser (progDesc "Dataize the program"))
     )
 
 parserInfo :: ParserInfo Command

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -86,10 +86,10 @@ spec = do
   it "prints version" $
     testCLI ["--version"] [showVersion version]
 
-  it "prints help" $ do
-    output <- capture_ (runCLI ["--help"])
-    output `shouldContain` "Phino - CLI Manipulator of 𝜑-Calculus Expressions"
-    output `shouldContain` "Usage:"
+  it "prints help" $
+    testCLI
+      ["--help"]
+      ["Phino - CLI Manipulator of 𝜑-Calculus Expressions", "Usage:"]
 
   it "prints debug info with --log-level=DEBUG" $
     withStdin "Q -> [[]]" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -16,7 +16,6 @@ import Paths_phino (version)
 import System.Directory (removeFile)
 import System.Exit (ExitCode (ExitFailure))
 import System.IO
-import System.IO.Silently (capture_)
 import Test.Hspec
 import Text.Printf (printf)
 


### PR DESCRIPTION
Closes: #240 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More consistent, unified help output across all CLI subcommands and the top-level command.
- Bug Fixes
  - Ensured --help reliably shows usage and descriptions for commands and subcommands.
- Tests
  - Strengthened help output verification with higher-level assertions for improved reliability.
- Refactor
  - Simplified CLI help handling configuration to reduce duplication and improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->