### PR TITLE
bug(#399): added `macos-15-intel` to runner

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-release:
     strategy:
       matrix:
-        os: [macos-15, ubuntu-22.04]
+        os: [macos-15, ubuntu-22.04, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Ref: #399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded build automation to support additional macOS platforms, ensuring broader compatibility for binary releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->