### PR TITLE
fix(#714): normalize formations after each rewrite step

### DIFF
--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -16,6 +16,7 @@ module Misc
   , btsToStr
   , btsToNum
   , withVoidRho
+  , normalizeFormations
   , allPathsIn
   , ensuredFile
   , shuffle
@@ -198,6 +199,19 @@ withVoidRho bds = withVoidRho' bds False
         BiVoid AtRho -> bd : withVoidRho' rest True
         BiTau AtRho _ -> bd : withVoidRho' rest True
         _ -> bd : withVoidRho' rest hasRho
+
+-- Recursively ensure all formations have a BiVoid AtRho binding (ρ ↦ ∅).
+-- Fixes in-memory ExFormation [] to ExFormation [BiVoid AtRho] after rewriting,
+-- keeping the invariant that the parser enforces via withVoidRho.
+normalizeFormations :: Expression -> Expression
+normalizeFormations (ExFormation bds) = ExFormation (withVoidRho (map normalizeFormationsB bds))
+normalizeFormations (ExDispatch e a) = ExDispatch (normalizeFormations e) a
+normalizeFormations (ExApplication e b) = ExApplication (normalizeFormations e) (normalizeFormationsB b)
+normalizeFormations e = e
+
+normalizeFormationsB :: Binding -> Binding
+normalizeFormationsB (BiTau a e) = BiTau a (normalizeFormations e)
+normalizeFormationsB b = b
 
 -- Transform dispatch to list of attributes
 -- >>> fqnToAttrs (ExDispatch (ExDispatch (ExDispatch ExGlobal (AtLabel "org")) (AtLabel "eolang")) (AtLabel "number"))

--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -16,7 +16,7 @@ module Misc
   , btsToStr
   , btsToNum
   , withVoidRho
-  , normalizeFormations
+  , recoverFormations
   , allPathsIn
   , ensuredFile
   , shuffle
@@ -203,15 +203,15 @@ withVoidRho bds = withVoidRho' bds False
 -- Recursively ensure all formations have a BiVoid AtRho binding (ρ ↦ ∅).
 -- Fixes in-memory ExFormation [] to ExFormation [BiVoid AtRho] after rewriting,
 -- keeping the invariant that the parser enforces via withVoidRho.
-normalizeFormations :: Expression -> Expression
-normalizeFormations (ExFormation bds) = ExFormation (withVoidRho (map normalizeFormationsB bds))
-normalizeFormations (ExDispatch e a) = ExDispatch (normalizeFormations e) a
-normalizeFormations (ExApplication e b) = ExApplication (normalizeFormations e) (normalizeFormationsB b)
-normalizeFormations e = e
+recoverFormations :: Expression -> Expression
+recoverFormations (ExFormation bindings) = ExFormation (withVoidRho (map recoverFormations' bindings))
+recoverFormations (ExDispatch expr attr) = ExDispatch (recoverFormations expr) attr
+recoverFormations (ExApplication expr binding) = ExApplication (recoverFormations expr) (recoverFormations' binding)
+recoverFormations expr = expr
 
-normalizeFormationsB :: Binding -> Binding
-normalizeFormationsB (BiTau a e) = BiTau a (normalizeFormations e)
-normalizeFormationsB b = b
+recoverFormations' :: Binding -> Binding
+recoverFormations' (BiTau attr expr) = BiTau attr (recoverFormations expr)
+recoverFormations' binding = binding
 
 -- Transform dispatch to list of attributes
 -- >>> fqnToAttrs (ExDispatch (ExDispatch (ExDispatch ExGlobal (AtLabel "org")) (AtLabel "eolang")) (AtLabel "number"))

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -20,7 +20,7 @@ import Deps
 import Locator (locatedExpression, withLocatedExpression)
 import Logger (logDebug)
 import Matcher (Subst)
-import Misc (normalizeFormations)
+import Misc (recoverFormations)
 import Must (Must (..), exceedsUpperBound, inRange)
 import Printer (printExpression)
 import Replacer (ReplaceContext (ReplaceCtx), ReplaceExpressionFunc, replaceExpression, replaceExpressionFast)
@@ -168,7 +168,7 @@ rewrite' state (rule : rest) iteration ctx@RewriteContext{..} = do
                     else pure (_rewrittens, _unique, False)
                 matched -> do
                   logDebug (printf "Rule '%s' has been matched, applying..." ruleName)
-                  expr <- normalizeFormations <$> tryBuildAndReplaceFast (expression, ptn, res, matched) (ReplaceCtx _maxDepth)
+                  expr <- recoverFormations <$> tryBuildAndReplaceFast (expression, ptn, res, matched) (ReplaceCtx _maxDepth)
                   if expression == expr
                     then do
                       logDebug (printf "Applied '%s', no changes made" ruleName)

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -20,6 +20,7 @@ import Deps
 import Locator (locatedExpression, withLocatedExpression)
 import Logger (logDebug)
 import Matcher (Subst)
+import Misc (normalizeFormations)
 import Must (Must (..), exceedsUpperBound, inRange)
 import Printer (printExpression)
 import Replacer (ReplaceContext (ReplaceCtx), ReplaceExpressionFunc, replaceExpression, replaceExpressionFast)
@@ -167,7 +168,7 @@ rewrite' state (rule : rest) iteration ctx@RewriteContext{..} = do
                     else pure (_rewrittens, _unique, False)
                 matched -> do
                   logDebug (printf "Rule '%s' has been matched, applying..." ruleName)
-                  expr <- tryBuildAndReplaceFast (expression, ptn, res, matched) (ReplaceCtx _maxDepth)
+                  expr <- normalizeFormations <$> tryBuildAndReplaceFast (expression, ptn, res, matched) (ReplaceCtx _maxDepth)
                   if expression == expr
                     then do
                       logDebug (printf "Applied '%s', no changes made" ruleName)

--- a/test-resources/rewriter-packs/custom/sequential-rules-bug-714.yaml
+++ b/test-resources/rewriter-packs/custom/sequential-rules-bug-714.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Regression test for https://github.com/objectionary/phino/issues/714
+# Rule A (fast path) removes void bindings until the formation is empty.
+# Rule B must then match the empty formation [[ ]] and replace it.
+# Without the fix, rule A produces ExFormation [] (no rho binding) while
+# rule B's pattern is parsed as ExFormation [BiVoid AtRho], so they never match.
+repeat: 5
+must: 1
+input: |
+  {[[ x -> ? ]]}
+output: |
+  {[[ x -> Q ]]}
+rules:
+  custom:
+    - name: remove void
+      pattern: |
+        [[ !B1, !a -> ?, !B2 ]]
+      result: |
+        [[ !B1, !B2 ]]
+    - name: empty to filled
+      pattern: |
+        [[ ]]
+      result: |
+        [[ x -> Q ]]


### PR DESCRIPTION
## Summary

Fixes #714 — when two rewrite rules are applied sequentially in a single `phino` command, the second rule fails to match an empty formation produced by the first.

## Root cause

The parser always enforces the invariant `withVoidRho` (every formation carries `ρ ↦ ∅`). The Rewriter did not. The fast replacement path (`replaceBindingsFast` → `findAndReplace`) can remove all bindings from a formation — including `BiVoid AtRho` — leaving `ExFormation []`. Both representations print as `⟦⟧`, but `ExFormation [] /= ExFormation [BiVoid AtRho]` structurally, so a follow-up rule whose pattern was parsed (and therefore normalized) never matches.

## Fix

Apply a new helper `normalizeFormations` (a full-tree traversal of `withVoidRho`) to the result of `tryBuildAndReplaceFast` in `Rewriter.hs`, before any equality check or loop detection. This restores the invariant without touching `Builder`/`Replacer` internals — those operate on partial binding lists (fast-path "middles") which must remain un-normalized, otherwise patterns like `[[ !B1, !a -> ?, !B2 ]]` would only match when the void binding is immediately adjacent to `ρ`.

## Test plan

- [x] Added regression test `test-resources/rewriter-packs/custom/sequential-rules-bug-714.yaml` that fails on `master` and passes with the fix:
  - rule A `[[ !B1, !a -> ?, !B2 ]] => [[ !B1, !B2 ]]` (fast path) removes every void binding including `ρ`
  - rule B `[[ ]] => [[ x -> Q ]]` must then match the empty formation
- [ ] `make test` (run by CI)
- [ ] `make hlint`
- [ ] `make fourmolu`

## Files changed

- `src/Misc.hs` — add and export `normalizeFormations`
- `src/Rewriter.hs` — import and apply `normalizeFormations` after each rule application
- `test-resources/rewriter-packs/custom/sequential-rules-bug-714.yaml` — regression test