### PR TITLE
bug(#685): specialize hexByte for 2-char direct nibble math

### DIFF
--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -48,7 +48,7 @@ import qualified Data.ByteString as B
 import Data.ByteString.Builder (toLazyByteString, word64BE)
 import Data.ByteString.Lazy (unpack)
 import qualified Data.ByteString.Lazy.UTF8 as U
-import Data.Char (chr, isPrint, ord)
+import Data.Char (chr, isDigit, isPrint, ord)
 import Data.List (intercalate)
 import Data.Maybe (catMaybes)
 import qualified Data.Set as Set
@@ -259,7 +259,7 @@ hexByte :: String -> Word8
 hexByte [hi, lo] = (nibble hi `shiftL` 4) .|. nibble lo
   where
     nibble c
-      | c >= '0' && c <= '9' = fromIntegral (ord c - ord '0')
+      | isDigit c = fromIntegral (ord c - ord '0')
       | c >= 'A' && c <= 'F' = fromIntegral (ord c - ord 'A' + 10)
       | c >= 'a' && c <= 'f' = fromIntegral (ord c - ord 'a' + 10)
       | otherwise = error ("Invalid hex digit: " ++ [c])

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -256,6 +256,13 @@ btsToWord8 (BtMany bts) = map hexByte bts
 btsToWord8 (BtMeta mt) = error $ "Cannot convert meta bytes to Word8; " ++ T.unpack mt
 
 hexByte :: String -> Word8
+hexByte [hi, lo] = (nibble hi `shiftL` 4) .|. nibble lo
+  where
+    nibble c
+      | c >= '0' && c <= '9' = fromIntegral (ord c - ord '0')
+      | c >= 'A' && c <= 'F' = fromIntegral (ord c - ord 'A' + 10)
+      | c >= 'a' && c <= 'f' = fromIntegral (ord c - ord 'a' + 10)
+      | otherwise = error ("Invalid hex digit: " ++ [c])
 hexByte bt = case readHex bt of
   [(hex, "")] -> fromIntegral (hex :: Integer)
   _ -> error $ "Invalid hex byte; " ++ bt


### PR DESCRIPTION
## Summary

Follow-up to the `Misc` cleanups merged in #692. Late-profile on a `rewrite --sweet native.phi` run showed `hexByte` still consuming ~12% inherited time, with ~122k calls and most of the cost in `readHex`.

This PR specializes `hexByte` for the 2-character case (the universal layout for `Bytes` elements — `BtOne "XX"`, `BtMany ["XX", ...]`) using direct nibble math via `shiftL`/`.|.`. The `readHex` fallback remains for any non-2-char input.

Closes another hotspot under #685.

## Numbers

Bench `rewrite/normalize` (10 batches, min): **185.6ms → 176.5ms** (~5%)
Bench `parse/phi` (10 batches, min): **325.7ms → 247.2ms** (~24%)
Wall-time A/B on `rewrite --input phi --sweet native.phi` (8 runs, same host): user median **1.20s → 1.12s** (~7%)

## Test plan

- [x] `make test` — 1020/1020 pass
- [x] Output byte-identical to baseline on `native.phi`
- [x] `regression-check` CI gate (from #688) will confirm no perf regression