### PR TITLE
bug(#360): fix indents + renaming in `Must` module

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -11,7 +11,7 @@ import Builder (contextualize)
 import Control.Exception (throwIO)
 import Data.List (partition)
 import Misc
-import Must (Must(..))
+import Must (Must (..))
 import Rewriter (RewriteContext (RewriteContext), rewrite')
 import Rule (RuleContext (RuleContext), isNF)
 import Term (BuildTermFunc)
@@ -28,7 +28,7 @@ data DataizeContext = DataizeContext
   }
 
 switchContext :: DataizeContext -> RewriteContext
-switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _depthSensitive _buildTerm MustDisabled
+switchContext DataizeContext {..} = RewriteContext _program _maxDepth _maxCycles _depthSensitive _buildTerm MtDisabled
 
 maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
 maybeBinding _ [] = (Nothing, [])

--- a/src/Must.hs
+++ b/src/Must.hs
@@ -1,58 +1,57 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Must (Must(..), inRange, exceedsUpperBound) where
+module Must (Must (..), inRange, exceedsUpperBound) where
 
 import Data.List (isInfixOf)
 import Text.Read (readMaybe)
 
 data Must
-  = MustDisabled
-  | MustExact Integer
-  | MustRange (Maybe Integer) (Maybe Integer)
+  = MtDisabled
+  | MtExact Integer
+  | MtRange (Maybe Integer) (Maybe Integer)
   deriving (Eq)
 
 instance Show Must where
-  show MustDisabled = "disabled"
-  show (MustExact n) = show n
-  show (MustRange Nothing Nothing) = ".."
-  show (MustRange Nothing (Just max)) = ".." ++ show max
-  show (MustRange (Just min) Nothing) = show min ++ ".."
-  show (MustRange (Just min) (Just max)) = show min ++ ".." ++ show max
+  show MtDisabled = "disabled"
+  show (MtExact n) = show n
+  show (MtRange Nothing Nothing) = ".."
+  show (MtRange Nothing (Just max)) = ".." ++ show max
+  show (MtRange (Just min) Nothing) = show min ++ ".."
+  show (MtRange (Just min) (Just max)) = show min ++ ".." ++ show max
 
 instance Read Must where
-  readsPrec _ "0" = [(MustDisabled, "")]
-  readsPrec _ s 
+  readsPrec _ "0" = [(MtDisabled, "")]
+  readsPrec _ s
     | ".." `isInfixOf` s = parseRange s
     | otherwise = parseExact s
     where
       parseRange :: String -> [(Must, String)]
       parseRange str = case break (== '.') str of
-        (minStr, '.':'.':maxStr) ->
+        (minStr, '.' : '.' : maxStr) ->
           let minPart = if null minStr then Nothing else readMaybe minStr
               maxPart = if null maxStr then Nothing else readMaybe maxStr
-          in case (minPart, maxPart, null minStr, null maxStr) of
-            (Nothing, Nothing, False, False) -> [] -- Invalid range: non-numeric values
-            (Nothing, Nothing, True, True) -> [] -- Invalid range: empty range '..'
-            (Nothing, Just max, True, False) ->
-              [(MustRange Nothing (Just max), "") | max >= 0]
-            (Just min, Nothing, False, True) ->
-              [(MustRange (Just min) Nothing, "") | min >= 0]
-            (Just min, Just max, False, False) ->
-              [(MustRange (Just min) (Just max), "") | min >= 0 && max >= 0 && min <= max]
-            _ -> [] -- Invalid range format
+           in case (minPart, maxPart, null minStr, null maxStr) of
+                (Nothing, Nothing, False, False) -> [] -- Invalid range: non-numeric values
+                (Nothing, Nothing, True, True) -> [] -- Invalid range: empty range '..'
+                (Nothing, Just max, True, False) ->
+                  [(MtRange Nothing (Just max), "") | max >= 0]
+                (Just min, Nothing, False, True) ->
+                  [(MtRange (Just min) Nothing, "") | min >= 0]
+                (Just min, Just max, False, False) ->
+                  [(MtRange (Just min) (Just max), "") | min >= 0 && max >= 0 && min <= max]
+                _ -> [] -- Invalid range format
         _ -> [] -- Invalid range: expected format like '3..5', '3..', or '..5'
-      
       parseExact :: String -> [(Must, String)]
       parseExact str = case readMaybe str of
-        Just n | n >= 0 -> [(if n == 0 then MustDisabled else MustExact n, "")]
+        Just n | n >= 0 -> [(if n == 0 then MtDisabled else MtExact n, "")]
         Just _ -> [] -- Invalid value: must be non-negative
         Nothing -> [] -- Invalid value: expected integer
 
 inRange :: Must -> Integer -> Bool
-inRange MustDisabled _ = True
-inRange (MustExact expected) actual = actual == expected
-inRange (MustRange minVal maxVal) actual =
+inRange MtDisabled _ = True
+inRange (MtExact expected) actual = actual == expected
+inRange (MtRange minVal maxVal) actual =
   checkMin && checkMax
   where
     checkMin = maybe True (<= actual) minVal
@@ -60,7 +59,7 @@ inRange (MustRange minVal maxVal) actual =
 
 -- | Check if a value exceeds the upper bound of the range
 exceedsUpperBound :: Must -> Integer -> Bool
-exceedsUpperBound MustDisabled _ = False
-exceedsUpperBound (MustExact n) current = current > n
-exceedsUpperBound (MustRange _ (Just max)) current = current > max
-exceedsUpperBound (MustRange _ Nothing) _ = False
+exceedsUpperBound MtDisabled _ = False
+exceedsUpperBound (MtExact n) current = current > n
+exceedsUpperBound (MtRange _ (Just max)) current = current > max
+exceedsUpperBound (MtRange _ Nothing) _ = False

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -17,7 +17,7 @@ import Data.Maybe (catMaybes, fromMaybe, isJust)
 import Logger (logDebug)
 import Matcher (MetaValue (MvAttribute, MvBindings, MvBytes, MvExpression), Subst (Subst), combine, combineMany, defaultScope, matchProgram, substEmpty, substSingle)
 import Misc (ensuredFile)
-import Must (Must(..), inRange, exceedsUpperBound)
+import Must (Must (..), exceedsUpperBound, inRange)
 import Parser (parseProgram, parseProgramThrows)
 import Pretty (PrintMode (SWEET), prettyAttribute, prettyBytes, prettyExpression, prettyExpression', prettyProgram, prettyProgram', prettySubsts)
 import Replacer (ReplaceProgramContext (ReplaceProgramContext), ReplaceProgramThrowsFunc, replaceProgramFastThrows, replaceProgramThrows)
@@ -46,13 +46,13 @@ data RewriteException
 instance Show RewriteException where
   show MustBeGoing {..} =
     printf
-      "With option --must=%s it's expected rewriting cycles to be in range %s, but rewriting stopped after %d cycles"
+      "With option --must=%s it's expected rewriting cycles to be in range [%s], but rewriting stopped after %d cycles"
       (show must)
       (show must)
       count
   show MustStopBefore {..} =
     printf
-      "With option --must=%s it's expected rewriting cycles to be in range %s, but rewriting has already reached %d cycles and is still going"
+      "With option --must=%s it's expected rewriting cycles to be in range [%s], but rewriting has already reached %d cycles and is still going"
       (show must)
       (show must)
       count

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -186,11 +186,11 @@ spec = do
 
     it "fails with --nothing and --must=1" $
       withStdin "Q -> [[ ]]" $
-        testCLIFailed ["rewrite", "--nothing", "--must=1"] "it's expected rewriting cycles to be in range 1, but rewriting stopped after 0"
+        testCLIFailed ["rewrite", "--nothing", "--must=1"] "it's expected rewriting cycles to be in range [1], but rewriting stopped after 0"
 
     it "fails with --normalize and --must=1" $
       withStdin "Q -> [[ x -> [[ y -> 5 ]].y ]].x" $
-        testCLIFailed ["rewrite", "--max-depth=2", "--normalize", "--must=1"] "it's expected rewriting cycles to be in range 1, but rewriting has already reached 2"
+        testCLIFailed ["rewrite", "--max-depth=2", "--normalize", "--must=1"] "it's expected rewriting cycles to be in range [1], but rewriting has already reached 2"
 
     describe "must range tests" $ do
       it "accepts range ..5 (0 to 5 cycles)" $
@@ -221,13 +221,13 @@ spec = do
         withStdin "Q -> [[ x -> [[ y -> 5 ]].y ]].x" $
           testCLIFailed 
             ["rewrite", "--max-depth=2", "--normalize", "--must=..1"] 
-            "it's expected rewriting cycles to be in range ..1, but rewriting has already reached 2"
+            "it's expected rewriting cycles to be in range [..1], but rewriting has already reached 2"
 
       it "fails when cycles below range 2.." $
         withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $
           testCLIFailed
             ["rewrite", "--rule=test-resources/cli/simple.yaml", "--must=2.."]
-            "it's expected rewriting cycles to be in range 2.., but rewriting stopped after 1"
+            "it's expected rewriting cycles to be in range [2..], but rewriting stopped after 1"
 
       it "fails with invalid range 5..3" $
         withStdin "Q -> [[ ]]" $

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -75,8 +75,8 @@ spec =
                     Just num -> num
                     _ -> 1
               must' = case must pack of
-                Just num -> MustExact num
-                _ -> MustDisabled
+                Just num -> MtExact num
+                _ -> MtDisabled
           case skip pack of
             Just True -> pending
             _ -> do


### PR DESCRIPTION
Closes: #360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Unified validation across rewrite, dataize, and explain commands to prevent invalid option combinations.
  - Disallows using --sweet with --output when formats conflict.
  - Enforces that explain requires at least one of --rule or --normalize.
  - Validates --must values: exact must be positive; ranges non‑negative with min ≤ max; clearer, more descriptive errors on failure.
  - Error messages now display must ranges in brackets (e.g., [1], [..1], [2..]) for consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->