### PR TITLE
make --must accept ranges

### DIFF
--- a/phino.cabal
+++ b/phino.cabal
@@ -37,7 +37,7 @@ library
     Functions,
     Term,
     Misc,
-    MustRange,
+    Must,
     Logger,
     Regexp,
     Pretty,

--- a/phino.cabal
+++ b/phino.cabal
@@ -37,6 +37,7 @@ library
     Functions,
     Term,
     Misc,
+    MustRange,
     Logger,
     Regexp,
     Pretty,

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -22,7 +22,7 @@ import qualified Functions
 import Logger
 import Misc (ensuredFile)
 import qualified Misc
-import MustRange (MustRange(..))
+import Must (Must(..))
 import Options.Applicative
 import Parser (parseProgramThrows)
 import Paths_phino (version)
@@ -78,7 +78,7 @@ data OptsRewrite = OptsRewrite
     omitListing :: Bool,
     omitComments :: Bool,
     depthSensitive :: Bool,
-    must :: MustRange,
+    must :: Must,
     maxDepth :: Integer,
     maxCycles :: Integer,
     targetFile :: Maybe FilePath,
@@ -265,7 +265,7 @@ runCLI args = handle handler $ do
         (throwIO (InvalidRewriteArguments "The --sweet and --output=xmir can't stay together"))
       validateMaxDepth maxDepth
       validateMaxCycles maxCycles
-      validateMustRange must
+      validateMust must
     validateDataizeArguments :: OptsDataize -> IO ()
     validateDataizeArguments OptsDataize{..} = do
       validateMaxDepth maxDepth
@@ -279,10 +279,10 @@ runCLI args = handle handler $ do
     validateMaxDepth depth = validateIntArgument depth (<= 0) "--max-depth must be positive"
     validateMaxCycles :: Integer -> IO ()
     validateMaxCycles cycles = validateIntArgument cycles (<= 0) "--max-cycles must be positive"
-    validateMustRange :: MustRange -> IO ()
-    validateMustRange MustDisabled = pure ()
-    validateMustRange (MustExact n) = validateIntArgument n (<= 0) "--must exact value must be positive"
-    validateMustRange (MustRange minVal maxVal) = do
+    validateMust :: Must -> IO ()
+    validateMust MustDisabled = pure ()
+    validateMust (MustExact n) = validateIntArgument n (<= 0) "--must exact value must be positive"
+    validateMust (MustRange minVal maxVal) = do
       maybe (pure ()) (\n -> validateIntArgument n (< 0) "--must minimum must be non-negative") minVal
       maybe (pure ()) (\n -> validateIntArgument n (< 0) "--must maximum must be non-negative") maxVal
       case (minVal, maxVal) of

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -11,7 +11,7 @@ import Builder (contextualize)
 import Control.Exception (throwIO)
 import Data.List (partition)
 import Misc
