### PR TITLE
Add graft where-function for marker-replacing splice

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,13 @@ Here's list of functions that are supported for extensions:
   because such bindings cannot be renamed and would produce duplicates
   when spliced at more than one position. When no binding matches the
   sentinel, the output equals the input unchanged.
+* `graft` - same call shape as `splice` (`𝐵-in`, sentinel, `𝐵-rep`) and the
+  same renaming guarantees, but every matched sentinel binding is replaced by
+  the renamed copy of `𝐵-rep` instead of preserved in place. Use it when the
+  marker must not survive the substitution — for example, when fusing two
+  bodies that both produce the same effect and the original marker would fire
+  a second time. When no binding matches the sentinel, the output equals the
+  input unchanged.
 
 ## Meta variables
 

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -45,6 +45,7 @@ buildTerm' "number" = _number
 buildTerm' "sum" = _sum
 buildTerm' "join" = _join
 buildTerm' "splice" = _splice
+buildTerm' "graft" = _graft
 buildTerm' func = _unsupported func
 
 argToBytes :: Y.ExtraArgument -> Subst -> IO Bytes
@@ -250,14 +251,20 @@ _join args subst = do
         _ -> AtLabel "unknown"
 
 _splice :: BuildTermMethod
-_splice [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subst = do
+_splice = _spliceLike "splice" True
+
+_graft :: BuildTermMethod
+_graft = _spliceLike "graft" False
+
+_spliceLike :: String -> Bool -> BuildTermMethod
+_spliceLike name keepMarker [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subst = do
   inBds <- buildBindingThrows inArg subst
   repBds <- buildBindingThrows repArg subst
   mapM_ validateRep repBds
   (sentinel, _) <- buildExpressionThrows sentExpr subst
   let avoid = map Y.ArgAttribute (attributesFromBindings (inBds ++ repBds))
-  spliced <- splice inBds sentinel repBds avoid
-  pure (TeBindings spliced)
+  result <- walk inBds sentinel repBds avoid
+  pure (TeBindings result)
   where
     validateRep :: Binding -> IO ()
     validateRep (BiTau (AtLabel _) _) = pure ()
@@ -266,19 +273,20 @@ _splice [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subs
       throwIO
         ( userError
             ( printf
-                "Function splice() can only rename τ-labelled bindings in the replacement group, but got '%s' which would produce duplicates when spliced more than once"
+                "Function %s() can only rename τ-labelled bindings in the replacement group, but got '%s' which would produce duplicates when applied at more than one position"
+                name
                 (printBinding bd)
             )
         )
-    splice :: [Binding] -> Expression -> [Binding] -> [Y.ExtraArgument] -> IO [Binding]
-    splice [] _ _ _ = pure []
-    splice (bd : rest) sent rep avoid
+    walk :: [Binding] -> Expression -> [Binding] -> [Y.ExtraArgument] -> IO [Binding]
+    walk [] _ _ _ = pure []
+    walk (bd : rest) sent rep avoid
       | matches sent bd = do
           fresh <- traverse (renamed avoid) rep
-          tail' <- splice rest sent rep avoid
-          pure (fresh ++ bd : tail')
+          tail' <- walk rest sent rep avoid
+          pure (fresh ++ (if keepMarker then bd : tail' else tail'))
       | otherwise = do
-          tail' <- splice rest sent rep avoid
+          tail' <- walk rest sent rep avoid
           pure (bd : tail')
     matches :: Expression -> Binding -> Bool
     matches sent (BiTau _ (ExFormation bds)) = any (isPhi sent) bds
@@ -291,14 +299,15 @@ _splice [Y.ArgBinding inArg, Y.ArgExpression sentExpr, Y.ArgBinding repArg] subs
       term <- _randomTau avoid subst
       case term of
         TeAttribute attr -> pure (BiTau attr expr)
-        _ -> throwIO (userError "Failed to generate fresh tau attribute for splice")
+        _ -> throwIO (userError (printf "Failed to generate fresh tau attribute for %s" name))
     renamed avoid (BiVoid (AtLabel _)) = do
       term <- _randomTau avoid subst
       case term of
         TeAttribute attr -> pure (BiVoid attr)
-        _ -> throwIO (userError "Failed to generate fresh tau attribute for splice")
+        _ -> throwIO (userError (printf "Failed to generate fresh tau attribute for %s" name))
     renamed _ bd = pure bd
-_splice _ _ = throwIO (userError "Function splice() requires exactly 3 arguments: input bindings, sentinel expression, replacement bindings")
+_spliceLike name _ _ _ =
+  throwIO (userError (printf "Function %s() requires exactly 3 arguments: input bindings, sentinel expression, replacement bindings" name))
 
 _unsupported :: BuildTermFunc
 _unsupported func _ _ = throwIO (userError (printf "Function %s() is not supported or does not exist" func))

--- a/test-resources/rewriter-packs/custom/graft-replaces-marker.yaml
+++ b/test-resources/rewriter-packs/custom/graft-replaces-marker.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+input: |
+  Q -> [[
+    cps -> [[
+      a -> [[ @ ->Q.hone.emit ]],
+      x -> [[ @ ->Q.jeo.opcode.iconst_0 ]],
+      b -> [[ @ ->Q.hone.emit ]],
+      y -> [[ @ ->Q.jeo.opcode.iconst_1 ]],
+      c -> [[ @ ->Q.hone.emit ]]
+    ]],
+    auto -> [[
+      r1 -> [[ @ ->Q.jeo.opcode.iadd ]],
+      r2 -> [[ @ ->Q.jeo.opcode.istore ]]
+    ]]
+  ]]
+output: |-
+  Φ ↦ ⟦
+    n ↦ 8
+  ⟧
+rules:
+  custom:
+    - name: graft and count
+      pattern: |
+        [[
+          cps -> [[ !B-cps, ^ -> ? ]],
+          auto -> [[ !B-auto, ^ -> ? ]]
+        ]]
+      result: '[[ n -> !e ]]'
+      where:
+        - meta: '!B-grafted'
+          function: graft
+          args:
+            - '!B-cps'
+            - 'Φ.hone.emit'
+            - '!B-auto'
+        - meta: '!e'
+          function: size
+          args: ['!B-grafted']

--- a/test/FunctionsSpec.hs
+++ b/test/FunctionsSpec.hs
@@ -145,6 +145,108 @@ spec = describe "Functions" $ do
         ) ::
         IO (Either IOError ())
     outcome `shouldSatisfy` isLeft
+  Test.Hspec.it "grafts replacement in place of every sentinel match" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        bar = ExDispatch ExGlobal (AtLabel "bar")
+        cpsBody =
+          [ phiBinding "x" foo
+          , phiBinding "emit1" emit
+          , phiBinding "y" bar
+          , phiBinding "emit2" emit
+          ]
+        autoBody =
+          [ phiBinding "add1" foo
+          , phiBinding "add2" bar
+          ]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings cpsBody)
+                , ("B-rep", MvBindings autoBody)
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "graft"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    bds <- uniqueBindings' result
+    logDebug (printf "Grafted bindings:\n%s" (printExpression (ExFormation bds)))
+    map bodyOf bds
+      `shouldBe` [ Just foo
+                 , Just foo
+                 , Just bar
+                 , Just bar
+                 , Just foo
+                 , Just bar
+                 ]
+  Test.Hspec.it "returns the input unchanged when graft finds no sentinel" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        body = [phiBinding "x" foo, phiBinding "y" foo]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings [phiBinding "z" foo])
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "graft"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    result `shouldBe` body
+  Test.Hspec.it "produces only unique attributes for many graft positions" $ do
+    let foo = ExDispatch ExGlobal (AtLabel "foo")
+        body = [phiBinding (T.pack ('e' : show i)) emit | i <- [1 .. 5 :: Int]]
+        rep = [phiBinding "a" foo, phiBinding "b" foo]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings rep)
+                ]
+            )
+    TeBindings result <-
+      buildTerm
+        "graft"
+        [ ArgBinding (BiMeta "B-in")
+        , ArgExpression emit
+        , ArgBinding (BiMeta "B-rep")
+        ]
+        subst
+    bds <- uniqueBindings' result
+    bds `shouldSatisfy` ((== 5 * length rep) . length)
+  Test.Hspec.it "fails fast when graft replacement contains a non-label binding" $ do
+    let body = [phiBinding "e1" emit, phiBinding "e2" emit]
+        rep = [phiBinding "a" emit, BiVoid AtRho]
+        subst =
+          Subst
+            ( Map.fromList
+                [ ("B-in", MvBindings body)
+                , ("B-rep", MvBindings rep)
+                ]
+            )
+    outcome <-
+      try
+        ( void
+            ( buildTerm
+                "graft"
+                [ ArgBinding (BiMeta "B-in")
+                , ArgExpression emit
+                , ArgBinding (BiMeta "B-rep")
+                ]
+                subst
+            )
+        ) ::
+        IO (Either IOError ())
+    outcome `shouldSatisfy` isLeft
   where
     isLeft :: Either a b -> Bool
     isLeft (Left _) = True


### PR DESCRIPTION
This adds a new `graft` where-function next to `splice` in `src/Functions.hs`. It accepts the same three arguments — input bindings, sentinel expression, replacement bindings — and applies the same `τ`-label renaming via `random-tau`, but at every sentinel match it puts the renamed copy of the replacement group in place of the marker instead of in front of it.

The existing `splice` is the right tool when the marker must survive (so it fires after the inserted body), but there are fusion rules where the marker must not survive — for example merging two cps bodies that each end in `Φ.hone.emit`, where keeping the original marker would emit a second item against an empty stack. Hand-rolling the marker-drop on top of `splice` does not work because the replacement body may carry its own emits, so a follow-up pattern cannot tell the original marker apart from the new ones. `graft` keeps the operation atomic and the rule self-documenting.

The recursion in `splice` is factored into a shared helper that takes a `keepMarker` flag, so the only behavioural difference is the one branch that drops `bd` from the spliced output. Validation, sentinel matching, fresh `τ`-renaming, and the avoidance set are reused verbatim. README is updated, and tests cover the happy path, the no-match identity case, the all-unique invariant across many positions, and the fail-fast guard on non-label replacement bindings; a YAML rewriter pack exercises `graft` end-to-end through the rule engine.

Closes #721