### PR TITLE
Fix incorrect injection of additional void ρ binding (#748)

### DIFF
--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -25,12 +25,14 @@ bdWithVoidRho :: BINDING -> BINDING
 bdWithVoidRho BI_EMPTY{..} = BI_PAIR voidRho (BDS_EMPTY tab) tab
 bdWithVoidRho bd@BI_PAIR{pair = PA_VOID{attr = AT_RHO _}} = bd
 bdWithVoidRho bd@BI_PAIR{pair = PA_TAU{attr = AT_RHO _}} = bd
+bdWithVoidRho bd@BI_PAIR{pair = PA_FORMATION{attr = AT_RHO _}} = bd
 bdWithVoidRho BI_PAIR{..} = BI_PAIR pair (bdsWithVoidRho bindings) tab
   where
     bdsWithVoidRho :: BINDINGS -> BINDINGS
     bdsWithVoidRho BDS_EMPTY{..} = BDS_PAIR EOL tab voidRho (BDS_EMPTY tab)
     bdsWithVoidRho bds@BDS_PAIR{pair = PA_VOID{attr = AT_RHO _}} = bds
     bdsWithVoidRho bds@BDS_PAIR{pair = PA_TAU{attr = AT_RHO _}} = bds
+    bdsWithVoidRho bds@BDS_PAIR{pair = PA_FORMATION{attr = AT_RHO _}} = bds
     bdsWithVoidRho BDS_PAIR{..} = BDS_PAIR eol tab pair (bdsWithVoidRho bindings)
     bdsWithVoidRho bds@BDS_META{} = bds
 bdWithVoidRho bd@BI_META{} = bd

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -71,6 +71,28 @@ spec = do
           it desc (printProgram prog `shouldBe` expected)
       )
 
+  describe "printProgram in salty does not inject a duplicate void rho when rho is already present" $
+    forM_
+      [
+        ( "rho bound to an empty formation"
+        , Program (ExFormation [BiTau AtRho (ExFormation [BiVoid AtRho])])
+        , "Φ ↦ ⟦ ρ ↦ ⟦ ρ ↦ ∅ ⟧ ⟧"
+        )
+      ,
+        ( "rho bound to a non empty formation"
+        , Program (ExFormation [BiTau AtRho (ExFormation [BiVoid (AtLabel "名前"), BiVoid AtRho])])
+        , "Φ ↦ ⟦ ρ ↦ ⟦ 名前 ↦ ∅, ρ ↦ ∅ ⟧ ⟧"
+        )
+      ,
+        ( "rho binding placed after another binding"
+        , Program (ExFormation [BiTau (AtLabel "café") ExGlobal, BiTau AtRho (ExFormation [BiVoid AtRho])])
+        , "Φ ↦ ⟦ café ↦ Φ, ρ ↦ ⟦ ρ ↦ ∅ ⟧ ⟧"
+        )
+      ]
+      ( \(desc, prog, expected) ->
+          it desc (printProgram' prog (SALTY, UNICODE, SINGLELINE, defaultMargin) `shouldBe` expected)
+      )
+
   describe "printAttribute with default encoding" $
     forM_
       [ ("label", AtLabel "attr", "attr")


### PR DESCRIPTION
Closes #748.

## Problem

```bash
echo '{⟦ρ↦⟦⟧⟧}' | phino rewrite
```

produced `Φ ↦ ⟦ ρ ↦ ⟦ ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧` — an extra `ρ ↦ ∅` was injected into a formation that already had a `ρ` binding. Expected: `Φ ↦ ⟦ ρ ↦ ⟦ ρ ↦ ∅ ⟧ ⟧`.

## Root cause

The parsed AST is correct; the duplicate is added at the **print step**. `rewrite` prints in salty by default, which runs `toSalty`. There, `bdWithVoidRho` (`src/Sugar.hs`) decides whether a formation needs a trailing `ρ ↦ ∅` appended. It recognized an existing `ρ` binding only as `PA_VOID{attr = AT_RHO}` or `PA_TAU{attr = AT_RHO}` — but not as `PA_FORMATION{attr = AT_RHO}`, the inline-voids sugar used for `ρ ↦ ⟦…⟧`. So it wrongly concluded `ρ` was absent and appended a duplicate.

## Fix

Added the missing `PA_FORMATION{attr = AT_RHO _}` case to both the head (`bdWithVoidRho`) and tail (`bdsWithVoidRho`) matchers, completing coverage of all three `PAIR` constructors that can carry a `ρ` attribute.

## Tests

Added regression tests to `PrinterSpec.hs` covering the issue's case, a `ρ`-formation with extra inner voids, and a `ρ` binding placed in the bindings tail (exercises the tail path). Full suite passes (`1041 examples, 0 failures`); `hlint` and `fourmolu` are clean.