-import MustRange (MustRange(..))
+import Must (Must(..))
 import Rewriter (RewriteContext (RewriteContext), rewrite')
 import Rule (RuleContext (RuleContext), isNF)
 import Term (BuildTermFunc)

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -11,6 +11,7 @@ import Builder (contextualize)
 import Control.Exception (throwIO)
 import Data.List (partition)
 import Misc
+import MustRange (MustRange(..))
 import Rewriter (RewriteContext (RewriteContext), rewrite')
 import Rule (RuleContext (RuleContext), isNF)
 import Term (BuildTermFunc)
@@ -27,7 +28,7 @@ data DataizeContext = DataizeContext
   }
 
 switchContext :: DataizeContext -> RewriteContext
-switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _depthSensitive _buildTerm 0
+switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _depthSensitive _buildTerm MustDisabled
 
 maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
 maybeBinding _ [] = (Nothing, [])

--- a/src/Must.hs
+++ b/src/Must.hs
@@ -1,17 +1,18 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module MustRange (MustRange(..), inRange, exceedsUpperBound) where
+module Must (Must(..), inRange, exceedsUpperBound) where
 
+import Data.List (isInfixOf)
 import Text.Read (readMaybe)
 
-data MustRange
+data Must
   = MustDisabled
   | MustExact Integer
   | MustRange (Maybe Integer) (Maybe Integer)
   deriving (Eq)
 
-instance Show MustRange where
+instance Show Must where
   show MustDisabled = "disabled"
   show (MustExact n) = show n
   show (MustRange Nothing Nothing) = ".."
@@ -19,20 +20,13 @@ instance Show MustRange where
   show (MustRange (Just min) Nothing) = show min ++ ".."
   show (MustRange (Just min) (Just max)) = show min ++ ".." ++ show max
 
-instance Read MustRange where
+instance Read Must where
   readsPrec _ "0" = [(MustDisabled, "")]
   readsPrec _ s 
     | ".." `isInfixOf` s = parseRange s
     | otherwise = parseExact s
     where
-      isInfixOf needle haystack = any (isPrefixOf needle) (tails haystack)
-        where
-          isPrefixOf [] _ = True
-          isPrefixOf _ [] = False
-          isPrefixOf (x:xs) (y:ys) = x == y && isPrefixOf xs ys
-          tails [] = [[]]
-          tails xs@(_:xs') = xs : tails xs'
-      
+      parseRange :: String -> [(Must, String)]
       parseRange str = case break (== '.') str of
         (minStr, '.':'.':maxStr) ->
           let minPart = if null minStr then Nothing else readMaybe minStr
@@ -49,12 +43,13 @@ instance Read MustRange where
             _ -> [] -- Invalid range format
         _ -> [] -- Invalid range: expected format like '3..5', '3..', or '..5'
       
+      parseExact :: String -> [(Must, String)]
       parseExact str = case readMaybe str of
         Just n | n >= 0 -> [(if n == 0 then MustDisabled else MustExact n, "")]
         Just _ -> [] -- Invalid value: must be non-negative
         Nothing -> [] -- Invalid value: expected integer
 
-inRange :: MustRange -> Integer -> Bool
+inRange :: Must -> Integer -> Bool
 inRange MustDisabled _ = True
 inRange (MustExact expected) actual = actual == expected
 inRange (MustRange minVal maxVal) actual =
@@ -64,7 +59,7 @@ inRange (MustRange minVal maxVal) actual =
     checkMax = maybe True (>= actual) maxVal
 
 -- | Check if a value exceeds the upper bound of the range
-exceedsUpperBound :: MustRange -> Integer -> Bool
+exceedsUpperBound :: Must -> Integer -> Bool
 exceedsUpperBound MustDisabled _ = False
 exceedsUpperBound (MustExact n) current = current > n
 exceedsUpperBound (MustRange _ (Just max)) current = current > max

--- a/src/MustRange.hs
+++ b/src/MustRange.hs
@@ -1,7 +1,7 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module MustRange (MustRange(..), isInRange, exceedsUpperBound) where
+module MustRange (MustRange(..), inRange, exceedsUpperBound) where
 
 import Text.Read (readMaybe)
 
@@ -54,10 +54,10 @@ instance Read MustRange where
         Just _ -> [] -- Invalid value: must be non-negative
         Nothing -> [] -- Invalid value: expected integer
 
-isInRange :: MustRange -> Integer -> Bool
-isInRange MustDisabled _ = True
-isInRange (MustExact expected) actual = actual == expected
-isInRange (MustRange minVal maxVal) actual =
+inRange :: MustRange -> Integer -> Bool
+inRange MustDisabled _ = True
+inRange (MustExact expected) actual = actual == expected
+inRange (MustRange minVal maxVal) actual =
   checkMin && checkMax
   where
     checkMin = maybe True (<= actual) minVal

--- a/src/MustRange.hs
+++ b/src/MustRange.hs
@@ -1,0 +1,71 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module MustRange (MustRange(..), isInRange, exceedsUpperBound) where
+
+import Text.Read (readMaybe)
+
+data MustRange
+  = MustDisabled
+  | MustExact Integer
+  | MustRange (Maybe Integer) (Maybe Integer)
+  deriving (Eq)
+
+instance Show MustRange where
+  show MustDisabled = "disabled"
+  show (MustExact n) = show n
+  show (MustRange Nothing Nothing) = ".."
+  show (MustRange Nothing (Just max)) = ".." ++ show max
+  show (MustRange (Just min) Nothing) = show min ++ ".."
+  show (MustRange (Just min) (Just max)) = show min ++ ".." ++ show max
+
+instance Read MustRange where
+  readsPrec _ "0" = [(MustDisabled, "")]
+  readsPrec _ s 
+    | ".." `isInfixOf` s = parseRange s
+    | otherwise = parseExact s
+    where
+      isInfixOf needle haystack = any (isPrefixOf needle) (tails haystack)
+        where
+          isPrefixOf [] _ = True
+          isPrefixOf _ [] = False
+          isPrefixOf (x:xs) (y:ys) = x == y && isPrefixOf xs ys
+          tails [] = [[]]
+          tails xs@(_:xs') = xs : tails xs'
+      
+      parseRange str = case break (== '.') str of
+        (minStr, '.':'.':maxStr) ->
+          let minPart = if null minStr then Nothing else readMaybe minStr
+              maxPart = if null maxStr then Nothing else readMaybe maxStr
+          in case (minPart, maxPart, null minStr, null maxStr) of
+            (Nothing, Nothing, False, False) -> [] -- Invalid range: non-numeric values
+            (Nothing, Nothing, True, True) -> [] -- Invalid range: empty range '..'
+            (Nothing, Just max, True, False) ->
+              [(MustRange Nothing (Just max), "") | max >= 0]
+            (Just min, Nothing, False, True) ->
+              [(MustRange (Just min) Nothing, "") | min >= 0]
+            (Just min, Just max, False, False) ->
+              [(MustRange (Just min) (Just max), "") | min >= 0 && max >= 0 && min <= max]
+            _ -> [] -- Invalid range format
+        _ -> [] -- Invalid range: expected format like '3..5', '3..', or '..5'
+      
+      parseExact str = case readMaybe str of
+        Just n | n >= 0 -> [(if n == 0 then MustDisabled else MustExact n, "")]
+        Just _ -> [] -- Invalid value: must be non-negative
+        Nothing -> [] -- Invalid value: expected integer
+
+isInRange :: MustRange -> Integer -> Bool
+isInRange MustDisabled _ = True
+isInRange (MustExact expected) actual = actual == expected
+isInRange (MustRange minVal maxVal) actual =
+  checkMin && checkMax
+  where
+    checkMin = maybe True (<= actual) minVal
+    checkMax = maybe True (>= actual) maxVal
+
+-- | Check if a value exceeds the upper bound of the range
+exceedsUpperBound :: MustRange -> Integer -> Bool
+exceedsUpperBound MustDisabled _ = False
+exceedsUpperBound (MustExact n) current = current > n
+exceedsUpperBound (MustRange _ (Just max)) current = current > max
+exceedsUpperBound (MustRange _ Nothing) _ = False

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -17,7 +17,7 @@ import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Logger (logDebug)
 import Matcher (MetaValue (MvAttribute, MvBindings, MvBytes, MvExpression), Subst (Subst), combine, combineMany, defaultScope, matchProgram, substEmpty, substSingle)
 import Misc (ensuredFile)
-import MustRange (MustRange(..), isInRange, exceedsUpperBound)
+import MustRange (MustRange(..), inRange, exceedsUpperBound)
 import Parser (parseProgram, parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyAttribute, prettyBytes, prettyExpression, prettyExpression', prettyProgram, prettyProgram', prettySubsts)
 import Replacer (ReplaceProgramContext (ReplaceProgramContext), ReplaceProgramThrowsFunc, replaceProgramFastThrows, replaceProgramThrows)
@@ -166,7 +166,7 @@ rewrite' prog rules ctx = _rewrite prog 1
       let cycles = _maxCycles ctx
           must = _must ctx
           currentCount = count - 1
-      if not (isInRange must currentCount) && currentCount > 0 && exceedsUpperBound must currentCount
+      if not (inRange must currentCount) && currentCount > 0 && exceedsUpperBound must currentCount
         then throwIO (MustStopBefore must currentCount)
         else
           if currentCount == cycles
@@ -181,7 +181,7 @@ rewrite' prog rules ctx = _rewrite prog 1
               if rewritten == prog
                 then do
                   logDebug "No rule matched, rewriting is stopped"
-                  if not (isInRange must currentCount)
+                  if not (inRange must currentCount)
                     then throwIO (MustBeGoing must currentCount)
                     else pure rewritten
                 else _rewrite rewritten (count + 1)

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -17,6 +17,7 @@ import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Logger (logDebug)
 import Matcher (MetaValue (MvAttribute, MvBindings, MvBytes, MvExpression), Subst (Subst), combine, combineMany, defaultScope, matchProgram, substEmpty, substSingle)
 import Misc (ensuredFile)
+import MustRange (MustRange(..), isInRange, exceedsUpperBound)
 import Parser (parseProgram, parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyAttribute, prettyBytes, prettyExpression, prettyExpression', prettyProgram, prettyProgram', prettySubsts)
 import Replacer (ReplaceProgramContext (ReplaceProgramContext), ReplaceProgramThrowsFunc, replaceProgramFastThrows, replaceProgramThrows)
@@ -33,27 +34,28 @@ data RewriteContext = RewriteContext
     _maxCycles :: Integer,
     _depthSensitive :: Bool,
     _buildTerm :: BuildTermFunc,
-    _must :: Integer
+    _must :: MustRange
   }
 
 data RewriteException
-  = MustBeGoing {must :: Integer, count :: Integer}
-  | MustStopBefore {must :: Integer}
+  = MustBeGoing {must :: MustRange, count :: Integer}
+  | MustStopBefore {must :: MustRange, count :: Integer}
   | StoppedOnLimit {flag :: String, limit :: Integer}
   deriving (Exception)
 
 instance Show RewriteException where
   show MustBeGoing {..} =
     printf
-      "With option --must=%d it's expected exactly %d rewriting cycles happened, but rewriting stopped after %d"
-      must
-      must
+      "With option --must=%s it's expected rewriting cycles to be in range %s, but rewriting stopped after %d cycles"
+      (show must)
+      (show must)
       count
   show MustStopBefore {..} =
     printf
-      "With option --must=%d it's expected exactly %d rewriting cycles happened, but rewriting is still going"
-      must
-      must
+      "With option --must=%s it's expected rewriting cycles to be in range %s, but rewriting has already reached %d cycles and is still going"
+      (show must)
+      (show must)
+      count
   show StoppedOnLimit {..} =
     printf
       "With option --depth-sensitive it's expected rewriting iterations amount does not reach the limit: --%s=%d"
@@ -163,10 +165,11 @@ rewrite' prog rules ctx = _rewrite prog 1
     _rewrite prog count = do
       let cycles = _maxCycles ctx
           must = _must ctx
-      if must /= 0 && count - 1 > must
-        then throwIO (MustStopBefore must)
+          currentCount = count - 1
+      if not (isInRange must currentCount) && currentCount > 0 && exceedsUpperBound must currentCount
+        then throwIO (MustStopBefore must currentCount)
         else
-          if count - 1 == cycles
+          if currentCount == cycles
             then do
               logDebug (printf "Max amount of rewriting cycles for all rules (%d) has been reached, rewriting is stopped" cycles)
               if _depthSensitive ctx
@@ -178,7 +181,7 @@ rewrite' prog rules ctx = _rewrite prog 1
               if rewritten == prog
                 then do
                   logDebug "No rule matched, rewriting is stopped"
-                  if must /= 0 && count - 1 /= must
-                    then throwIO (MustBeGoing must (count - 1))
+                  if not (isInRange must currentCount)
+                    then throwIO (MustBeGoing must currentCount)
                     else pure rewritten
                 else _rewrite rewritten (count + 1)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -184,13 +184,68 @@ spec = do
           ["rewrite", "--rule=test-resources/cli/simple.yaml", "--must=1", "--sweet"]
           ["x ↦ \"bar\""]
 
-    it "fails with --nothing and --must" $
+    it "fails with --nothing and --must=1" $
       withStdin "Q -> [[ ]]" $
-        testCLIFailed ["rewrite", "--nothing", "--must"] "it's expected exactly 1 rewriting cycles happened, but rewriting stopped after 0"
+        testCLIFailed ["rewrite", "--nothing", "--must=1"] "it's expected rewriting cycles to be in range 1, but rewriting stopped after 0"
 
-    it "fails with --normalize and --must" $
+    it "fails with --normalize and --must=1" $
       withStdin "Q -> [[ x -> [[ y -> 5 ]].y ]].x" $
-        testCLIFailed ["rewrite", "--max-depth=2", "--normalize", "--must"] "it's expected exactly 1 rewriting cycles happened, but rewriting is still going"
+        testCLIFailed ["rewrite", "--max-depth=2", "--normalize", "--must=1"] "it's expected rewriting cycles to be in range 1, but rewriting has already reached 2"
+
+    describe "must range tests" $ do
+      it "accepts range ..5 (0 to 5 cycles)" $
+        withStdin "Q -> [[ ]]" $
+          testCLI ["rewrite", "--nothing", "--must=..5", "--sweet"] ["{⟦⟧}"]
+
+      it "accepts range 0..0 (exactly 0 cycles)" $
+        withStdin "Q -> [[ ]]" $
+          testCLI ["rewrite", "--nothing", "--must=0..0", "--sweet"] ["{⟦⟧}"]
+
+      it "accepts range 1..1 (exactly 1 cycle)" $
+        withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $
+          testCLI
+            ["rewrite", "--rule=test-resources/cli/simple.yaml", "--must=1..1", "--sweet"]
+            ["x ↦ \"bar\""]
+
+      it "accepts range 1..3 when 1 cycle happens" $
+        withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $
+          testCLI
+            ["rewrite", "--rule=test-resources/cli/simple.yaml", "--must=1..3", "--sweet"]
+            ["x ↦ \"bar\""]
+
+      it "accepts range 0.. (0 or more)" $
+        withStdin "Q -> [[ ]]" $
+          testCLI ["rewrite", "--nothing", "--must=0..", "--sweet"] ["{⟦⟧}"]
+
+      it "fails when cycles exceed range ..1" $
+        withStdin "Q -> [[ x -> [[ y -> 5 ]].y ]].x" $
+          testCLIFailed 
+            ["rewrite", "--max-depth=2", "--normalize", "--must=..1"] 
+            "it's expected rewriting cycles to be in range ..1, but rewriting has already reached 2"
+
+      it "fails when cycles below range 2.." $
+        withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $
+          testCLIFailed
+            ["rewrite", "--rule=test-resources/cli/simple.yaml", "--must=2.."]
+            "it's expected rewriting cycles to be in range 2.., but rewriting stopped after 1"
+
+      it "fails with invalid range 5..3" $
+        withStdin "Q -> [[ ]]" $
+          testCLIFailed
+            ["rewrite", "--nothing", "--must=5..3"]
+            "cannot parse value `5..3'"
+
+      it "fails with negative in range -1..5" $
+        withStdin "Q -> [[ ]]" $
+          testCLIFailed
+            ["rewrite", "--nothing", "--must=-1..5"]
+            "cannot parse value `-1..5'"
+
+      it "fails with malformed range syntax" $
+        withStdin "Q -> [[ ]]" $
+          testCLIFailed
+            ["rewrite", "--nothing", "--must=3...5"]
+            "cannot parse value `3...5'"
 
     it "prints to target file" $
       withStdin "Q -> [[ ]]" $

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -15,7 +15,7 @@ import Data.Yaml qualified as Yaml
 import Functions (buildTerm)
 import GHC.Generics
 import Misc (allPathsIn, ensuredFile)
-import MustRange (MustRange(..))
+import Must (Must(..))
 import Parser (parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyProgram')
 import Rewriter (RewriteContext (RewriteContext), rewrite')

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -15,6 +15,7 @@ import Data.Yaml qualified as Yaml
 import Functions (buildTerm)
 import GHC.Generics
 import Misc (allPathsIn, ensuredFile)
+import MustRange (MustRange(..))
 import Parser (parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyProgram')
 import Rewriter (RewriteContext (RewriteContext), rewrite')
@@ -74,8 +75,8 @@ spec =
                     Just num -> num
                     _ -> 1
               must' = case must pack of
-                Just num -> num
-                _ -> 0
+                Just num -> MustExact num
+                _ -> MustDisabled
           case skip pack of
             Just True -> pending
             _ -> do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - The --must CLI option now supports ranges in addition to exact values, e.g., "3", "..5", "3..", or "3..5". Default is disabled (0). Rewriting now enforces these ranges, with clearer validation and error messages when cycles fall outside the specified bounds.

- Tests
  - Expanded coverage for range parsing and enforcement, including valid/invalid inputs and boundary conditions (e.g., "..5", "0..0", "1..3", failures for "..1" overflow, "2.." underflow, and malformed ranges).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->