### PR TITLE
feat(#702): add --pin global option to fail on version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ $ phino --version
 0.0.0.0
 ```
 
+You can ensure scripts are run with a specific version of `phino` using
+the `--pin` global option. It exits with an error when the version supplied
+doesn't match the installed one:
+
+```bash
+phino --pin=0.0.0.67 dataize hello.phi
+```
+
 ## Dataize
 
 Then, you dataize the program:

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -10,9 +10,11 @@ module CLI (runCLI) where
 import CLI.Parsers
 import CLI.Runners
 import CLI.Types
-import Control.Exception.Base (Exception (displayException), SomeException, fromException, handle)
+import Control.Exception.Base (Exception (displayException), SomeException, fromException, handle, throwIO)
+import Data.Version (showVersion)
 import Logger
 import Options.Applicative
+import Paths_phino (version)
 import System.Exit (ExitCode (..), exitFailure)
 
 handler :: SomeException -> IO ()
@@ -32,11 +34,20 @@ setLogger cmd =
         CmdMatch OptsMatch{_logLevel, _logLines} -> (_logLevel, _logLines)
    in setLogConfig level lns
 
+checkPin :: Maybe String -> IO ()
+checkPin Nothing = pure ()
+checkPin (Just expected)
+  | expected == actual = pure ()
+  | otherwise = throwIO (VersionMismatch expected actual)
+  where
+    actual = showVersion version
+
 runCLI :: [String] -> IO ()
 runCLI args = handle handler $ do
-  cmd <- handleParseResult (execParserPure defaultPrefs parserInfo args)
-  setLogger cmd
-  case cmd of
+  CliArgs{_pin, _command} <- handleParseResult (execParserPure defaultPrefs parserInfo args)
+  checkPin _pin
+  setLogger _command
+  case _command of
     CmdRewrite opts -> runRewrite opts
     CmdDataize opts -> runDataize opts
     CmdExplain opts -> runExplain opts

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -345,8 +345,21 @@ commandParser =
         <> command "match" (info matchParser (progDesc "Match 𝜑-program against provided pattern and build matched substitutions"))
     )
 
-parserInfo :: ParserInfo Command
+optPin :: Parser (Maybe String)
+optPin =
+  optional
+    ( strOption
+        ( long "pin"
+            <> metavar "VERSION"
+            <> help "Fail if this version doesn't match the version of phino"
+        )
+    )
+
+cliArgsParser :: Parser CliArgs
+cliArgsParser = CliArgs <$> optPin <*> commandParser
+
+parserInfo :: ParserInfo CliArgs
 parserInfo =
   info
-    (commandParser <**> helper <**> simpleVersioner (showVersion version))
+    (cliArgsParser <**> helper <**> simpleVersioner (showVersion version))
     (fullDesc <> header "Phino - CLI Manipulator of 𝜑-Calculus Expressions")

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -38,6 +38,7 @@ data CmdException
   | CouldNotDataize
   | CouldNotPrintExpressionInXMIR
   | EmptySubstsOnMatch
+  | VersionMismatch String String
   deriving (Exception)
 
 instance Show CmdException where
@@ -46,6 +47,8 @@ instance Show CmdException where
   show CouldNotDataize = "Could not dataize given program"
   show CouldNotPrintExpressionInXMIR = "Could not print expression with --output=xmir, only program printing is allowed"
   show EmptySubstsOnMatch = "Provided pattern was not matched, no substitutions are built"
+  show (VersionMismatch expected actual) =
+    printf "Version mismatch: --pin requires '%s', but this is phino %s" expected actual
 
 data Command
   = CmdRewrite OptsRewrite
@@ -53,6 +56,11 @@ data Command
   | CmdExplain OptsExplain
   | CmdMerge OptsMerge
   | CmdMatch OptsMatch
+
+data CliArgs = CliArgs
+  { _pin :: Maybe String
+  , _command :: Command
+  }
 
 data IOFormat = XMIR | PHI | LATEX
   deriving (Eq)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -125,7 +125,7 @@ spec = do
           ["--pin=" ++ showVersion version, "rewrite", "--sweet"]
           ["{⟦⟧}"]
 
-    it "fails when --pin doesnt match actual version" $
+    it "fails when --pin doesn't match actual version" $
       withStdin "Q -> [[ ]]" $
         testCLIFailed
           ["--pin=9.9.9.9", "rewrite"]

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -118,6 +118,25 @@ spec = do
       ["--help"]
       ["Phino - CLI Manipulator of 𝜑-Calculus Expressions", "Usage:"]
 
+  describe "--pin" $ do
+    it "succeeds when --pin matches actual version" $
+      withStdin "Q -> [[ ]]" $
+        testCLISucceeded
+          ["--pin=" ++ showVersion version, "rewrite", "--sweet"]
+          ["{⟦⟧}"]
+
+    it "fails when --pin doesnt match actual version" $
+      withStdin "Q -> [[ ]]" $
+        testCLIFailed
+          ["--pin=9.9.9.9", "rewrite"]
+          ["Version mismatch: --pin requires '9.9.9.9', but this is phino " ++ showVersion version]
+
+    it "fails when --pin is empty" $
+      withStdin "Q -> [[ ]]" $
+        testCLIFailed
+          ["--pin=", "rewrite"]
+          ["Version mismatch: --pin requires ''"]
+
   it "prints debug info with --log-level=DEBUG" $
     withStdin "{[[]]}" $
       testCLISucceeded ["rewrite", "--log-level=DEBUG"] ["[DEBUG]:"]


### PR DESCRIPTION
## Summary

Closes #702.

Adds a top-level `--pin VERSION` option to `phino`. When supplied, it
compares the value against the installed `phino` version and exits with
an error if they don't match. Use it to make build scripts fail fast
when run against an unexpected `phino` release:

```bash
phino --pin=0.0.0.67 dataize hello.phi
```

The option lives next to `--version` and `--help` at the top level, so
it must appear before the subcommand.

## Test plan

- [x] `make test` — all 1023 existing tests still pass, plus three new
  cases in `CLISpec.hs` (match, mismatch, empty version)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
- [x] Manual smoke: `phino --pin=$(phino --version) rewrite ...` succeeds;
  `phino --pin=9.9.9.9 rewrite ...` exits with `Version mismatch`