### PR TITLE
bug(#653): add benchmark suite

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,10 +38,10 @@ jobs:
           key: ubuntu-m2-${{ hashFiles('benchmark/.mvn/wrapper/maven-wrapper.properties') }}
           restore-keys: ubuntu-m2-
       - run: cabal update
-      - run: |-
+      - run: |
           cabal build all
           echo "$(cabal list-bin phino | xargs dirname)" >> $GITHUB_PATH
-      - run: |-
+      - run: |
           set -e
           output=$(make bench 2>&1)
           echo "$output"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
       - run: cabal update
       - run: |
           cabal build all
-          echo "$(cabal list-bin phino | xargs dirname)" >> $GITHUB_PATH
+          cabal list-bin phino | xargs dirname >> "$GITHUB_PATH"
       - run: |
           set -e
           output=$(make bench 2>&1)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: benchmark
+'on':
+  push:
+    branches:
+      - master
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  benchmark:
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - id: setup
+        uses: haskell-actions/setup@v2.11.0
+        with:
+          ghc-version: '9.8.4'
+          cabal-version: '3.12.1.0'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ubuntu-ghc9.8.4-cabal-${{ hashFiles('**/*.cabal') }}
+          restore-keys: ubuntu-ghc9.8.4-cabal-
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: ubuntu-m2-${{ hashFiles('benchmark/.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: ubuntu-m2-
+      - run: cabal update
+      - run: |
+          cabal build all
+          echo "$(cabal list-bin phino | xargs dirname)" >> $GITHUB_PATH
+      - run: |
+          set -e
+          output=$(make bench 2>&1)
+          echo "$output"
+          result=$(echo "$output" | grep -E "^(=== |  )")
+          sum=$(
+            printf "\`\`\`text\n"
+            echo "$result"
+            printf "\`\`\`\n\n"
+            echo "The results were calculated in [this GHA job][benchmark-gha]"
+            echo "on $(date +'%Y-%m-%d') at $(date +'%H:%M'),"
+            echo "on $(uname) with $(nproc --all) CPUs."
+          )
+          export sum
+          perl -i -0777 -pe 's/(?<=<!-- benchmark_begin -->).*(?=<!-- benchmark_end -->)/\n\n$ENV{sum}\n\n/gs;' README.md
+          url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          export url
+          perl -i -0777 -pe 's/(?<=\[benchmark-gha\]: )[^\n]+(?=\n)/$ENV{url}/gs;' README.md
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          sign-commits: true
+          branch: benchmark
+          commit-message: 'new benchmark results'
+          delete-branch: true
+          title: 'New benchmarking results'
+          base: master

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,10 +38,10 @@ jobs:
           key: ubuntu-m2-${{ hashFiles('benchmark/.mvn/wrapper/maven-wrapper.properties') }}
           restore-keys: ubuntu-m2-
       - run: cabal update
-      - run: |
+      - run: |-
           cabal build all
           echo "$(cabal list-bin phino | xargs dirname)" >> $GITHUB_PATH
-      - run: |
+      - run: |-
           set -e
           output=$(make bench 2>&1)
           echo "$output"

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: yegor256/copyrights-action@0.0.12
         with:
           license: LICENSES/MIT.txt
+          ignore: benchmark/.mvn/**

--- a/.github/workflows/jeo-update.yml
+++ b/.github/workflows/jeo-update.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: jeo-update
+'on':
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+jobs:
+  update:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check latest jeo version
+        id: jeo
+        run: |
+          latest=$(git ls-remote --tags --refs https://github.com/objectionary/jeo-maven-plugin.git \
+            | grep -oP '\d+\.\d+\.\d+' | sort -V | tail -1)
+          current=$(sed -n 's/^JEO_VERSION := //p' Makefile)
+          echo "latest=${latest}" >> $GITHUB_OUTPUT
+          echo "changed=$([ "${latest}" != "${current}" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+      - name: Update Makefile
+        if: steps.jeo.outputs.changed == 'true'
+        run: sed -i "s/^JEO_VERSION := .*/JEO_VERSION := ${{ steps.jeo.outputs.latest }}/" Makefile
+      - uses: peter-evans/create-pull-request@v7
+        if: steps.jeo.outputs.changed == 'true'
+        with:
+          sign-commits: true
+          branch: jeo-update
+          commit-message: 'jeo-maven-plugin updated to ${{ steps.jeo.outputs.latest }}'
+          delete-branch: true
+          title: 'Update jeo-maven-plugin to ${{ steps.jeo.outputs.latest }}'
+          base: master

--- a/.github/workflows/jeo-update.yml
+++ b/.github/workflows/jeo-update.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Check latest jeo version
         id: jeo
-        run: |-
+        run: |
           latest=$(git ls-remote --tags --refs https://github.com/objectionary/jeo-maven-plugin.git \
             | grep -oP '\d+\.\d+\.\d+' | sort -V | tail -1)
           current=$(sed -n 's/^JEO_VERSION := //p' Makefile)

--- a/.github/workflows/jeo-update.yml
+++ b/.github/workflows/jeo-update.yml
@@ -18,8 +18,8 @@ jobs:
           latest=$(git ls-remote --tags --refs https://github.com/objectionary/jeo-maven-plugin.git \
             | grep -oP '\d+\.\d+\.\d+' | sort -V | tail -1)
           current=$(sed -n 's/^JEO_VERSION := //p' Makefile)
-          echo "latest=${latest}" >> $GITHUB_OUTPUT
-          echo "changed=$([ "${latest}" != "${current}" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "latest=${latest}" >> "$GITHUB_OUTPUT"
+          echo "changed=$([ "${latest}" != "${current}" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
       - name: Update Makefile
         if: steps.jeo.outputs.changed == 'true'
         run: sed -i "s/^JEO_VERSION := .*/JEO_VERSION := ${{ steps.jeo.outputs.latest }}/" Makefile

--- a/.github/workflows/jeo-update.yml
+++ b/.github/workflows/jeo-update.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Check latest jeo version
         id: jeo
-        run: |
+        run: |-
           latest=$(git ls-remote --tags --refs https://github.com/objectionary/jeo-maven-plugin.git \
             | grep -oP '\d+\.\d+\.\d+' | sort -V | tail -1)
           current=$(sed -n 's/^JEO_VERSION := //p' Makefile)

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,8 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: phino
-Upstream-Contact: objectionary@gmail.com
-Source: https://github.com/objectionary/phino
-
-Files: benchmark/mvnw benchmark/mvnw.cmd benchmark/.mvn/*
-Copyright: The Apache Software Foundation
-License: Apache-2.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: phino
+Upstream-Contact: objectionary@gmail.com
+Source: https://github.com/objectionary/phino
+
+Files: benchmark/mvnw benchmark/mvnw.cmd benchmark/.mvn/*
+Copyright: The Apache Software Foundation
+License: Apache-2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ make test          # cabal test --ghc-options=-Werror
 make hlint         # hlint src app test
 make fourmolu      # fourmolu --mode check src app test (2-space indent, leading commas)
 make coverage      # cabal test --enable-coverage + hpc-codecov (threshold 65%)
+make bench         # prepare resources + cabal bench --enable-benchmarks
 make all           # coverage + hlint + fourmolu
 ```
 
@@ -18,9 +19,17 @@ cabal v2-run spec -- --match "parse bytes"
 cabal v2-run spec -- --match "Rewriter"
 ```
 
+Benchmarks run 3 warmup iterations, auto-calibrate batch size to hit a
+~20ms measurement window per batch, then run 10 batches and print total,
+avg, min, max, and std dev per operation. Batch size scales automatically
+so the same benchmark works for both tiny and large inputs. Resource files
+(`benchmark/tmp/`) are generated on first run and cached by Make; removed
+by `make clean`. Requires Java and curl; Maven is fetched automatically
+via `benchmark/mvnw`.
+
 ## Architecture
 
-`phino` is a CLI tool for manipulating phi-calculus (𝜑-calculus) expressions — the formal foundation of the EO programming language. Three Cabal components: `library` (`src/`), executable `phino` (`app/`), test suite `spec` (`test/`).
+`phino` is a CLI tool for manipulating phi-calculus (𝜑-calculus) expressions — the formal foundation of the EO programming language. Four Cabal components: `library` (`src/`), executable `phino` (`app/`), test suite `spec` (`test/`), benchmark suite `bench` (`benchmark/`).
 
 ### Five CLI commands
 `rewrite` | `dataize` | `explain` | `merge` | `match` — all wired in `src/CLI/Runners.hs`, parsed in `src/CLI/Parsers.hs`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ make test          # cabal test --ghc-options=-Werror
 make hlint         # hlint src app test
 make fourmolu      # --mode check src app test (2-space indent, leading commas)
 make coverage      # cabal test --enable-coverage + hpc-codecov (threshold 65%)
+make bench         # prepare resources + cabal bench --enable-benchmarks
 make all           # coverage + hlint + fourmolu
 ```
 
@@ -26,12 +27,20 @@ cabal v2-run spec -- --match "parse bytes"
 cabal v2-run spec -- --match "Rewriter"
 ```
 
+Benchmarks run 3 warmup iterations, auto-calibrate batch size to hit a
+~20ms measurement window per batch, then run 10 batches and print total,
+avg, min, max, and std dev per operation. Batch size scales automatically
+so the same benchmark works for both tiny and large inputs. Resource files
+(`benchmark/tmp/`) are generated on first run and cached by Make; removed
+by `make clean`. Requires Java and curl; Maven is fetched automatically
+via `benchmark/mvnw`.
+
 ## Architecture
 
 `phino` is a CLI tool for manipulating phi-calculus (𝜑-calculus) expressions
-— the formal foundation of the EO programming language. Three Cabal
+— the formal foundation of the EO programming language. Four Cabal
 components: `library` (`src/`), executable `phino` (`app/`), test suite
-`spec` (`test/`).
+`spec` (`test/`), benchmark suite `bench` (`benchmark/`).
 
 ### Five CLI commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ via `benchmark/mvnw`.
 
 ## Architecture
 
-phino` is a CLI tool for manipulating phi-calculus (𝜑-calculus) expressions
+`phino` is a CLI tool for manipulating phi-calculus (𝜑-calculus) expressions
 — the formal foundation of the EO programming language. Four Cabal
 components: `library` (`src/`), executable `phino` (`app/`), test suite
 `spec` (`test/`), benchmark suite `bench` (`benchmark/`).

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,17 @@
 
 .ONESHELL:
 .SHELLFLAGS := -e -o pipefail -c
-.PHONY: all test hlint fourmolu coverage clean
+.PHONY: all test hlint fourmolu coverage bench clean
 
 SHELL := bash
+
+JNA_VERSION := 5.15.0
+JEO_VERSION := 0.15.1
+ifeq ($(OS),Windows_NT)
+  MVNW := $(CURDIR)/benchmark/mvnw.cmd
+else
+  MVNW := $(CURDIR)/benchmark/mvnw
+endif
 
 all: coverage hlint fourmolu
 
@@ -33,6 +41,22 @@ coverage:
 	echo "Coverage $${coverage}% meets threshold $${threshold}%"
 
 .SILENT:
+bench: benchmark/tmp/native.phi
+	cabal bench --enable-benchmarks
+
+benchmark/tmp/native.phi: benchmark/tmp/Native.xmir
+	phino rewrite --input xmir --sweet benchmark/tmp/Native.xmir > benchmark/tmp/native.phi
+
+benchmark/tmp/Native.xmir:
+	command -v java >/dev/null 2>&1 || { echo "java is required to run benchmarks but was not found in PATH"; exit 1; }
+	mkdir -p $(CURDIR)/benchmark/tmp/jeo/target/classes/com/sun/jna
+	curl -sSL https://repo1.maven.org/maven2/net/java/dev/jna/jna/$(JNA_VERSION)/jna-$(JNA_VERSION).jar -o $(CURDIR)/benchmark/tmp/jna.jar
+	cd $(CURDIR)/benchmark/tmp/jeo/target/classes && jar xf $(CURDIR)/benchmark/tmp/jna.jar com/sun/jna/Native.class
+	cd $(CURDIR)/benchmark/tmp/jeo && $(MVNW) org.eolang:jeo-maven-plugin:$(JEO_VERSION):disassemble -Djeo.disassemble.sourcesDir=target/classes -Djeo.disassemble.outputDir=xmir -q
+	mv $(CURDIR)/benchmark/tmp/jeo/xmir/com/sun/jna/Native.xmir $(CURDIR)/benchmark/tmp/Native.xmir
+	rm -rf $(CURDIR)/benchmark/tmp/jeo
+
+.SILENT:
 clean:
 	cabal clean
-	rm -rf .stack-work
+	rm -rf .stack-work benchmark/tmp

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ make bench
 ```
 
 <!-- benchmark_begin -->
-TBD
+TBD with [GHA job][benchmark-gha]
 <!-- benchmark_end -->
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -339,6 +339,26 @@ Every meta variable may also be used with an integer index, like `!B1` or `𝜏0
 Incorrect usage of meta variables in 𝜑-expression patterns leads to
 parsing errors.
 
+## Benchmark
+
+To run performance benchmarks, you need [Java 8+][java] and [curl][curl].
+Maven is downloaded automatically on first run via `benchmark/mvnw`.
+
+The benchmark uses the compiled [`Native`][jna-native] class from
+[JNA][jna] — a large real-world Java class — as its test input.
+On first run, `make bench` downloads the class, disassembles it to
+[XMIR][xmir] via [jeo-maven-plugin][jeo], converts it to 𝜑 using
+`phino rewrite`, and caches the results in `benchmark/tmp/`.
+Subsequent runs skip straight to the benchmarks.
+
+```bash
+make bench
+```
+
+<!-- benchmark_begin -->
+TBD
+<!-- benchmark_end -->
+
 ## How to Contribute
 
 Fork repository, make changes, then send us a [pull request][guidelines].
@@ -365,3 +385,9 @@ or [Stack ≥ 3.0][stack] installed.
 [guidelines]: https://www.yegor256.com/2014/04/15/github-guidelines.html
 [xmir]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [latex]: https://en.wikipedia.org/wiki/LaTeX
+[java]: https://www.java.com/en/download/
+[curl]: https://curl.se/
+[jna]: https://github.com/java-native-access/jna
+[jna-native]: https://github.com/java-native-access/jna/blob/master/src/com/sun/jna/Native.java
+[jeo]: https://github.com/objectionary/jeo-maven-plugin
+[benchmark-gha]: https://github.com/objectionary/phino/actions/workflows/benchmark.yml

--- a/README.md
+++ b/README.md
@@ -344,6 +344,26 @@ Every meta variable may also be used with an integer index, like `!B1` or `𝜏0
 Incorrect usage of meta variables in 𝜑-expression patterns leads to
 parsing errors.
 
+## Benchmark
+
+To run performance benchmarks, you need [Java 8+][java] and [curl][curl].
+Maven is downloaded automatically on first run via `benchmark/mvnw`.
+
+The benchmark uses the compiled [`Native`][jna-native] class from
+[JNA][jna] — a large real-world Java class — as its test input.
+On first run, `make bench` downloads the class, disassembles it to
+[XMIR][xmir] via [jeo-maven-plugin][jeo], converts it to 𝜑 using
+`phino rewrite`, and caches the results in `benchmark/tmp/`.
+Subsequent runs skip straight to the benchmarks.
+
+```bash
+make bench
+```
+
+<!-- benchmark_begin -->
+TBD
+<!-- benchmark_end -->
+
 ## How to Contribute
 
 Fork repository, make changes, then send us a [pull request][guidelines].
@@ -370,3 +390,9 @@ or [Stack ≥ 3.0][stack] installed.
 [guidelines]: https://www.yegor256.com/2014/04/15/github-guidelines.html
 [xmir]: https://news.eolang.org/2022-11-25-xmir-guide.html
 [latex]: https://en.wikipedia.org/wiki/LaTeX
+[java]: https://www.java.com/en/download/
+[curl]: https://curl.se/
+[jna]: https://github.com/java-native-access/jna
+[jna-native]: https://github.com/java-native-access/jna/blob/master/src/com/sun/jna/Native.java
+[jeo]: https://github.com/objectionary/jeo-maven-plugin
+[benchmark-gha]: https://github.com/objectionary/phino/actions/workflows/benchmark.yml

--- a/benchmark/.mvn/wrapper/maven-wrapper.properties
+++ b/benchmark/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/benchmark/.mvn/wrapper/maven-wrapper.properties.license
+++ b/benchmark/.mvn/wrapper/maven-wrapper.properties.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: The Apache Software Foundation
+SPDX-License-Identifier: Apache-2.0

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,0 +1,88 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module Main where
+
+import AST (Expression (ExGlobal))
+import Control.Exception (evaluate)
+import Control.Monad (replicateM, replicateM_)
+import Data.Time.Clock
+import Deps (dontSaveStep)
+import Functions (buildTerm)
+import Must (Must (MtDisabled))
+import Parser (parseProgramThrows)
+import Rewriter (RewriteContext (RewriteContext), rewrite)
+import Text.Printf (printf)
+import XMIR (parseXMIRThrows, xmirToPhi)
+import Yaml (normalizationRules)
+
+warmups :: Int
+warmups = 3
+
+iterations :: Int
+iterations = 10
+
+targetBatchMs :: Double
+targetBatchMs = 20.0
+
+rewriteCtx :: RewriteContext
+rewriteCtx =
+  RewriteContext
+    ExGlobal
+    100
+    100
+    False
+    buildTerm
+    MtDisabled
+    Nothing
+    dontSaveStep
+
+timeAction :: IO a -> IO Double
+timeAction action = do
+  start <- getCurrentTime
+  _ <- evaluate =<< action
+  end <- getCurrentTime
+  pure (realToFrac (diffUTCTime end start) * 1e6)
+
+timeBatch :: Int -> IO a -> IO Double
+timeBatch batch action = do
+  start <- getCurrentTime
+  replicateM_ batch (evaluate =<< action)
+  end <- getCurrentTime
+  pure (realToFrac (diffUTCTime end start) * 1e6 / fromIntegral batch)
+
+calibrate :: IO a -> IO Int
+calibrate action = do
+  t <- timeAction action
+  pure (max 1 (round (targetBatchMs * 1000.0 / t)))
+
+stdDev :: [Double] -> Double -> Double
+stdDev xs avg = sqrt (sum (map (\x -> (x - avg) ^ (2 :: Int)) xs) / fromIntegral (length xs))
+
+runBench :: String -> IO a -> IO ()
+runBench name action = do
+  replicateM_ warmups action
+  batch <- calibrate action
+  times <- replicateM iterations (timeBatch batch action)
+  let total = sum times * fromIntegral batch
+      avg = sum times / fromIntegral iterations
+      mn = minimum times
+      mx = maximum times
+      sd = stdDev times avg
+  putStrLn $ "=== " ++ name ++ " ==="
+  putStrLn $ printf "  warmup:     %d iterations" warmups
+  putStrLn $ printf "  batches:    %d x %d" iterations batch
+  putStrLn $ printf "  total:      %.3f μs" total
+  putStrLn $ printf "  avg:        %.3f μs" avg
+  putStrLn $ printf "  min:        %.3f μs" mn
+  putStrLn $ printf "  max:        %.3f μs" mx
+  putStrLn $ printf "  std dev:    %.3f μs" sd
+
+main :: IO ()
+main = do
+  src <- readFile "benchmark/tmp/native.phi"
+  xsrc <- readFile "benchmark/tmp/Native.xmir"
+  prog <- parseProgramThrows src
+  runBench "parse/phi" (parseProgramThrows src)
+  runBench "parse/xmir" (parseXMIRThrows xsrc >>= xmirToPhi)
+  runBench "rewrite/normalize" (rewrite prog normalizationRules rewriteCtx)

--- a/benchmark/mvnw
+++ b/benchmark/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/benchmark/mvnw
+++ b/benchmark/mvnw
@@ -1,4 +1,6 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: The Apache Software Foundation
+# SPDX-License-Identifier: Apache-2.0
 # ----------------------------------------------------------------------------
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/benchmark/mvnw.cmd
+++ b/benchmark/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/benchmark/mvnw.cmd
+++ b/benchmark/mvnw.cmd
@@ -1,4 +1,6 @@
 <# : batch portion
+@REM SPDX-FileCopyrightText: The Apache Software Foundation
+@REM SPDX-License-Identifier: Apache-2.0
 @REM ----------------------------------------------------------------------------
 @REM Licensed to the Apache Software Foundation (ASF) under one
 @REM or more contributor license agreements.  See the NOTICE file

--- a/phino.cabal
+++ b/phino.cabal
@@ -174,3 +174,16 @@ test-suite spec
     hspec-discover:hspec-discover >=2.11.0 && <2.12
 
   default-language: Haskell2010
+
+-- Benchmark suite
+benchmark bench
+  import: warnings
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: benchmark
+  build-depends:
+    base >=4.18.3.0 && <5,
+    phino,
+    time >=1.12 && <1.16,
+
+  default-language: Haskell2010


### PR DESCRIPTION
## Summary

- Add custom JMH-style benchmark suite (`benchmark/Main.hs`) with 3 warmup iterations, auto-calibrated batching (~20ms window), 10 measured batches, and stats (total, avg, min, max, std dev)
- Test on real-world input: JNA `Native` class downloaded, disassembled via jeo-maven-plugin, converted to φ, cached in `benchmark/tmp/` (gitignored)
- Add Maven wrapper (`benchmark/mvnw`) — no Maven pre-install required
- Add `benchmark.yml` GHA: runs on every push to master, updates README benchmark section via PR
- Add `jeo-update.yml` GHA: daily check for new jeo-maven-plugin releases via `git ls-remote`, opens PR to update `Makefile`
- Add Java presence check in Makefile before benchmark resource generation
- Update CLAUDE.md and README with benchmark documentation

## Test plan

- [ ] `make bench` works locally after `cabal build all` with Java installed
- [ ] `make bench` fails with clear message when `java` not in PATH
- [ ] `benchmark.yml` GHA triggers on push to master and creates PR with updated README
- [ ] `jeo-update.yml` can be triggered manually via `workflow_dispatch`
- [ ] REUSE check passes (Apache-2.0 declared for Maven wrapper files via `.reuse/dep5`)

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)