### PR TITLE
Relax '!t' tail matching to allow application-led tails

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,8 @@ This is the list of supported meta variables:
                 `nf:` guard is needed)
 * `!B` || `𝐵` - list of bindings
 * `!d` || `δ` - bytes in meta delta binding
-* `!t` - tail after expression, sequence of applications and/or dispatches,
-         must start only with dispatch
+* `!t` - tail after expression, a possibly empty sequence of applications
+         and/or dispatches
 * `!F` - function name in meta lambda binding
 
 Every meta variable may also be used with an integer index, like `!B1` or `𝜏0`.

--- a/src/Matcher.hs
+++ b/src/Matcher.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
@@ -109,15 +107,8 @@ tailExpressions ptn tgt = case tailExpressionsReversed ptn tgt of
           (substs, tails) <- tailExpressionsReversed ptn' expr
           Just (substs, TaDispatch attr : tails)
         ExApplication expr tau -> do
-          (substs, tails@(t : _)) <- tailExpressionsReversed ptn' expr
-          if not (null tails) && isDispatch t
-            then Just (substs, TaApplication tau : tails)
-            else Nothing
-          where
-            isDispatch :: Tail -> Bool
-            isDispatch = \case
-              TaDispatch _ -> True
-              TaApplication _ -> False
+          (substs, tails) <- tailExpressionsReversed ptn' expr
+          Just (substs, TaApplication tau : tails)
         _ -> Just ([], [])
       substs -> Just (substs, [])
 

--- a/test/MatcherSpec.hs
+++ b/test/MatcherSpec.hs
@@ -409,6 +409,12 @@ spec = do
         , substs [[("t", MvTail [TaDispatch (AtLabel "org"), TaApplication (BiTau (AtLabel "x") (ExFormation [BiVoid AtRho]))])]]
         )
       ,
+        ( "Q.x * !t => Q.x(y -> [[]]) => [(!t >> [(y -> [[]])])]"
+        , ExMetaTail (ExDispatch ExGlobal (AtLabel "x")) "t"
+        , ExApplication (ExDispatch ExGlobal (AtLabel "x")) (BiTau (AtLabel "y") (ExFormation [BiVoid AtRho]))
+        , substs [[("t", MvTail [TaApplication (BiTau (AtLabel "y") (ExFormation [BiVoid AtRho]))])]]
+        )
+      ,
         ( "Q.!a * !t => Q.org.eolang(x -> [[]]) => [(!a >> org, !t >> [ .eolang, ( x -> [[ ]] ) ])]"
         , ExMetaTail (ExDispatch ExGlobal (AtMeta "a")) "t"
         , ExApplication (ExDispatch (ExDispatch ExGlobal (AtLabel "org")) (AtLabel "eolang")) (BiTau (AtLabel "x") (ExFormation [BiVoid AtRho]))


### PR DESCRIPTION
Fixes #765.

`Matcher.tailExpressions` rejected any `!t` tail that **started with an application**: its `ExApplication` branch only peeled an application when the head-ward part had already produced a **non-empty** tail led by a **dispatch**. This made `!t` stricter than both the grammar (which parses `* !t` for any head) and the morphing rules' `• t` continuation — so `Q.x * !t` could not match `Q.x(y -> [[]])`. Since every number is `Φ.number(<bytes>)` and atoms are applications, this blocks rule-driven morphing of all arithmetic (the executor falls through to the stuck case).

## Fix

Make the `ExApplication` branch symmetric with the `ExDispatch` branch — the tail may now begin with an application:

```haskell
ExApplication expr tau -> do
  (substs, tails) <- tailExpressionsReversed ptn' expr
  Just (substs, TaApplication tau : tails)
```

Drops the now-unused `isDispatch` helper and the `LambdaCase` pragma, and updates the README wording for `!t`.

## Why it's safe

- `!t` is used only by the (not-yet-active) morphing rules; **no normalization rule uses a meta-tail**, so the rewriter is unaffected.
- The change is a strict superset: every existing dispatch-led `MatcherSpec` tail case still matches identically.
- Full suite green (1063 examples, `-Werror`), `hlint` and `fourmolu` clean, `markdownlint` clean.

## Test

Added a `MatcherSpec` case that fails before the fix and passes after:

```
Q.x * !t  =>  Q.x(y -> [[]])  =>  [(!t >> [(y -> [[]])])]
```

## Background

The corresponding paper inconsistency (the `foundations.tex` head/tail definition forbids application-led tails, contradicting how `operators.tex` uses `• t`) is filed as objectionary/calculus-paper#27. This unblocks the execution-driven driver in #760 (draft PR #764).
