### PR TITLE
bug(#364): remove `--nothing` option

### DIFF
--- a/src/Must.hs
+++ b/src/Must.hs
@@ -13,7 +13,7 @@ data Must
   deriving (Eq)
 
 instance Show Must where
-  show MtDisabled = "disabled"
+  show MtDisabled = "0"
   show (MtExact n) = show n
   show (MtRange Nothing Nothing) = ".."
   show (MtRange Nothing (Just max)) = ".." ++ show max


### PR DESCRIPTION
Closes: #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * Removed the --nothing CLI flag and simplified rule selection to rely on --normalize and file-based rules. Logs and messages updated accordingly.
* Documentation
  * Clarified in-place help text: “Edit file in-place instead of printing to output.”
* Style
  * Output formatting tweak: the “disabled” Must value now renders as “0”.
* Tests
  * Updated CLI tests to remove --nothing usage and align expectations with the new rule selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->