### PR TITLE
bug(#440): introduced `--label` option to `rewrite` command

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -24,7 +24,8 @@ data LatexContext = LatexContext
   { sugar :: SugarType,
     line :: LineFormat,
     nonumber :: Bool,
-    expression :: Maybe String
+    expression :: Maybe String,
+    label :: Maybe String
   }
 
 renderToLatex :: Program -> LatexContext -> String
@@ -39,6 +40,9 @@ rewrittensToLatex rewrittens ctx@LatexContext {..} =
   let equation = phiquation ctx
    in concat
         [ printf "\\begin{%s}\n" equation,
+          case label of
+            Just lbl -> printf "\\label{%s}\n" lbl
+            _ -> "",
           case expression of
             Just expr -> printf "\\phiExpression{%s} " expr
             _ -> "",

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -180,12 +180,18 @@ spec = do
           testCLIFailed
             ["rewrite", "--omit-comments", "--output=phi"]
             ["--omit-comments"]
-      
+
       it "with --expression and --output != latex" $
         withStdin "{[[]]}" $
           testCLIFailed
             ["rewrite", "--expression=foo", "--output=phi"]
             ["--expression option can stay together with --output=latex only"]
+
+      it "with --label and --output != latex" $
+        withStdin "{[[]]}" $
+          testCLIFailed
+            ["rewrite", "--label=foo", "--output=phi"]
+            ["--label option can stay together with --output=latex only"]
 
       it "with wrong --hide option" $
         withStdin "{[[]]}" $
@@ -290,13 +296,22 @@ spec = do
             "\\Big\\{[[ |x| -> 5 ]]\\Big\\}",
             "\\end{phiquation*}"
           ]
-    
+
     it "rewrite as LaTeX with expression name" $
       withStdin "Q -> [[ x -> 5 ]]" $
         testCLISucceeded
           ["rewrite", "--output=latex", "--sweet", "--flat", "--expression=foo"]
           [ "\\begin{phiquation}",
             "\\phiExpression{foo} \\Big\\{[[ |x| -> 5 ]]\\Big\\}",
+            "\\end{phiquation}"
+          ]
+
+    it "rewrite as LaTeX with label name" $
+      withStdin "Q -> [[ x -> 5 ]]" $
+        testCLISucceeded
+          ["rewrite", "--output=latex", "--sweet", "--flat", "--label=foo"]
+          [ "\\begin{phiquation}\n\\label{foo}\n",
+            "\\Big\\{[[ |x| -> 5 ]]\\Big\\}\n",
             "\\end{phiquation}"
           ]
 
@@ -464,7 +479,7 @@ spec = do
                 "⟧}"
               ]
           ]
-    
+
     it "hides default package" $
       withStdin "{[[ org -> [[ eolang -> [[ number -> [[]] ]]]], x -> 42 ]]}" $
         testCLISucceeded


### PR DESCRIPTION
Closes: #440 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--label` parameter for the rewrite command to support LaTeX label declarations
  * Generated LaTeX output now includes label declarations when specified

* **Tests**
  * Added test coverage for label parameter functionality and validation across different output formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->