### PR TITLE
Add splice where-function for multi-position sentinel rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,13 @@ Here's list of functions that are supported for extensions:
 * `join` - accepts list of bindings and returns list of joined bindings. Duplicated
   `ρ`, `Δ` and `λ` attributes are ignored, all other duplicated attributes are replaced
   with unique attributes using `random-tau` function.
+* `splice` - accepts three arguments: input bindings `𝐵-in`, a sentinel expression,
+  and replacement bindings `𝐵-rep`. Returns a new binding group where `𝐵-rep`
+  is inserted in front of every binding in `𝐵-in` whose value is a formation
+  with `φ` equal to the sentinel. Every spliced copy of `𝐵-rep` has its
+  `τ`-labelled attributes renamed via `random-tau` so the resulting binding
+  group has no duplicates. When no binding matches the sentinel the output
+  equals the input unchanged.
 
 ## Meta variables
 

--- a/README.md
+++ b/README.md
@@ -335,9 +335,11 @@ Here's list of functions that are supported for extensions:
   and replacement bindings `𝐵-rep`. Returns a new binding group where `𝐵-rep`
   is inserted in front of every binding in `𝐵-in` whose value is a formation
   with `φ` equal to the sentinel. Every spliced copy of `𝐵-rep` has its
-  `τ`-labelled attributes renamed via `random-tau` so the resulting binding
-  group has no duplicates. When no binding matches the sentinel the output
-  equals the input unchanged.
+  `τ`-labelled attributes renamed via `random-tau`, so duplicates introduced
+  by repeated insertion are avoided only for those `τ` attributes. If `𝐵-rep`
+  contains non-`τ` special attributes such as `ρ`, `Δ`, `λ`, or `φ`, splicing
+  at multiple positions may still produce duplicates. When no binding matches
+  the sentinel the output equals the input unchanged.
 
 ## Meta variables
 

--- a/README.md
+++ b/README.md
@@ -335,11 +335,13 @@ Here's list of functions that are supported for extensions:
   and replacement bindings `𝐵-rep`. Returns a new binding group where `𝐵-rep`
   is inserted in front of every binding in `𝐵-in` whose value is a formation
   with `φ` equal to the sentinel. Every spliced copy of `𝐵-rep` has its
-  `τ`-labelled attributes renamed via `random-tau`, so duplicates introduced
-  by repeated insertion are avoided only for those `τ` attributes. If `𝐵-rep`
-  contains non-`τ` special attributes such as `ρ`, `Δ`, `λ`, or `φ`, splicing
-  at multiple positions may still produce duplicates. When no binding matches
-  the sentinel the output equals the input unchanged.
+  `τ`-labelled attributes renamed via `random-tau` so the resulting binding
+  group has no duplicates. `𝐵-rep` must contain only `τ`-labelled bindings
+  (`BiTau (AtLabel _) _` or `BiVoid (AtLabel _)`); any `ρ`, `Δ`, `λ`, `φ`,
+  `α`, or meta-attribute binding in `𝐵-rep` makes the function fail fast
+  because such bindings cannot be renamed and would produce duplicates
+  when spliced at more than one position. When no binding matches the
+  sentinel, the output equals the input unchanged.
 
 ## Meta variables
 

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -44,6 +44,7 @@ buildTerm' "string" = _string
 buildTerm' "number" = _number
 buildTerm' "sum" = _sum
 buildTerm' "join" = _join
+buildTerm' "splice" = _splice
 buildTerm' func = _unsupported func
 
 argToBytes :: Y.ExtraArgument -> Subst -> IO Bytes
@@ -247,6 +248,45 @@ _join args subst = do
       case unsafePerformIO (_randomTau (map Y.ArgAttribute (Set.toList attrs)) subst) of
         TeAttribute attr' -> attr'
         _ -> AtLabel "unknown"
