### PR TITLE
bug(#567): show dots in latex if rewriting exceeds limits

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -20,7 +20,7 @@ import Logger
 import qualified Misc as M
 import Parser (parseProgramThrows)
 import qualified Printer as P
-import Rewriter (Rewritten)
+import Rewriter (Rewrittens)
 import System.IO (getContents')
 import Text.Printf (printf)
 import XMIR (parseXMIRThrows, printXMIR, programToXMIR, xmirToPhi)
@@ -58,11 +58,11 @@ parseProgram phi PHI = parseProgramThrows phi
 parseProgram xmir XMIR = parseXMIRThrows xmir >>= xmirToPhi
 parseProgram _ LATEX = invalidCLIArguments "LaTeX cannot be used as input format"
 
-printRewrittens :: PrintProgramContext -> [Rewritten] -> IO String
-printRewrittens ctx@PrintProgCtx{..} rewrittens
+printRewrittens :: PrintProgramContext -> Rewrittens -> IO String
+printRewrittens ctx@PrintProgCtx{..} rewrittens@(chain, _)
   | _outputFormat == LATEX && _sequence = rewrittensToLatex rewrittens (printCtxToLatexCtx ctx)
-  | _focus == ExGlobal = mapM (printProgram ctx . fst) rewrittens <&> intercalate "\n"
-  | otherwise = mapM (\(prog, _) -> locatedExpression _focus prog >>= printExpression ctx) rewrittens <&> intercalate "\n"
+  | _focus == ExGlobal = mapM (printProgram ctx . fst) chain <&> intercalate "\n"
+  | otherwise = mapM (\(prog, _) -> locatedExpression _focus prog >>= printExpression ctx) chain <&> intercalate "\n"
 
 printExpression :: PrintProgramContext -> Expression -> IO String
 printExpression ctx@PrintProgCtx{..} ex = case _outputFormat of

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -154,7 +154,7 @@ morph (expr, seq) ctx@DataizeContext{..} = do
         then morph (ExTermination, seq) ctx -- PRIM
         else do
           prog' <- withLocatedExpression _locator expr _program
-          rewrittens' <- rewrite prog' normalizationRules (switchContext ctx) -- NMZ todo
+          (rewrittens', _) <- rewrite prog' normalizationRules (switchContext ctx) -- NMZ todo
           let seq' = reverse rewrittens' <> tail seq
           expr' <- locatedExpression _locator (fst (head seq'))
           morph (expr', seq') ctx

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -559,6 +559,19 @@ spec = do
               ]
           ]
 
+    it "shows exceeding of limits in latex" $
+      withStdin "{[[ x -> $.y, y -> $.x ]].x}" $
+        testCLISucceeded
+          ["rewrite", "--normalize", "--flat", "--sequence", "--output=latex", "--sweet", "--max-depth=1", "--max-cycles=1"]
+          [ unlines
+              [ "\\begin{phiquation}"
+              , "\\Big\\{[[ |x| -> |y|, |y| -> |x| ]].|x|\\Big\\} \\leadsto_{\\nameref{r:dot}}"
+              , "  \\leadsto \\Big\\{[[ |x| -> |y|, |y| -> |x| ]].|y|( ^ -> [[ |x| -> |y|, |y| -> |x| ]] )\\Big\\}"
+              , "  \\leadsto \\dots"
+              , "\\end{phiquation}"
+              ]
+          ]
+
     it "focuses expression in phi without sequence" $
       withStdin "{[[ ex -> [[ x -> [[ y -> ?, k -> [[ t -> 42]]  ]]( y -> [[ t -> 42 ]]) ]].i ]]}" $
         testCLISucceeded

--- a/test/RewriterSpec.hs
+++ b/test/RewriterSpec.hs
@@ -99,7 +99,7 @@ spec =
                   if normalize'
                     then pure normalizationRules
                     else pure []
-              rewrittens <-
+              (rewrittens, _) <-
                 rewrite
                   prog
                   rules'


### PR DESCRIPTION
Closes: #567 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now tracks when rewrite limits (depth or cycles) are exceeded and communicates this through the output format.

* **Tests**
  * Added test case validating the display of limit-exceeding behavior when using LaTeX output format with strict constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->