### PR TITLE
bug(#594): `\vert` instead of pipe

### DIFF
--- a/src/Render.hs
+++ b/src/Render.hs
@@ -216,7 +216,7 @@ instance Render LOGIC_OPERATOR where
 
 instance Render NUMBER where
   render INDEX{..} = printf "\\indexof{ %s }" (render attr)
-  render LENGTH{..} = printf "|%s|" (render binding)
+  render LENGTH{..} = printf "\\vert %s \\vert" (render binding)
   render LITERAL{..} = show num
 
 instance Render COMPARABLE where

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -843,7 +843,7 @@ spec = do
             , "\\trrule{ALPHA}"
             , "  { [[ B_1, \\tau_1 -> ?, B_2 ]] ( \\tau_2 -> e ) }"
             , "  { [[ B_1, \\tau_1 -> ?, B_2 ]] ( \\tau_1 -> e ) }"
-            , "  { if $ \\indexof{ \\tau_2 } = |B_1| $ }"
+            , "  { if $ \\indexof{ \\tau_2 } = \\vert B_1 \\vert $ }"
             , "  { }"
             , "\\trrule{COPY}"
             , "  { [[ B_1, \\tau -> ?, B_2 ]] ( \\tau -> e_1 ) }"


### PR DESCRIPTION
Closes: #594 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated absolute value notation rendering to use LaTeX-compliant vertical delimiters for improved mathematical typesetting compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->