### PR TITLE
bug(#520): add `--update` flag to rewrite

### DIFF
--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -282,6 +282,7 @@ rewriteParser =
             <*> optDepthSensitive
             <*> optNonumber
             <*> switch (long "in-place" <> help "Edit file in-place instead of printing to output")
+            <*> switch (long "update" <> help "Skip rewriting if --target file is newer than the input file")
             <*> optSequence
             <*> optCanonize
             <*> optCompress

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -81,11 +81,10 @@ runRewrite OptsRewrite{..} = do
     checkUpdate :: IO ()
     checkUpdate = case (_update, _inputFile, _targetFile) of
       (True, Just src, Just tgt) -> do
-        targetExists <- doesFileExist tgt
-        when targetExists $ do
-          srcMtime <- getModificationTime src
-          tgtMtime <- getModificationTime tgt
-          when (tgtMtime > srcMtime) $ do
+        exists <- doesFileExist tgt
+        when exists $ do
+          newer <- (>) <$> getModificationTime tgt <*> getModificationTime src
+          when newer $ do
             logDebug (printf "Target '%s' is newer than source '%s', skipping rewriting (--update)" tgt src)
             exitSuccess
       _ -> pure ()

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -29,6 +29,8 @@ import Parser (parseExpressionThrows)
 import qualified Printer as P
 import Rewriter
 import Rule (RuleContext (..), matchProgramWithRule)
+import System.Directory (doesFileExist, getModificationTime)
+import System.Exit (exitSuccess)
 import Text.Printf (printf)
 import XMIR
 import qualified Yaml as Y
@@ -36,6 +38,7 @@ import qualified Yaml as Y
 runRewrite :: OptsRewrite -> IO ()
 runRewrite OptsRewrite{..} = do
   validateOpts
+  checkUpdate
   excluded <- validatedDispatches "hide" _hide
   included <- validatedDispatches "show" _show
   [loc] <- validatedDispatches "locator" [_locator]
@@ -64,6 +67,9 @@ runRewrite OptsRewrite{..} = do
     validateOpts = do
       when (_inPlace && isNothing _inputFile) (invalidCLIArguments "The option --in-place requires an input file")
       when (_inPlace && isJust _targetFile) (invalidCLIArguments "The options --in-place and --target cannot be used together")
+      when (_update && _inPlace) (invalidCLIArguments "The options --update and --in-place cannot be used together")
+      when (_update && isNothing _targetFile) (invalidCLIArguments "The option --update requires --target")
+      when (_update && isNothing _inputFile) (invalidCLIArguments "The option --update requires an input file")
       when (length _show > 1) (invalidCLIArguments "The option --show can be used only once")
       validateLatexOptions
         _outputFormat
@@ -72,6 +78,17 @@ runRewrite OptsRewrite{..} = do
         [(_meetPopularity, "meet-popularity"), (_meetLength, "meet-length")]
       validateMust' _must
       validateXmirOptions _outputFormat [(_omitListing, "omit-listing"), (_omitComments, "omit-comments")] _focus
+    checkUpdate :: IO ()
+    checkUpdate = case (_update, _inputFile, _targetFile) of
+      (True, Just src, Just tgt) -> do
+        targetExists <- doesFileExist tgt
+        when targetExists $ do
+          srcMtime <- getModificationTime src
+          tgtMtime <- getModificationTime tgt
+          when (tgtMtime > srcMtime) $ do
+            logDebug (printf "Target '%s' is newer than source '%s', skipping rewriting (--update)" tgt src)
+            exitSuccess
+      _ -> pure ()
     validateBreakpoint :: Maybe String -> [Y.Rule] -> IO ()
     validateBreakpoint Nothing _ = pure ()
     validateBreakpoint (Just rule) rules =

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -117,6 +117,7 @@ data OptsRewrite = OptsRewrite
   , _depthSensitive :: Bool
   , _nonumber :: Bool
   , _inPlace :: Bool
+  , _update :: Bool
   , _sequence :: Bool
   , _canonize :: Bool
   , _compress :: Bool

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -10,11 +10,12 @@ import CLI (runCLI)
 import Control.Exception
 import Control.Monad (forM_, unless, when)
 import Data.List (intercalate, isInfixOf)
+import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
 import GHC.IO.Handle
 import Paths_phino (version)
-import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, removeFile)
+import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, removeFile, setModificationTime)
 import System.Exit (ExitCode (ExitFailure))
 import System.FilePath ((</>))
 import System.IO
