### PR TITLE
bug(#565): remove INFO level from logger

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -199,17 +199,14 @@ optLogLevel =
     parseLogLevel
     ( long "log-level"
         <> metavar "LEVEL"
-        <> help ("Log level (" <> intercalate ", " (map show [DEBUG, INFO, WARNING, ERROR, NONE]) <> ")")
-        <> value INFO
+        <> help ("Log level (" <> intercalate ", " (map show [DEBUG, ERROR, NONE]) <> ")")
+        <> value ERROR
         <> showDefault
     )
   where
     parseLogLevel :: ReadM LogLevel
     parseLogLevel = eitherReader $ \lvl -> case map toUpper lvl of
       "DEBUG" -> Right DEBUG
-      "INFO" -> Right INFO
-      "WARNING" -> Right WARNING
-      "WARN" -> Right WARNING
       "ERROR" -> Right ERROR
       "ERR" -> Right ERROR
       "NONE" -> Right NONE

--- a/src/Logger.hs
+++ b/src/Logger.hs
@@ -5,11 +5,9 @@
 
 module Logger
   ( logDebug
-  , logInfo
-  , logWarning
   , logError
   , setLogConfig
-  , LogLevel (DEBUG, INFO, WARNING, ERROR, NONE)
+  , LogLevel (DEBUG, ERROR, NONE)
   )
 where
 
@@ -19,14 +17,14 @@ import qualified Data.List as DL
 import GHC.IO (unsafePerformIO)
 import System.IO
 
-data LogLevel = DEBUG | INFO | WARNING | ERROR | NONE
+data LogLevel = DEBUG | ERROR | NONE
   deriving (Show, Ord, Eq, Bounded, Enum, Read)
 
 data Logger = Logger {level :: LogLevel, lns :: Int}
 
 logger :: IORef Logger
 {-# NOINLINE logger #-}
-logger = unsafePerformIO (newIORef (Logger INFO 25))
+logger = unsafePerformIO (newIORef (Logger ERROR 25))
 
 setLogConfig :: LogLevel -> Int -> IO ()
 setLogConfig lvl cnt = writeIORef logger (Logger lvl cnt)
@@ -45,8 +43,6 @@ logMessage lvl message = do
        in hPutStrLn stderr ("[" ++ show lvl ++ "]: " ++ DL.intercalate "\n" msg)
     )
 
-logDebug, logInfo, logWarning, logError :: String -> IO ()
+logDebug, logError :: String -> IO ()
 logDebug = logMessage DEBUG
-logInfo = logMessage INFO
-logWarning = logMessage WARNING
 logError = logMessage ERROR


### PR DESCRIPTION
Closes: #565 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the logging system to support only DEBUG and ERROR log levels; INFO and WARNING levels have been removed from the public API.
  * Updated the default log level from INFO to ERROR, reducing the amount of messages logged by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->