### PR TITLE
fix: skip primitive conversion for non-primitives

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -11,7 +11,6 @@
 module CST where
 
 import AST
-import Data.Maybe (isJust)
 import qualified Data.Text as T
 import Misc
 import qualified Yaml as Y
@@ -317,7 +316,7 @@ instance ToCST Expression EXPRESSION where
         next = tabs + 1
         (ts', rs) = withoutRhosInPrimitives ex ts
         obj = ExApplication ex (head' ts')
-     in if length ts' == 1 && isJust (matchDataObject obj)
+     in if length ts' == 1 && isPrimitiveDataObject obj
           then applicationToPrimitive obj tabs rs
           else
             if null exs
@@ -344,6 +343,10 @@ instance ToCST Expression EXPRESSION where
     where
       primitives :: [T.Text]
       primitives = ["number", "string"]
+      isPrimitiveDataObject :: Expression -> Bool
+      isPrimitiveDataObject expression = case matchDataObject expression of
+        Just (label, _) -> label `elem` primitives
+        Nothing -> False
       withoutRhosInPrimitives :: Expression -> [Binding] -> ([Binding], [Binding])
       withoutRhosInPrimitives _ [] = ([], [])
       withoutRhosInPrimitives obj@(BaseObject label) bds@(rho@(BiTau AtRho _) : rest)

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -69,8 +69,8 @@ spec = do
         form = ExFormation [BiDelta (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"]), BiVoid AtRho]
         isCSTNumber (EX_NUMBER{}) = True
         isCSTNumber _ = False
-        isApplicationTaus (EX_APPLICATION_TAUS{}) = True
-        isApplicationTaus _ = False
+        isApplicationExprs (EX_APPLICATION_EXPRS{}) = True
+        isApplicationExprs _ = False
     forM_
       [ ("number(bytes(data))", app number (bt (app bts (bt form))))
       , ("again(number)(bytes(data))", app (again number) (bt (app bts (bt form))))
@@ -88,7 +88,7 @@ spec = do
           alphaBinding = BiTau (AtAlpha 0)
           body = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
           nonPrimitive = ExApplication foo (alphaBinding (ExApplication byteObject (alphaBinding body)))
-      (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` isApplicationTaus
+      (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` isApplicationExprs
 
   describe "CST printing packs" $ do
     let resources = "test-resources/cst/printing-packs"

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -82,10 +82,10 @@ spec = do
 
     xit "keeps non-primitive data-shaped applications out of primitive conversion" $ do
       let foo = BaseObject "foo"
-          bts = BaseObject "bytes"
-          bt = BiTau (AtAlpha 0)
-          form = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
-          nonPrimitive = ExApplication foo (bt (ExApplication bts (bt form)))
+          bytes = BaseObject "bytes"
+          alpha = BiTau (AtAlpha 0)
+          body = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
+          nonPrimitive = ExApplication foo (alpha (ExApplication bytes (alpha body)))
       (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` const True
 
   describe "CST printing packs" $ do

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -82,10 +82,10 @@ spec = do
 
     xit "keeps non-primitive data-shaped applications out of primitive conversion" $ do
       let foo = BaseObject "foo"
-          bytes = BaseObject "bytes"
-          alpha = BiTau (AtAlpha 0)
+          byteObject = BaseObject "bytes"
+          alphaBinding = BiTau (AtAlpha 0)
           body = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
-          nonPrimitive = ExApplication foo (alpha (ExApplication bytes (alpha body)))
+          nonPrimitive = ExApplication foo (alphaBinding (ExApplication byteObject (alphaBinding body)))
       (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` const True
 
   describe "CST printing packs" $ do

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -69,6 +69,8 @@ spec = do
         form = ExFormation [BiDelta (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"]), BiVoid AtRho]
         isCSTNumber (EX_NUMBER{}) = True
         isCSTNumber _ = False
+        isApplicationTaus (EX_APPLICATION_TAUS{}) = True
+        isApplicationTaus _ = False
     forM_
       [ ("number(bytes(data))", app number (bt (app bts (bt form))))
       , ("again(number)(bytes(data))", app (again number) (bt (app bts (bt form))))
@@ -80,13 +82,13 @@ spec = do
       ]
       (\(desc, ex) -> it desc (toCST ex (0, EOL) `shouldSatisfy` isCSTNumber))
 
-    xit "keeps non-primitive data-shaped applications out of primitive conversion" $ do
+    it "keeps non-primitive data-shaped applications out of primitive conversion" $ do
       let foo = BaseObject "foo"
           byteObject = BaseObject "bytes"
           alphaBinding = BiTau (AtAlpha 0)
           body = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
           nonPrimitive = ExApplication foo (alphaBinding (ExApplication byteObject (alphaBinding body)))
-      (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` const True
+      (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` isApplicationTaus
 
   describe "CST printing packs" $ do
     let resources = "test-resources/cst/printing-packs"

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -86,7 +86,7 @@ spec = do
           bt = BiTau (AtAlpha 0)
           form = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
           nonPrimitive = ExApplication foo (bt (ExApplication bts (bt form)))
-      toCST nonPrimitive (0, EOL) `shouldSatisfy` const True
+      (toCST nonPrimitive (0, EOL) :: EXPRESSION) `shouldSatisfy` const True
 
   describe "CST printing packs" $ do
     let resources = "test-resources/cst/printing-packs"

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -80,6 +80,14 @@ spec = do
       ]
       (\(desc, ex) -> it desc (toCST ex (0, EOL) `shouldSatisfy` isCSTNumber))
 
+    xit "keeps non-primitive data-shaped applications out of primitive conversion" $ do
+      let foo = BaseObject "foo"
+          bts = BaseObject "bytes"
+          bt = BiTau (AtAlpha 0)
+          form = ExFormation [BiDelta (BtOne "01"), BiVoid AtRho]
+          nonPrimitive = ExApplication foo (bt (ExApplication bts (bt form)))
+      toCST nonPrimitive (0, EOL) `shouldSatisfy` const True
+
   describe "CST printing packs" $ do
     let resources = "test-resources/cst/printing-packs"
     packs <- runIO (allPathsIn resources)


### PR DESCRIPTION
## Summary
- Guard CST primitive conversion so only `number` and `string` data objects enter `applicationToPrimitive`.
- Enable the regression test for non-primitive data-shaped applications and assert they stay regular applications instead of panicking.

Closes #686

## Tests
- `git diff --check` -> passed
- `rg -n "Data.Maybe|isJust" src\CST.hs` -> no matches
- `git merge-tree --write-tree origin/master HEAD` -> passed
- Not run locally: `ghc`, `cabal`, `stack`, and `fourmolu` are not installed in this Windows workspace.

Prepared with local automation assistance and reviewed before submission.