### PR TITLE
Make where-clause `args` optional, defaulting to `[]`

### DIFF
--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -120,7 +120,15 @@ instance FromJSON ExtraArgument where
       ]
 
 instance FromJSON Extra where
-  parseJSON = genericParseJSON defaultOptions
+  parseJSON =
+    withObject
+      "Extra"
+      ( \o ->
+          Extra
+            <$> o .: "meta"
+            <*> o .: "function"
+            <*> o .:? "args" .!= []
+      )
 
 instance FromJSON Rule where
   parseJSON =

--- a/test-resources/rewriter-packs/custom/random-tau-mints-fresh.yaml
+++ b/test-resources/rewriter-packs/custom/random-tau-mints-fresh.yaml
@@ -15,4 +15,3 @@ rules:
       where:
         - meta: '!a'
           function: random-tau
-          args: []

--- a/test-resources/rewriter-packs/custom/random-tau-skips-program-wide.yaml
+++ b/test-resources/rewriter-packs/custom/random-tau-skips-program-wide.yaml
@@ -25,4 +25,3 @@ rules:
       where:
         - meta: '!a'
           function: random-tau
-          args: []

--- a/test-resources/yaml-packs/where-without-args.yaml
+++ b/test-resources/yaml-packs/where-without-args.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A 'where' extension may omit the 'args' key entirely; it defaults to an
+# empty list. 'random-tau' takes no arguments, so it is written argless.
+name: where-without-args
+pattern: |
+  [[ x -> !e ]]
+result: |
+  [[ x -> !e, !a -> [[ ]], ^ -> ? ]]
+where:
+  - meta: '!a'
+    function: random-tau


### PR DESCRIPTION
Fixes #738.

## Problem

After #728, `random-tau` scans the document for taken names and accepts no runtime arguments. But the YAML schema still mandated an `args` key: `Extra` declares `args :: [ExtraArgument]` and derived its decoder via `genericParseJSON defaultOptions`. Because `args` is a plain list rather than `Maybe` (unlike `Rule`'s `when`/`where_`/`having`), a `where` entry that omitted `args` failed to decode with:

```
Error in $.where[0]: ... key "args" not found
```

So the argless form promised by #728 didn't actually parse — downstream `hone-maven-plugin` (which dropped its `args: []` lines) no longer parsed against `0.0.0.72`.

## Fix

Replace the derived `FromJSON Extra` instance with a hand-written `parseJSON` that reads `args` via `o .:? "args" .!= []`. The field now defaults to an empty list when omitted.

- Argless `where` clauses now decode.
- Existing `args: []` and `args: [...]` clauses keep decoding (backward compatible).
- Runtime arity checks in `Functions.hs` still reject misuse.

## Tests

- Added `test-resources/yaml-packs/where-without-args.yaml`, a rule whose `where` clause omits `args` (exercised by `YamlSpec`'s "parses yaml rule" suite).
- Dropped the now-redundant `args: []` from the two `random-tau` rewriter packs, matching the argless form.

Note: no Haskell toolchain was available in the build environment, so the change was not compiled locally; CI should validate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVz4Fi1MTDX6Z7tyRUTMPP)_