### PR TITLE
bug(#401): info about `--input=xmir` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ echo 'Φ ↦ ⟦ φ ↦ ⟦ Δ ⤍ 68-65-6C-6C-6F ⟧ ⟧' | phino rewrite --r
 Φ ↦ ⟦ φ ↦ ⟦ Δ ⤍ 62-79-65 ⟧ ⟧
 ```
 
-You're able to pass [`XMIR`](xmir) as input. Use `--input=xmir` and `phino`
+You're able to pass [`XMIR`][xmir] as input. Use `--input=xmir` and `phino`
 will parse given `XMIR` from file or `stdin` and convert it to `phi` AST.
 
 ```bash


### PR DESCRIPTION
Closes: #401 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with built-in rules usage via --normalize and updated workflow examples.
  * Added XMIR input documentation (--input=xmir), an XMIR guide link, and examples showing --rule combined with --input=xmir.
  * Updated command-line help phrasing to show phino [COMMAND] --help and adjusted surrounding example text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->