### PR TITLE
bug(#280): remove xmir attribute

### DIFF
--- a/test-resources/xmir-parsing-packs/application-with-dispatch.yaml
+++ b/test-resources/xmir-parsing-packs/application-with-dispatch.yaml
@@ -6,10 +6,10 @@ xmir: |
   <object>
     <o name="app">
       <o name="x" base=".plus">
-        <o base="Q.number">
+        <o base="Φ.number">
           <o>00-00-00-01</o>
         </o>
-        <o as="arg" base="Q.number">
+        <o as="arg" base="Φ.number">
           <o>00-00-00-02</o>
         </o>
       </o>

--- a/test-resources/xmir-parsing-packs/application.yaml
+++ b/test-resources/xmir-parsing-packs/application.yaml
@@ -5,13 +5,13 @@
 xmir: |
   <object>
     <o name="app">
-      <o name="x" base="Q.org.eolang">
-        <o base="Q.x"/>
+      <o name="x" base="Φ.org.eolang">
+        <o base="Φ.x"/>
         <o as="α1" base=".plus">
-          <o base="Q.y"/>
+          <o base="Φ.y"/>
         </o>
         <o as="arg">
-          <o name="y" base="$"/>
+          <o name="y" base="ξ"/>
         </o>
       </o>
     </o>

--- a/test-resources/xmir-parsing-packs/base-dispatch.yaml
+++ b/test-resources/xmir-parsing-packs/base-dispatch.yaml
@@ -4,7 +4,7 @@
 xmir: |
   <object>
     <o name="app">
-      <o name="x" base="Q.org.eolang"/>
+      <o name="x" base="Φ.org.eolang"/>
     </o>
   </object>
 phi: '{[[ app -> [[ x -> Q.org.eolang ]] ]]}'

--- a/test-resources/xmir-parsing-packs/formation-dispatch.yaml
+++ b/test-resources/xmir-parsing-packs/formation-dispatch.yaml
@@ -6,7 +6,7 @@ xmir: |
     <o name="app">
       <o name="x" base=".plus">
         <o>
-          <o name="plus" base="Q.number"/>
+          <o name="plus" base="Φ.number"/>
         </o>
       </o>
     </o>

--- a/test-resources/xmir-parsing-packs/formation.yaml
+++ b/test-resources/xmir-parsing-packs/formation.yaml
@@ -4,8 +4,8 @@
 xmir: |
   <object>
     <o name="app">
-      <o name="x" base="Q"/>
-      <o name="y" base="$"/>
+      <o name="x" base="Φ"/>
+      <o name="y" base="ξ"/>
     </o>
   </object>
 phi: '{[[ app -> [[ x -> Q, y -> $ ]] ]]}'

--- a/test-resources/xmir-parsing-packs/reverse-dispatch.yaml
+++ b/test-resources/xmir-parsing-packs/reverse-dispatch.yaml
@@ -5,7 +5,7 @@ xmir: |
   <object>
     <o name="app">
       <o name="x" base=".eolang">
-        <o base="Q.org"/>
+        <o base="Φ.org"/>
       </o>
     </o>
   </object>

--- a/test-resources/xmir-parsing-packs/with-package.yaml
+++ b/test-resources/xmir-parsing-packs/with-package.yaml
@@ -12,7 +12,7 @@ xmir: |
       </meta>
     </metas>
     <o name="app">
-      <o name="x" base="Q.org.eolang"/>
+      <o name="x" base="Φ.org.eolang"/>
     </o>
   </object>
 phi: |

--- a/test-resources/xmir-parsing-packs/with-phi.yaml
+++ b/test-resources/xmir-parsing-packs/with-phi.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-xmir: | 
+xmir: |
   <object>
     <o name="app">
       <o name="φ" base="ξ.φ"/>

--- a/test-resources/xmir-parsing-packs/with-phi.yaml
+++ b/test-resources/xmir-parsing-packs/with-phi.yaml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-xmir: |
+xmir: | 
   <object>
     <o name="app">
-      <o name="@" base="$.@"/>
+      <o name="φ" base="ξ.φ"/>
     </o>
   </object>
-phi: '{[[ app -> [[ @ -> $.@ ]] ]]}'
+phi: '{[[ app -> [[ φ -> $.φ ]] ]]}'

--- a/test-resources/xmir-printing-packs/application.yaml
+++ b/test-resources/xmir-printing-packs/application.yaml
@@ -4,9 +4,13 @@
 ---
 phi: |
   Q -> [[
-    foo -> Q.y(5, "foo")
+    foo -> [[
+      @ -> $.^.z,
+      bar -> Q.y(5, "foo")
+    ]]
   ]]
 xpaths:
-  - '/object/o[@name="foo" and @base="Q.y"]'
-  - '/object/o/o[@as="α0" and @base="Q.org.eolang.number"]'
-  - '/object/o/o[@as="α1" and @base="Q.org.eolang.string"]'
+  - '/object/o[@name="foo" and o[2][@base="Φ.y"]]'
+  - '/object/o/o/o[@as="α0" and @base="Φ.org.eolang.number"]'
+  - '/object/o/o/o[@as="α1" and @base="Φ.org.eolang.string"]'
+  - '/object/o/o[@name="φ" and @base="ξ.ρ.z"]'

--- a/test-resources/xmir-printing-packs/simple.yaml
+++ b/test-resources/xmir-printing-packs/simple.yaml
@@ -17,4 +17,4 @@ phi: |
 xpaths:
   - '/object/metas/meta[head="package" and tail="org.eolang"]'
   - '/object/o[@name="foo"]'
-  - '/object/o/o[@name="x" and @base="Q.org.eolang.number"]'
+  - '/object/o/o[@name="x" and @base="Φ.org.eolang.number"]'

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -201,7 +201,7 @@ spec = do
       withStdin "Q -> [[ x -> Q.y ]]" $
         testCLI
           ["rewrite", "--output=xmir"]
-          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "  <o base=\"Q.y\" name=\"x\"/>"]
+          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "  <o base=\"Φ.y\" name=\"x\"/>"]
 
     it "rewrites as LaTeX" $
       withStdin "Q -> [[ x -> QQ.z(y -> 5), q -> T, w -> $, ^ -> Q, @ -> 1, y -> \"H$@^M\"]]" $
