### PR TITLE
docs(#399): update README with build instructions for `phino` from source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ result
 tmp
 try-unphi
 venv
+.aidy/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,34 @@ Download paths are:
 * Ubuntu: <http://phino.objectionary.com/releases/ubuntu-24.04/phino-latest>
 * MacOS: <http://phino.objectionary.com/releases/macos-15/phino-latest>
 
+## Build
+
+To build `phino` from source, clone this repository:
+
+```bash
+git clone git@github.com:objectionary/phino.git
+cd phino
+```
+
+Then, run the following command (ensure you have [Cabal][cabal] installed):
+
+```bash
+cabal build all
+```
+
+Next, run this command to install `phino` system-wide:
+
+```bash
+sudo cp "$(cabal list-bin phino)" /usr/local/bin/phino
+```
+
+Verify that `phino` is installed correctly:
+
+```bash
+phino --version
+0.0.0.0
+```
+
 ## Dataize
 
 Then, you dataize the program:


### PR DESCRIPTION
This PR updates the `.gitignore` file and enhances the `README.md` with build instructions for `phino`, addressing installation issues for x86_64 processors.

Related to #399