### PR TITLE
bug(#373): replace unprintable characters in latex

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -3,23 +3,31 @@
 
 module LaTeX (explainRules, programToLaTeX) where
 
+import Ast (Program)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
+import Pretty (Encoding (ASCII), PrintMode, prettyProgram')
 import qualified Yaml as Y
-import Ast (Program)
-import Pretty (PrintMode, prettyProgram', Encoding (ASCII))
+
+escapeUnprintedChars :: String -> String
+escapeUnprintedChars [] = []
+escapeUnprintedChars (ch : rest) = case ch of
+  '$' -> "\\char36{}" ++ escapeUnprintedChars rest
+  '@' -> "\\char64{}" ++ escapeUnprintedChars rest
+  '^' -> "\\char94{}" ++ escapeUnprintedChars rest
+  _ -> ch : escapeUnprintedChars rest
 
 programToLaTeX :: Program -> PrintMode -> String
-programToLaTeX prog mode = unlines
-  [
-    "\\documentclass{article}",
-    "\\usepackage{eolang}",
-    "\\begin{document}",
-    "\\begin{phiquation}",
-    prettyProgram' prog mode ASCII,
-    "\\end{phiquation}",
-    "\\end{document}"
-  ]
+programToLaTeX prog mode =
+  unlines
+    [ "\\documentclass{article}",
+      "\\usepackage{eolang}",
+      "\\begin{document}",
+      "\\begin{phiquation}",
+      escapeUnprintedChars (prettyProgram' prog mode ASCII),
+      "\\end{phiquation}",
+      "\\end{document}"
+    ]
 
 -- @todo #114:30min Implement LaTeX conversion for rules.
 --  Convert Rule data structure to LaTeX inference rule format.

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -166,7 +166,7 @@ spec = do
           ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "  <o base=\"Q.y\" name=\"x\"/>"]
 
     it "rewrites as LaTeX" $
-      withStdin "Q -> [[ x -> QQ.z(y -> 5), q -> T ]]" $
+      withStdin "Q -> [[ x -> QQ.z(y -> 5), q -> T, w -> $, ^ -> Q, @ -> 1, y -> \"H$@^M\"]]" $
         testCLI
           ["rewrite", "--output=latex", "--sweet"]
           [ "\\documentclass{article}",
@@ -177,7 +177,11 @@ spec = do
             "  x -> QQ.z(",
             "    y -> 5",
             "  ),",
-            "  q -> T",
+            "  q -> T,",
+            "  w -> \\char36{},",
+            "  \\char94{} -> Q,",
+            "  \\char64{} -> 1,",
+            "  y -> \"H\\char36{}\\char64{}\\char94{}M\"",
             "]]}",
             "\\end{phiquation}",
             "\\end{document}"


### PR DESCRIPTION
Closes: #373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - LaTeX export now safely escapes TeX-sensitive characters ($, @, ^) to prevent rendering issues.
- Refactor
  - Simplified LaTeX output construction for clarity and consistency.
- Tests
  - Expanded CLI LaTeX tests to cover new character mappings and escaping (e.g., $, @, ^ within strings).
  - Updated expected outputs to reflect escaped characters in rendered LaTeX.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->