### PR TITLE
bug(#685): add print-path benchmarks for the margin hotspot

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -8,10 +8,15 @@ import Control.Exception (evaluate)
 import Control.Monad (replicateM, replicateM_)
 import Data.Time.Clock
 import Deps (dontSaveStep)
+import Encoding (Encoding (UNICODE))
 import Functions (buildTerm)
+import Lining (LineFormat (MULTILINE, SINGLELINE))
+import Margin (defaultMargin)
 import Must (Must (MtDisabled))
 import Parser (parseProgramThrows)
+import Printer (printProgram')
 import Rewriter (RewriteContext (RewriteContext), rewrite)
+import Sugar (SugarType (SALTY, SWEET))
 import Text.Printf (printf)
 import XMIR (parseXMIRThrows, xmirToPhi)
 import Yaml (normalizationRules)
@@ -86,3 +91,12 @@ main = do
   runBench "parse/phi" (parseProgramThrows src)
   runBench "parse/xmir" (parseXMIRThrows xsrc >>= xmirToPhi)
   runBench "rewrite/normalize" (rewrite prog normalizationRules rewriteCtx)
+  runBench
+    "print/sweet/multiline"
+    (evaluate (length (printProgram' prog (SWEET, UNICODE, MULTILINE, defaultMargin))))
+  runBench
+    "print/sweet/flat"
+    (evaluate (length (printProgram' prog (SWEET, UNICODE, SINGLELINE, defaultMargin))))
+  runBench
+    "print/salty/multiline"
+    (evaluate (length (printProgram' prog (SALTY, UNICODE, MULTILINE, defaultMargin))))


### PR DESCRIPTION
Refs #685.

The existing bench suite covers `parse/phi`, `parse/xmir`, and `rewrite/normalize`, but does not exercise the print pipeline — i.e. the path through `Printer.printProgram'` that runs `withMargin`. That's the path #685 is about, and it has been unmeasured by CI.

This PR adds three cases against the same `native.phi` input the existing benches use:

- `print/sweet/multiline` — default user-facing path (SWEET + UNICODE + MULTILINE + default margin).
- `print/sweet/flat` — same with SINGLELINE; on master, this currently pays the full `withMargin` cost too (the layout is computed and then collapsed), so the bench will catch any future "skip margin for SINGLELINE" win.
- `print/salty/multiline` — canonical phi syntax stress case (SALTY desugars to a larger CST, scaling Margin work proportionally).

Each case wraps the pure `printProgram' prog cfg` in `evaluate (length …)` to force the full result inside the timed window.

## Local numbers

On `native.phi` (24,154 lines), against `master` HEAD:

| Bench | avg |
|---|---|
| parse/phi | 0.56s |
| parse/xmir | 2.77s |
| rewrite/normalize | 0.31s |
| **print/sweet/multiline** | **2.76s** |
| **print/sweet/flat** | **2.49s** |
| **print/salty/multiline** | **8.64s** |

Two things worth flagging:

1. `print/sweet/multiline` is at parity with `parse/xmir` (~2.77s) — printing the parsed program takes as long as parsing the XMIR. It's ~9× slower than `rewrite/normalize`.
2. `print/sweet/flat` is only ~10% faster than the multiline case — empirical confirmation that `--flat` doesn't bypass `withMargin` on master.

GHA-measured numbers will land in `README.md` via the existing benchmark-on-push workflow once this merges.

## Test plan

- [x] `cabal bench --enable-benchmarks` builds and runs locally
- [x] All three new cases produce stable numbers (std dev ~3–7%)
- [ ] CI benchmark job runs successfully against `master` after merge (will produce updated `README.md` PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)