@@ -226,7 +226,7 @@ spec = do
           ]
 
     it "rewrites with XMIR as input" $
-      withStdin "<object><o name=\"app\"><o name=\"x\" base=\"Q.number\"/></o></object>" $
+      withStdin "<object><o name=\"app\"><o name=\"x\" base=\"Φ.number\"/></o></object>" $
         testCLI
           ["rewrite", "--input=xmir", "--sweet"]
           [ unlines
@@ -242,7 +242,7 @@ spec = do
       withStdin "Q -> [[ x -> Q.y ]]" $
         testCLI
           ["rewrite", "--output=xmir", "--omit-listing"]
-          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>1 line(s)</listing>", "  <o base=\"Q.y\" name=\"x\"/>"]
+          ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "<listing>1 line(s)</listing>", "  <o base=\"Φ.y\" name=\"x\"/>"]
 
     it "does not fail on exactly 1 rewriting" $
       withStdin "{⟦ t ↦ ⟦ x ↦ \"foo\" ⟧ ⟧}" $


### PR DESCRIPTION
Closes: #280 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - XMIR output now uses Greek-letter identifiers (Φ, ξ, φ, ρ) and improved pretty-printing for expressions and attributes.
- Refactor
  - Internal XMIR formatting and parsing updated to replace legacy symbols (@, ^, Q.*) with the new base and attribute notation.
- Style
  - Updated CLI-visible error messages and text to reflect Greek-letter symbols and revised attribute paths.
- Tests
  - Test resources and expectations updated to the new XMIR format (Φ.*, ξ paths, φ/ρ attributes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->