### PR TITLE
Render data-bytes meta as \delta in explain output

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -88,7 +88,7 @@ data META_HEAD
   | B -- 𝐵
   | B' -- B
   | D -- δ
-  | D' -- d
+  | D' -- \delta
   | TAIL -- t
   | F -- F
   deriving (Eq, Show)

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -244,7 +244,8 @@ instance ToLaTeX BINDINGS where
   toLaTeX bds = bds
 
 instance ToLaTeX PAIR where
-  toLaTeX PA_DELTA{..} = PA_DELTA' bytes
+  toLaTeX PA_DELTA{..} = toLaTeX (PA_DELTA' bytes)
+  toLaTeX PA_DELTA'{..} = PA_DELTA' (toLaTeX bytes)
   toLaTeX PA_LAMBDA{..} = PA_LAMBDA' (piped func)
   toLaTeX PA_LAMBDA'{..} = PA_LAMBDA' (piped func)
   toLaTeX PA_VOID{..} = PA_VOID (toLaTeX attr) arrow void
@@ -254,7 +255,6 @@ instance ToLaTeX PAIR where
   toLaTeX PA_META_DELTA'{..} = PA_META_DELTA' (toLaTeX meta)
   toLaTeX PA_META_LAMBDA{..} = toLaTeX (PA_META_LAMBDA' meta)
   toLaTeX PA_META_LAMBDA'{..} = PA_META_LAMBDA' (toLaTeX meta)
-  toLaTeX pair = pair
 
 instance ToLaTeX META where
   toLaTeX META{..} =
@@ -270,6 +270,10 @@ instance ToLaTeX META_HEAD where
   toLaTeX B = B'
   toLaTeX D = D'
   toLaTeX mh = mh
+
+instance ToLaTeX BYTES where
+  toLaTeX (BT_META meta) = BT_META (toLaTeX meta)
+  toLaTeX bts = bts
 
 instance ToLaTeX APP_ARG where
   toLaTeX APP_ARG{..} = APP_ARG (toLaTeX expr) (toLaTeX args)
@@ -366,7 +370,7 @@ explainDataizeRule rule =
     dataizeOutcome :: Y.DataizeOutcome -> String
     dataizeOutcome (Y.DoDataize (Y.DaExpr expr)) = dataize (renderToLatex (expressionToCST expr) defaultLatexContext)
     dataizeOutcome (Y.DoDataize (Y.DaMorph expr)) = dataize (morph (renderToLatex (expressionToCST expr) defaultLatexContext))
-    dataizeOutcome (Y.DoData bytes) = T.unpack (render (toCST' bytes :: BYTES))
+    dataizeOutcome (Y.DoData bytes) = T.unpack (render (toLaTeX (toCST' bytes :: BYTES)))
     dataizeOutcome Y.DoNothing = "\\varnothing"
 
 -- Render a single rule row through the shared \trrule macro: name, left-hand

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -120,7 +120,7 @@ instance Render META_HEAD where
   render B = "𝐵"
   render B' = "B"
   render D = "δ"
-  render D' = "d"
+  render D' = "\\delta"
   render TAIL = "t"
   render F = "F"
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1044,8 +1044,8 @@ spec = do
         [ unlines
             [ "\\begin{tabular}{rl}"
             , "\\trrule{delta}"
-            , "  { \\mathbb{D}( [[ B_1, D> δ, B_2 ]] ) }"
-            , "  { δ }"
+            , "  { \\mathbb{D}( [[ B_1, D> \\delta, B_2 ]] ) }"
+            , "  { \\delta }"
             , "  { }"
             , "  { }"
             , "\\trrule{box}"


### PR DESCRIPTION
Running `phino explain --dataize` printed the raw Unicode glyph δ for the data-bytes meta, both in the match clause and in the result column, instead of a proper LaTeX command. The rest of the table already uses LaTeX commands (for example the tau meta renders as `\tau`), so the stray δ stood out and would not typeset correctly.

The bytes carried by a delta binding were never passed through `toLaTeX`, so the byte meta head kept its Unicode form. This adds a `ToLaTeX` instance for bytes, threads the conversion through both the match and the result paths, and renders the byte meta as `\delta` to match the `\tau` convention.

One thing left untouched: the capital Δ attribute in the box rule's `if` condition is still emitted as Unicode. That is a separate symbol from the lowercase data meta this PR fixes, so I left it for a follow-up rather than widening the scope here.