### PR TITLE
bug(#444): escape specials in latex

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -73,6 +73,9 @@ programToLaTeX prog ctx =
           "}"
         ]
 
+piped :: String -> String
+piped str = "|" <> str <> "|"
+
 class ToLaTeX a where
   toLaTeX :: a -> a
 
@@ -90,9 +93,6 @@ instance ToLaTeX EXPRESSION where
 
 instance ToLaTeX ATTRIBUTE where
   toLaTeX AT_LABEL {..} = AT_LABEL (piped (toLaTeX label))
-    where
-      piped :: String -> String
-      piped str = "|" <> str <> "|"
   toLaTeX attr = attr
 
 instance ToLaTeX BINDING where
@@ -105,7 +105,8 @@ instance ToLaTeX BINDINGS where
 
 instance ToLaTeX PAIR where
   toLaTeX PA_DELTA {..} = PA_DELTA' bytes
-  toLaTeX PA_LAMBDA {..} = PA_LAMBDA' func
+  toLaTeX PA_LAMBDA {..} = PA_LAMBDA' (piped (toLaTeX func))
+  toLaTeX PA_LAMBDA' {..} = PA_LAMBDA' (piped (toLaTeX func))
   toLaTeX PA_VOID {..} = PA_VOID (toLaTeX attr) arrow void
   toLaTeX PA_TAU {..} = PA_TAU (toLaTeX attr) arrow (toLaTeX expr)
   toLaTeX pair = pair
@@ -126,6 +127,7 @@ instance ToLaTeX String where
         '$' -> "\\char36{}" <> escapeUnprintedChars rest
         '@' -> "\\char64{}" <> escapeUnprintedChars rest
         '^' -> "\\char94{}" <> escapeUnprintedChars rest
+        '_' -> "\\char95{}" <> escapeUnprintedChars rest
         _ -> ch : escapeUnprintedChars rest
 
 -- @todo #114:30min Implement LaTeX conversion for rules.

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -265,19 +265,20 @@ spec = do
           ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "  <o base=\"Φ.y\" name=\"x\"/>"]
 
     it "rewrites as LaTeX" $
-      withStdin "Q -> [[ x -> QQ.z(y -> 5), q -> T, w -> $, ^ -> Q, @ -> 1, y -> \"H$@^M\"]]" $
+      withStdin "Q -> [[ x_o -> QQ.z(y -> 5), q$ -> T, w -> $, ^ -> Q, @ -> 1, y -> \"H$@^M\", L> Fu_nc ]]" $
         testCLISucceeded
           ["rewrite", "--output=latex", "--sweet"]
           [ "\\begin{phiquation}",
-            "\\Big\\{[[",
-            "  |x| -> QQ.|z|(",
-            "    |y| -> 5",
-            "  ),",
-            "  |q| -> T,",
-            "  |w| -> $,",
-            "  ^ -> Q,",
-            "  @ -> 1,",
-            "  |y| -> \"H$@^M\"",
+            "\\Big\\{[[\n",
+            "  |x\\char95{}o| -> QQ.|z|(\n",
+            "    |y| -> 5\n",
+            "  ),\n",
+            "  |q\\char36{}| -> T,\n",
+            "  |w| -> $,\n",
+            "  ^ -> Q,\n",
+            "  @ -> 1,\n",
+            "  |y| -> \"H$@^M\",\n",
+            "  L> |Fu\\char95{}nc|\n",
             "]]\\Big\\}",
             "\\end{phiquation}"
           ]


### PR DESCRIPTION
Closes: #444 
Closes: #446 
Closes: #447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced LaTeX output generation with improved handling of underscore characters in identifier names.
  * Refined rendering of certain expression types in LaTeX conversion.

* **Tests**
  * Updated test cases to validate correct rendering of identifiers containing special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->