+
+_splice :: BuildTermMethod
+_splice [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subst = do
+  inBds <- buildBindingThrows inArg subst
+  repBds <- buildBindingThrows repArg subst
+  (sentinel, _) <- buildExpressionThrows sentExpr subst
+  let avoid = map Y.ArgAttribute (attributesFromBindings (inBds ++ repBds))
+  spliced <- splice inBds sentinel repBds avoid
+  pure (TeBindings spliced)
+  where
+    splice :: [Binding] -> Expression -> [Binding] -> [Y.ExtraArgument] -> IO [Binding]
+    splice [] _ _ _ = pure []
+    splice (bd : rest) sent rep avoid
+      | matches sent bd = do
+          fresh <- traverse (renamed avoid) rep
+          tail' <- splice rest sent rep avoid
+          pure (fresh ++ bd : tail')
+      | otherwise = do
+          tail' <- splice rest sent rep avoid
+          pure (bd : tail')
+    matches :: Expression -> Binding -> Bool
+    matches sent (BiTau _ (ExFormation bds)) = any (isPhi sent) bds
+    matches _ _ = False
+    isPhi :: Expression -> Binding -> Bool
+    isPhi sent (BiTau AtPhi expr) = expr == sent
+    isPhi _ _ = False
+    renamed :: [Y.ExtraArgument] -> Binding -> IO Binding
+    renamed avoid (BiTau (AtLabel _) expr) = do
+      term <- _randomTau avoid subst
+      case term of
+        TeAttribute attr -> pure (BiTau attr expr)
+        _ -> throwIO (userError "Failed to generate fresh tau attribute for splice")
+    renamed avoid (BiVoid (AtLabel _)) = do
+      term <- _randomTau avoid subst
+      case term of
+        TeAttribute attr -> pure (BiVoid attr)
+        _ -> throwIO (userError "Failed to generate fresh tau attribute for splice")
+    renamed _ bd = pure bd
+_splice _ _ = throwIO (userError "Function splice() requires exactly 3 arguments: input bindings, sentinel expression, replacement bindings")
 
 _unsupported :: BuildTermFunc
 _unsupported func _ _ = throwIO (userError (printf "Function %s() is not supported or does not exist" func))

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -19,7 +19,7 @@ import Logger (logDebug)
 import Matcher
 import Misc
 import Parser (parseAttributeThrows, parseNumberThrows)
-import Printer (printAttribute, printExpression, printExtraArg)
+import Printer (printAttribute, printBinding, printExpression, printExtraArg)
 import Random (randomString)
 import Regexp
 import Text.Printf (printf)
@@ -253,11 +253,23 @@ _splice :: BuildTermMethod
 _splice [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subst = do
   inBds <- buildBindingThrows inArg subst
   repBds <- buildBindingThrows repArg subst
+  mapM_ validateRep repBds
   (sentinel, _) <- buildExpressionThrows sentExpr subst
   let avoid = map Y.ArgAttribute (attributesFromBindings (inBds ++ repBds))
   spliced <- splice inBds sentinel repBds avoid
   pure (TeBindings spliced)
   where
+    validateRep :: Binding -> IO ()
+    validateRep (BiTau (AtLabel _) _) = pure ()
+    validateRep (BiVoid (AtLabel _)) = pure ()
+    validateRep bd =
+      throwIO
+        ( userError
+            ( printf
+                "Function splice() can only rename τ-labelled bindings in the replacement group, but got '%s' which would produce duplicates when spliced more than once"
+                (printBinding bd)
+            )
+        )
     splice :: [Binding] -> Expression -> [Binding] -> [Y.ExtraArgument] -> IO [Binding]
     splice [] _ _ _ = pure []
     splice (bd : rest) sent rep avoid

--- a/test-resources/rewriter-packs/custom/splice-counts-positions.yaml
+++ b/test-resources/rewriter-packs/custom/splice-counts-positions.yaml
@@ -22,7 +22,11 @@ output: |-
 rules:
   custom:
     - name: splice and count
-      pattern: '[[ cps -> [[ !B-cps, ^ -> ? ]], auto -> [[ !B-auto, ^ -> ? ]] ]]'
+      pattern: |
+        [[
+          cps -> [[ !B-cps, ^ -> ? ]],
+          auto -> [[ !B-auto, ^ -> ? ]]
+        ]]
       result: '[[ n -> !e ]]'
       where:
         - meta: '!B-spliced'

--- a/test-resources/rewriter-packs/custom/splice-counts-positions.yaml
+++ b/test-resources/rewriter-packs/custom/splice-counts-positions.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: |
+  Q -> [[
+    cps -> [[
+      a -> [[ @ ->Q.hone.emit ]],
+      x -> [[ @ ->Q.jeo.opcode.iconst_0 ]],
+      b -> [[ @ ->Q.hone.emit ]],
+      y -> [[ @ ->Q.jeo.opcode.iconst_1 ]],
+      c -> [[ @ ->Q.hone.emit ]]
+    ]],
+    auto -> [[
+      r1 -> [[ @ ->Q.jeo.opcode.iadd ]],
+      r2 -> [[ @ ->Q.jeo.opcode.istore ]]
+    ]]
+  ]]
+output: |-
+  Φ ↦ ⟦
+    n ↦ 11
+  ⟧
+rules:
+  custom:
+    - name: splice and count
+      pattern: '[[ cps -> [[ !B-cps, ^ -> ? ]], auto -> [[ !B-auto, ^ -> ? ]] ]]'
+      result: '[[ n -> !e ]]'
+      where:
+        - meta: '!B-spliced'
+          function: splice
+          args:
+            - '!B-cps'
+            - 'Φ.hone.emit'
+            - '!B-auto'
+        - meta: '!e'
+          function: size
+          args: ['!B-spliced']

--- a/test/FunctionsSpec.hs
+++ b/test/FunctionsSpec.hs
@@ -6,6 +6,8 @@
 module FunctionsSpec where
 
 import AST
+import Control.Exception (try)
+import Control.Monad (void)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Deps (Term (TeBindings))
@@ -24,6 +26,10 @@ emit = ExDispatch (ExDispatch ExGlobal (AtLabel "hone")) (AtLabel "emit")
 phiBinding :: T.Text -> Expression -> Binding
 phiBinding name body = BiTau (AtLabel name) (ExFormation [BiTau AtPhi body])
 
+bodyOf :: Binding -> Maybe Expression
+bodyOf (BiTau _ (ExFormation [BiTau AtPhi expr])) = Just expr
+bodyOf _ = Nothing
+
 spec :: Test.Hspec.Spec
 spec = describe "Functions" $ do
   Test.Hspec.it "contains only unique bindings after 'join'" $ do
@@ -35,7 +41,7 @@ spec = describe "Functions" $ do
     bds' <- uniqueBindings' bds
     logDebug (printf "Joined bindings:\n%s" (printExpression (ExFormation bds')))
     length bds' `shouldBe` 9
-  Test.Hspec.it "splices replacement before every sentinel match" $ do
+  Test.Hspec.it "splices replacement in the correct order before every sentinel match" $ do
     let foo = ExDispatch ExGlobal (AtLabel "foo")
         bar = ExDispatch ExGlobal (AtLabel "bar")
         cpsBody =
@@ -65,7 +71,16 @@ spec = describe "Functions" $ do
         subst
     bds <- uniqueBindings' result
     logDebug (printf "Spliced bindings:\n%s" (printExpression (ExFormation bds)))
-    length bds `shouldBe` length cpsBody + 2 * length autoBody
+    map bodyOf bds
+      `shouldBe` [ Just foo
+                 , Just foo
+                 , Just bar
+                 , Just emit
+                 , Just bar
+                 , Just foo
+                 , Just bar
+                 , Just emit
+                 ]
   Test.Hspec.it "returns the input unchanged when no sentinel match is found" $ do
     let foo = ExDispatch ExGlobal (AtLabel "foo")
         body = [phiBinding "x" foo, phiBinding "y" foo]
@@ -106,3 +121,31 @@ spec = describe "Functions" $ do
         subst
     bds <- uniqueBindings' result
     bds `shouldSatisfy` ((== length body + 5 * length rep) . length)
+  Test.Hspec.it "fails fast when replacement contains a non-label binding" $ do
+    let body = [phiBinding "e1" emit, phiBinding "e2" emit]
+        rep = [phiBinding "a" emit, BiVoid AtRho]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings rep)
+                ]
+            )
+    outcome <-
+      try
+        ( void
+            ( buildTerm
+                "splice"
+                [ ArgBinding (BiMeta "B-in")
+                , ArgExpression emit
+                , ArgBinding (BiMeta "B-rep")
+                ]
+                subst
+            )
+        ) ::
+        IO (Either IOError ())
+    outcome `shouldSatisfy` isLeft
+  where
+    isLeft :: Either a b -> Bool
+    isLeft (Left _) = True
+    isLeft _ = False

--- a/test/FunctionsSpec.hs
+++ b/test/FunctionsSpec.hs
@@ -7,18 +7,25 @@ module FunctionsSpec where
 
 import AST
 import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
 import Deps (Term (TeBindings))
 import Functions (buildTerm)
 import Logger (logDebug)
 import Matcher (MetaValue (MvBindings), Subst (Subst))
 import Misc (uniqueBindings')
 import Printer (printExpression)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import Text.Printf (printf)
-import Yaml (ExtraArgument (ArgBinding))
+import Yaml (ExtraArgument (ArgBinding, ArgExpression))
+
+emit :: Expression
+emit = ExDispatch (ExDispatch ExGlobal (AtLabel "hone")) (AtLabel "emit")
+
+phiBinding :: T.Text -> Expression -> Binding
+phiBinding name body = BiTau (AtLabel name) (ExFormation [BiTau AtPhi body])
 
 spec :: Test.Hspec.Spec
-spec = describe "Functions" $
+spec = describe "Functions" $ do
   Test.Hspec.it "contains only unique bindings after 'join'" $ do
     let first = ("B1", MvBindings [BiVoid AtRho, BiDelta BtEmpty, BiTau (AtLabel "x") ExGlobal, BiVoid (AtAlpha 0)])
         second = ("B2", MvBindings [BiTau AtRho ExThis, BiLambda "Func", BiDelta (BtOne "00"), BiVoid (AtAlpha 1)])
@@ -28,3 +35,74 @@ spec = describe "Functions" $
     bds' <- uniqueBindings' bds
     logDebug (printf "Joined bindings:\n%s" (printExpression (ExFormation bds')))
     length bds' `shouldBe` 9
+  Test.Hspec.it "splices replacement before every sentinel match" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        bar = ExDispatch ExGlobal (AtLabel "bar")
+        cpsBody =
+          [ phiBinding "x" foo
+          , phiBinding "emit1" emit
+          , phiBinding "y" bar
+          , phiBinding "emit2" emit
+          ]
+        autoBody =
+          [ phiBinding "add1" foo
+          , phiBinding "add2" bar
+          ]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings cpsBody)
+                , ("B-rep", MvBindings autoBody)
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "splice"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    bds <- uniqueBindings' result
+    logDebug (printf "Spliced bindings:\n%s" (printExpression (ExFormation bds)))
+    length bds `shouldBe` length cpsBody + 2 * length autoBody
+  Test.Hspec.it "returns the input unchanged when no sentinel match is found" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        body = [phiBinding "x" foo, phiBinding "y" foo]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings [phiBinding "z" foo])
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "splice"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    result `shouldBe` body
+  Test.Hspec.it "produces only unique attributes for many splice positions" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        body = [phiBinding (T.pack ('e' : show i)) emit | i <- [1 .. 5 :: Int]]
+        rep = [phiBinding "a" foo, phiBinding "b" foo]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings rep)
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "splice"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    bds <- uniqueBindings' result
+    bds `shouldSatisfy` ((== length body + 5 * length rep) . length)


### PR DESCRIPTION
This adds a `splice` where-function next to `join` in `src/Functions.hs`. It takes three arguments — an input binding group, a sentinel expression, and a replacement binding group — and returns a new binding group with the replacement inserted in front of every binding whose value is a formation with `φ` equal to the sentinel. Every spliced copy has its τ-labelled attributes renamed via `random-tau` so the resulting binding group has no duplicates, and when nothing matches the sentinel the input is returned unchanged.

The motivation is multi-emit fusion in `hone-maven-plugin` (the `401c-fuse-cps-auto.phr` rule), which needs to splice an auto body in front of every `Φ.hone.emit` marker in a cps body in one rule firing. A naïve workaround that keeps the source formation in `result` so phino's fixed-point loop fires once per emit marker re-matches forever; the existing `join` concatenates two binding groups but cannot find-and-replace inside one, and `sed` only operates on string scalars. `splice` is the binding-group analogue of `sed s/.../.../g`.

The change adds three direct unit tests in `FunctionsSpec.hs` (multi-match splice, zero-match passthrough, uniqueness across many positions) and one end-to-end YAML pack in `test-resources/rewriter-packs/custom/splice-counts-positions.yaml` that drives `splice` through the rewriter and counts the spliced bindings via `size`. The README gets a short entry under the where-functions list. No existing function changes.

Closes #708