@@ -153,6 +154,28 @@ spec = do
           testCLIFailed
             ["rewrite", "--in-place", "--target=output.phi", path]
             ["--in-place and --target cannot be used together"]
+
+      it "when --update is used without --target" $
+        withTempFile "updateXXXXXX.phi" $ \(path, h) -> do
+          hPutStr h "Q -> [[ ]]"
+          hClose h
+          testCLIFailed
+            ["rewrite", "--update", path]
+            ["--update requires --target"]
+
+      it "when --update is used without an input file" $
+        withStdin "Q -> [[ ]]" $
+          testCLIFailed
+            ["rewrite", "--update", "--target=output.phi"]
+            ["--update requires an input file"]
+
+      it "when --update is used with --in-place" $
+        withTempFile "updateXXXXXX.phi" $ \(path, h) -> do
+          hPutStr h "Q -> [[ ]]"
+          hClose h
+          testCLIFailed
+            ["rewrite", "--update", "--in-place", path]
+            ["--update and --in-place cannot be used together"]
 
       it "with --depth-sensitive" $
         withStdin "Q -> [[ x -> \"x\"]]" $
@@ -693,6 +716,38 @@ spec = do
         testCLISucceeded ["rewrite", rule "simple.yaml", "--in-place", "--sweet", path] []
         content <- readFile path
         content `shouldBe` "{⟦ x ↦ \"bar\" ⟧}"
+
+    it "skips rewriting with --update when target is newer than source" $
+      withTempFile "src-XXXXXX.phi" $ \(srcPath, srcH) -> do
+        hPutStr srcH "Q -> [[ x -> \"foo\" ]]"
+        hClose srcH
+        withTempFile "tgt-XXXXXX.phi" $ \(tgtPath, tgtH) -> do
+          hPutStr tgtH "ORIGINAL"
+          hClose tgtH
+          now <- getCurrentTime
+          setModificationTime srcPath (addUTCTime (-60) now)
+          setModificationTime tgtPath now
+          testCLISucceeded
+            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgtPath, srcPath]
+            []
+          content <- readFile tgtPath
+          content `shouldBe` "ORIGINAL"
+
+    it "rewrites with --update when source is newer than target" $
+      withTempFile "src-XXXXXX.phi" $ \(srcPath, srcH) -> do
+        hPutStr srcH "Q -> [[ x -> \"foo\" ]]"
+        hClose srcH
+        withTempFile "tgt-XXXXXX.phi" $ \(tgtPath, tgtH) -> do
+          hPutStr tgtH "ORIGINAL"
+          hClose tgtH
+          now <- getCurrentTime
+          setModificationTime tgtPath (addUTCTime (-60) now)
+          setModificationTime srcPath now
+          testCLISucceeded
+            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgtPath, srcPath]
+            []
+          content <- readFile tgtPath
+          content `shouldBe` "{⟦ x ↦ \"bar\" ⟧}"
 
     it "rewrites with cycles" $
       withStdin "Q -> [[ x -> \"x\" ]]" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -72,6 +72,13 @@ withTempFile pattern =
     (openTempFile "." pattern)
     (\(path, _) -> removeFile path)
 
+withTempFileContent :: String -> String -> (FilePath -> IO a) -> IO a
+withTempFileContent pattern content action =
+  withTempFile pattern $ \(path, h) -> do
+    hPutStr h content
+    hClose h
+    action path
+
 testCLI' :: [String] -> [String] -> Either ExitCode () -> Expectation
 testCLI' args outputs exit = do
   (out, result) <- withStdout (try (runCLI args) :: IO (Either ExitCode ()))
@@ -156,11 +163,9 @@ spec = do
             ["--in-place and --target cannot be used together"]
 
       it "when --update is used without --target" $
-        withTempFile "updateXXXXXX.phi" $ \(path, h) -> do
-          hPutStr h "Q -> [[ ]]"
-          hClose h
+        withStdin "Q -> [[ ]]" $
           testCLIFailed
-            ["rewrite", "--update", path]
+            ["rewrite", "--update"]
             ["--update requires --target"]
 
       it "when --update is used without an input file" $
