### PR TITLE
bug(#217): prohibit `--output=xmir` and `--sweet` together in rewrite cmd

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -39,7 +39,7 @@ import Data.Version (showVersion)
 import Debug.Trace
 import Misc
 import Paths_phino (version)
-import Pretty (PrintMode (SWEET), prettyAttribute, prettyBinding, prettyBytes, prettyExpression, prettyProgram, prettyProgram')
+import Pretty (PrintMode (SWEET), prettyAttribute, prettyBinding, prettyBytes, prettyExpression, prettyProgram)
 import Text.Printf (printf)
 import qualified Text.Read as TR
 import Text.XML

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -176,7 +176,7 @@ spec = do
       withStdin "Q -> [[ x -> Q.y ]]" $
         testCLI
           ["rewrite", "--nothing", "--output=xmir", "--omit-listing"]
-          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>4 lines of phi</listing>", "  <o base=\"Q.y\" name=\"x\"/>"]
+          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>1 line(s)</listing>", "  <o base=\"Q.y\" name=\"x\"/>"]
 
     it "does not fail on exactly 1 rewriting" $
       withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $
@@ -222,6 +222,12 @@ spec = do
         testCLIFailed
           ["rewrite", "--depth-sensitive", "--max-depth=1", "--max-cycles=1", "--rule=test-resources/cli/infinite.yaml"]
           "[ERROR]: With option --depth-sensitive it's expected rewriting iterations amount does not reach the limit: --max-depth=1"
+
+    it "fails on --sweet and --output=xmir together" $
+      withStdin "Q -> [[ ]]" $
+        testCLIFailed
+          ["rewrite", "--sweet", "--output=xmir", "--nothing"]
+          "The --sweet and --output=xmir can't stay together"
 
   describe "dataize" $ do
     it "dataizes simple program" $


### PR DESCRIPTION
Closes: #217 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Early CLI validation now prevents combining --sweet with --output=xmir, showing a clear, user-friendly error message.

- Refactor
  - XMIR output now uses supplied listing content; when listing is omitted, it reports the number of “line(s)” instead of “lines of phi,” improving clarity.

- Tests
  - Added tests for the new CLI validation.
  - Updated XMIR omit-listing test to expect “1 line(s)” output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->