### PR TITLE
bug(#422): added indent for `\leadsto`

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
+# Here we use macos-14-large as x86-64 arch instead of macos-15-intel
+# because of the bug in haskell-actions/setup plugin.
+# For more details see this: https://github.com/haskell-actions/setup/issues/77
 name: Release binary to S3
 'on':
   push:
@@ -11,7 +14,8 @@ jobs:
   build-and-release:
     strategy:
       matrix:
-        os: [macos-15, ubuntu-22.04, macos-15-intel]
+        os: [macos-15, ubuntu-22.04, macos-14-large]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -33,7 +33,7 @@ rewrittensToLatex rewrittens ctx =
   concat
     [ "\\begin{phiquation}\n",
       intercalate
-        "\n\\leadsto "
+        "\n  \\leadsto "
         ( map
             ( \Rewritten {..} ->
                 let prog = renderToLatex program ctx

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -312,8 +312,8 @@ spec = do
           [ unlines
               [ "\\begin{phiquation}",
                 "{[[ x -> \"foo\" ]]} \\leadsto_{\\nameref{r:first}}",
-                "\\leadsto {Q.x( y -> \"foo\" )} \\leadsto_{\\nameref{r:second}}",
-                "\\leadsto {[[ x -> \"foo\" ]]}",
+                "  \\leadsto {Q.x( y -> \"foo\" )} \\leadsto_{\\nameref{r:second}}",
+                "  \\leadsto {[[ x -> \"foo\" ]]}",
                 "\\end{phiquation}"
               ]
           ]


### PR DESCRIPTION
Closes: #422 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted LaTeX output formatting to improve visual alignment and positioning of mathematical expressions and notation within generated technical documents, reports, and publications.

* **Chores**
  * Updated and optimized continuous integration and continuous deployment pipeline infrastructure and configuration to enhance overall build reliability, consistency, and cross-platform performance across multiple supported operating systems and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->