### PR TITLE
ubuntu down to 22

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-release:
     strategy:
       matrix:
-        os: [macos-15, ubuntu-24.04]
+        os: [macos-15, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
closes #396

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build environment configuration to use Ubuntu 22.04 instead of Ubuntu 24.04 for release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->