### PR TITLE
bug(#425): attributes with pipes in LaTeX

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -70,10 +70,14 @@ instance ToLaTeX EXPRESSION where
   toLaTeX EX_FORMATION {..} = EX_FORMATION lsb eol tab (toLaTeX binding) eol' tab' rsb
   toLaTeX EX_APPLICATION {..} = EX_APPLICATION (toLaTeX expr) eol tab (toLaTeX bindings) eol' tab'
   toLaTeX EX_APPLICATION' {..} = EX_APPLICATION' (toLaTeX expr) eol tab (toLaTeX args) eol' tab'
+  toLaTeX EX_DISPATCH{..} = EX_DISPATCH (toLaTeX expr) (toLaTeX attr)
   toLaTeX expr = expr
 
 instance ToLaTeX ATTRIBUTE where
-  toLaTeX AT_LABEL {..} = AT_LABEL (toLaTeX label)
+  toLaTeX AT_LABEL {..} = AT_LABEL (piped (toLaTeX label))
+    where
+      piped :: String -> String
+      piped str = "|" <> str <> "|"
   toLaTeX attr = attr
 
 instance ToLaTeX BINDING where

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -240,14 +240,14 @@ spec = do
           ["rewrite", "--output=latex", "--sweet"]
           [ "\\begin{phiquation}",
             "{[[",
-            "  x -> QQ.z(",
-            "    y -> 5",
+            "  |x| -> QQ.|z|(",
+            "    |y| -> 5",
             "  ),",
-            "  q -> T,",
-            "  w -> $,",
+            "  |q| -> T,",
+            "  |w| -> $,",
             "  ^ -> Q,",
             "  @ -> 1,",
-            "  y -> \"H$@^M\"",
+            "  |y| -> \"H$@^M\"",
             "]]}",
             "\\end{phiquation}"
           ]
@@ -311,9 +311,9 @@ spec = do
           ]
           [ unlines
               [ "\\begin{phiquation}",
-                "{[[ x -> \"foo\" ]]} \\leadsto_{\\nameref{r:first}}",
-                "  \\leadsto {Q.x( y -> \"foo\" )} \\leadsto_{\\nameref{r:second}}",
-                "  \\leadsto {[[ x -> \"foo\" ]]}",
+                "{[[ |x| -> \"foo\" ]]} \\leadsto_{\\nameref{r:first}}",
+                "  \\leadsto {Q.|x|( |y| -> \"foo\" )} \\leadsto_{\\nameref{r:second}}",
+                "  \\leadsto {[[ |x| -> \"foo\" ]]}",
                 "\\end{phiquation}"
               ]
           ]


### PR DESCRIPTION
Closes: #425 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dispatch expression support to LaTeX output generation
  * Updated identifier formatting in phiquation blocks to use absolute-value notation for all variables and mapped expressions (e.g., `x` → `|x|`, mappings like `x → QQ.z(y → 5)` now display as `|x| → QQ.|z|(|y| → 5)`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->