### PR TITLE
bug(#157): XMIR printing packs via `xmllint` introduced

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -34,6 +34,15 @@ jobs:
         with:
           ghc-version: '9.6.7'
           cabal-version: '3.12.1.0'
+      - name: Install xmllint on Ubuntu
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+      - name: Install xmllint on macOS
+        if: runner.os == 'macOS'
+        run: |
+          brew install libxml2
       - name: Update package list
         run: cabal update
       - name: Build project

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,5 @@ hlint:
 	if command -v hlint &> /dev/null; then
 		hlint src app test
 	else
-			echo "hlint not found, skipping." >&2  # Optional: Print a message
+			echo "hlint not found, skipping." >&2
 	fi

--- a/test-resources/xmir-printing-packs/application.yaml
+++ b/test-resources/xmir-printing-packs/application.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
+---
+phi: |
+  Q -> [[
+    foo -> Q.y(5, "foo")
+  ]]
+xpaths:
+  - '/object/o[@name="foo" and @base="Q.y"]'
+  - '/object/o/o[@as="α0" and @base="Q.org.eolang.number"]'
+  - '/object/o/o[@as="α1" and @base="Q.org.eolang.string"]'

--- a/test-resources/xmir-printing-packs/simple.yaml
+++ b/test-resources/xmir-printing-packs/simple.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
+---
+phi: |
+  Q -> [[
+    org -> [[
+      eolang -> [[
+        foo -> [[
+          x -> 5
+        ]],
+        L> Package
+      ]],
+      L> Package
+    ]]
+  ]]
+xpaths:
+  - '/object/metas/meta[head="package" and tail="org.eolang"]'
+  - '/object/o[@name="foo"]'
+  - '/object/o/o[@name="x" and @base="Q.org.eolang.number"]'

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -7,12 +7,13 @@
 
 module XMIRSpec where
 
+import Control.Exception (bracket)
 import Control.Monad (filterM, forM_, unless)
 import Data.Aeson
 import Data.List (intercalate)
 import Data.Yaml qualified as Yaml
 import GHC.Generics (Generic)
-import GHC.IO (bracket, unsafePerformIO)
+import GHC.IO (unsafePerformIO)
 import Misc (allPathsIn)
 import Parser (parseProgramThrows)
 import Pretty (PrintMode (SWEET))


### PR DESCRIPTION
Closes: #157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Tests
  - Added XMIR printing validation using XPath checks, executed when xmllint is available.
  - Added new test resources for separate parsing and printing test packs.
- Chores
  - CI updated to install xmllint on Linux and macOS runners to support new tests.
  - Minor Makefile cleanup to simplify lint-related messaging.
- Refactor
  - Test suite reorganized to separate parsing and printing validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->