### PR TITLE
bug(#664): prevent benchmark workflow loop on README-only pushes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,8 @@ name: benchmark
   push:
     branches:
       - master
+    paths-ignore:
+      - README.md
 concurrency:
   group: benchmark-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds `paths-ignore: [README.md]` to the `benchmark.yml` trigger so that merging a benchmark PR (which only modifies `README.md`) does not re-trigger the workflow and cause an infinite loop.

Closes #664