### PR TITLE
bug(#522): does not print `\phiMeet{}` twice

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -22,7 +22,6 @@ import Encoding (Encoding (ASCII), withEncoding)
 import Lining (LineFormat (MULTILINE, SINGLELINE), withLineFormat)
 import Matcher
 import Misc
-import Printer (printProgram')
 import Render (Render (render))
 import Replacer (ReplaceContext (ReplaceCtx), replaceProgram)
 import Rewriter (Rewritten (..))
@@ -99,12 +98,13 @@ meetInPrograms prefix = meetInPrograms' 1
        in case frequent of
             Just expr ->
               let met' = map (filter (== expr)) met
-                  substs = matchProgram expr first
-                  prog = replaceProgram (first, map (const expr) substs, map (const (ExPhiMeet prefix idx)) substs)
+                  (subst : substs) = matchProgram expr first
+                  prog = replaceProgram (first, [expr], [ExPhiMeet prefix idx])
+                  prog' = replaceProgram (prog, map (const expr) substs, map (const (ExPhiAgain prefix idx)) substs)
                   rest' = zipWith (\prgm exprs -> replaceProgram (prgm, exprs, map (const (ExPhiAgain prefix idx)) exprs)) rest met'
                   found = filter (not . null) met'
                in if length met' > 1 && toDouble (length found) / toDouble (length met') >= 0.5
-                    then prog : meetInPrograms' (idx + 1) rest'
+                    then prog' : meetInPrograms' (idx + 1) rest'
                     else next
             _ -> next
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -451,6 +451,19 @@ spec = do
               ]
           ]
 
+    it "should not print \\phiMeet{} twice" $
+      withStdin "{[[ ex -> [[ x -> [[ y -> ?, k -> [[ t -> 42]]  ]]( y -> [[ t -> 42 ]]) ]].i ]]}" $
+        testCLISucceeded
+          ["rewrite", "--normalize", "--sequence", "--flat", "--compress", "--output=latex", "--sweet"]
+          [ unlines
+              [ "\\begin{phiquation}"
+              , "\\Big\\{[[ |ex| -> [[ |x| -> [[ |y| -> ?, |k| -> \\phiMeet{1}{[[ |t| -> 42 ]]} ]]( |y| -> \\phiAgain{1} ) ]].|i| ]]\\Big\\} \\leadsto_{\\nameref{r:copy}}"
+              , "  \\leadsto \\Big\\{[[ |ex| -> [[ |x| -> [[ |y| -> \\phiAgain{1}, |k| -> \\phiAgain{1} ]] ]].|i| ]]\\Big\\} \\leadsto_{\\nameref{r:stop}}"
+              , "  \\leadsto \\Big\\{[[ |ex| -> T ]]\\Big\\}."
+              , "\\end{phiquation}"
+              ]
+          ]
+
     it "prints input as listing in XMIR" $
       withStdin "{[[ app -> [[]] ]]}" $
         testCLISucceeded

--- a/test/LaTeXSpec.hs
+++ b/test/LaTeXSpec.hs
@@ -25,6 +25,8 @@ spec = do
       , ("Q.x.y twice", "{Q.x.y}", "{[[ x -> Q.x.y, y -> Q.x.y.z ]]}", ["Q.x.y", "Q.x.y"])
       , ("Q.x.y.z.a and Q.x.y", "{Q.x.y.z.a}", "{[[ x -> Q.x.y, y -> Q.x.y.z ]]}", ["Q.x.y.z", "Q.x.y", "Q.x.y"])
       , ("Ignore data objects", "{[[ x -> \"foo\" ]]}", "{Q.x( y -> \"foo\" )}", [])
+      , ("Not found [[ t -> 42 ]]", "{⟦ ex ↦ ⟦ x ↦ ⟦ t ↦ 42 ⟧.t ⟧.x ⟧}", "{⟦ ex ↦ ⟦ x ↦ 42 ⟧.x ⟧}", [])
+      , ("Missed [[ t -> 42 ]]", "{⟦ ex ↦ ⟦ x ↦ ⟦ t ↦ 42 ⟧.t ⟧.x ⟧}", "{⟦ ex ↦ 42 ⟧}", [])
       ]
       ( \(desc, first, second, exprs) -> it desc $ do
           ptn <- parseProgramThrows first


### PR DESCRIPTION
Closes: #522 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a bug that caused duplicate output during expression normalization and LaTeX rendering.

* **Tests**
  * Enhanced test coverage for edge cases in program rewriting, including scenarios for expressions not found or missed during processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->