### PR TITLE
fix(#603): update text library version constraint for GHC compatibility

### DIFF
--- a/phino.cabal
+++ b/phino.cabal
@@ -93,7 +93,7 @@ library
     random >=1.2 && <1.4,
     regex-pcre-builtin ^>=0.95.2.3.8.44,
     scientific ^>=0.3.8.0,
-    text ^>=2.0.2,
+    text >=2.0.2,
     time ^>=1.12,
     transformers ^>=0.6.1.0,
     utf8-string ^>=1.0.2,


### PR DESCRIPTION
This PR updates the `text` library version constraint in `phino.cabal` to resolve build issues with GHC 9.12.2.

Fixes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated text library dependency constraints to support a broader range of compatible versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->