@@ -170,11 +175,9 @@ spec = do
             ["--update requires an input file"]
 
       it "when --update is used with --in-place" $
-        withTempFile "updateXXXXXX.phi" $ \(path, h) -> do
-          hPutStr h "Q -> [[ ]]"
-          hClose h
+        withStdin "Q -> [[ ]]" $
           testCLIFailed
-            ["rewrite", "--update", "--in-place", path]
+            ["rewrite", "--update", "--in-place", "input.phi"]
             ["--update and --in-place cannot be used together"]
 
       it "with --depth-sensitive" $
@@ -718,12 +721,8 @@ spec = do
         content `shouldBe` "{⟦ x ↦ \"bar\" ⟧}"
 
     it "skips rewriting with --update when target is newer than source" $
-      withTempFile "src-XXXXXX.phi" $ \(srcPath, srcH) -> do
-        hPutStr srcH "Q -> [[ x -> \"foo\" ]]"
-        hClose srcH
-        withTempFile "tgt-XXXXXX.phi" $ \(tgtPath, tgtH) -> do
-          hPutStr tgtH "ORIGINAL"
-          hClose tgtH
+      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \srcPath ->
+        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgtPath -> do
           now <- getCurrentTime
           setModificationTime srcPath (addUTCTime (-60) now)
           setModificationTime tgtPath now
@@ -734,12 +733,8 @@ spec = do
           content `shouldBe` "ORIGINAL"
 
     it "rewrites with --update when source is newer than target" $
-      withTempFile "src-XXXXXX.phi" $ \(srcPath, srcH) -> do
-        hPutStr srcH "Q -> [[ x -> \"foo\" ]]"
-        hClose srcH
-        withTempFile "tgt-XXXXXX.phi" $ \(tgtPath, tgtH) -> do
-          hPutStr tgtH "ORIGINAL"
-          hClose tgtH
+      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \srcPath ->
+        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgtPath -> do
           now <- getCurrentTime
           setModificationTime tgtPath (addUTCTime (-60) now)
           setModificationTime srcPath now

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -721,27 +721,27 @@ spec = do
         content `shouldBe` "{⟦ x ↦ \"bar\" ⟧}"
 
     it "skips rewriting with --update when target is newer than source" $
-      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \srcPath ->
-        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgtPath -> do
+      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \src ->
+        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgt -> do
           now <- getCurrentTime
-          setModificationTime srcPath (addUTCTime (-60) now)
-          setModificationTime tgtPath now
+          setModificationTime src (addUTCTime (-60) now)
+          setModificationTime tgt now
           testCLISucceeded
-            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgtPath, srcPath]
+            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgt, src]
             []
-          content <- readFile tgtPath
+          content <- readFile tgt
           content `shouldBe` "ORIGINAL"
 
     it "rewrites with --update when source is newer than target" $
-      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \srcPath ->
-        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgtPath -> do
+      withTempFileContent "src-XXXXXX.phi" "Q -> [[ x -> \"foo\" ]]" $ \src ->
+        withTempFileContent "tgt-XXXXXX.phi" "ORIGINAL" $ \tgt -> do
           now <- getCurrentTime
-          setModificationTime tgtPath (addUTCTime (-60) now)
-          setModificationTime srcPath now
+          setModificationTime tgt (addUTCTime (-60) now)
+          setModificationTime src now
           testCLISucceeded
-            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgtPath, srcPath]
+            ["rewrite", rule "simple.yaml", "--update", "--sweet", "--target=" ++ tgt, src]
             []
-          content <- readFile tgtPath
+          content <- readFile tgt
           content `shouldBe` "{⟦ x ↦ \"bar\" ⟧}"
 
     it "rewrites with cycles" $


### PR DESCRIPTION
## Summary
- Adds a `--update` flag to the `rewrite` command. When the `--target`
  file is newer than the input file, rewriting is skipped and the
  command exits successfully (`cp --update` semantics).
- Validation: `--update` requires both `--target` and an input file,
  and conflicts with `--in-place`.

## Test plan
- [x] `make all` passes (1020 examples, 69% coverage, hlint/fourmolu clean)
- [x] 5 new test cases in `test/CLISpec.hs`

Fixes #520