### PR TITLE
Unify version scheme to 4 components (0.0.0.N) everywhere

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Upload phino binary to S3
         shell: bash
         run: |
-          aws s3 cp dist-release/${{ runner.os == 'Windows' && 'phino.exe' || 'phino' }} s3://${{ secrets.S3_BUCKET }}/releases/${{ matrix.os }}/phino-0.${{ github.ref_name }}${{ runner.os == 'Windows' && '.exe' || '' }} --acl public-read
+          aws s3 cp dist-release/${{ runner.os == 'Windows' && 'phino.exe' || 'phino' }} s3://${{ secrets.S3_BUCKET }}/releases/${{ matrix.os }}/phino-${{ github.ref_name }}${{ runner.os == 'Windows' && '.exe' || '' }} --acl public-read
       - name: Upload as phino-latest
         shell: bash
         run: |

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -21,7 +21,7 @@ jobs:
       - run: |-
           git fetch --tags --force && \
           latest=$(git tag --sort=creatordate | tail -1) && \
-          sed -E -i "s/phino-[0-9.]+/phino-0.${latest}/g" README.md
+          sed -E -i "s/phino-[0-9.]+/phino-${latest}/g" README.md
       - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -18,15 +18,15 @@ install: |
 release:
   pre: false
   script: |
-    [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
-    sed -i "s/0\.0\.0\.0/0.${tag}/" phino.cabal
+    [[ "${tag}" =~ ^0\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
+    sed -i "s/0\.0\.0\.0/${tag}/" phino.cabal
     chmod 755 ../hackage-auth
     cabal check
     make binary
     cabal test
     git commit -am "set version to ${tag}"
     cabal sdist
-    cabal upload --token=$(cat ../hackage-auth) --publish dist-newstyle/sdist/phino-0.${tag}.tar.gz
+    cabal upload --token=$(cat ../hackage-auth) --publish dist-newstyle/sdist/phino-${tag}.tar.gz
 merge:
   script: |-
     make -j


### PR DESCRIPTION
Closes #774.

Standardizes the version scheme on **4 components everywhere** so the Git tag equals the published version, and removes the hidden `0.` prefix the release pipeline used to prepend.

## Why

A 3-component Git tag (`0.0.75`) was turned into a 4-component published version (`0.0.0.75`) by a hardcoded `0.` prefix, so the tag never matched what `--version`, Hackage, and the S3 binary reported.

## Changes

- `.rultor.yml`: `@rultor release` now requires a 4-component tag with a leading `0` (`^0\.[0-9]+\.[0-9]+\.[0-9]+$`) and aborts (`exit -1`) otherwise; the tag is `sed` verbatim into the cabal version; uploads `phino-${tag}.tar.gz`.
- `release-binary.yml`: S3 artifact named `phino-${ref_name}`.
- `up.yml`: README synced with `phino-${latest}`.

The leading `0` permanently encodes the pre-1.0 "version 0" concept; a tag like `1.2.0.3` is rejected until that line is deliberately changed.

Historical 3-component tags are left untouched — the authoritative Hackage history is already 4-component (`0.0.0.59 … 0.0.0.75`). Next release tag: `0.0.0.76`.

## Note for after merge

If `up.yml` runs on the master push *before* the first 4-component release, `latest` still resolves to `0.0.75` and it would open a version-up PR setting README to `phino-0.0.75`. It self-heals on the first 4-component release, so cut `0.0.0.76` right after merging.
