### PR TITLE
Use 3 components everywhere (0.0.N), including Hackage

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -35,5 +35,5 @@ jobs:
       - run: cabal haddock --haddock-hyperlink-source
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: dist-newstyle/build/aarch64-osx/ghc-${{ env.GHC_VERSION }}/phino-0.0.0.0/doc/html/phino
+          folder: dist-newstyle/build/aarch64-osx/ghc-${{ env.GHC_VERSION }}/phino-0.0.0/doc/html/phino
           branch: gh-pages

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -18,8 +18,8 @@ install: |
 release:
   pre: false
   script: |
-    [[ "${tag}" =~ ^0\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
-    sed -i "s/0\.0\.0\.0/${tag}/" phino.cabal
+    [[ "${tag}" =~ ^0\.[0-9]+\.[0-9]+$ ]] || exit -1
+    sed -i "s/^version: 0\.0\.0$/version: ${tag}/" phino.cabal
     chmod 755 ../hackage-auth
     cabal check
     make binary

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Verify that `phino` is installed correctly:
 
 ```bash
 $ phino --version
-0.0.0.0
+0.0.0
 ```
 
 You can ensure scripts are run with a specific version of `phino` using

--- a/phino.cabal
+++ b/phino.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: phino
-version: 0.0.0.0
+version: 0.0.0
 license: MIT
 synopsis: Command-Line Manipulator of 𝜑-Calculus Expressions
 description: Please see the README on GitHub at <https://github.com/objectionary/phino#readme>


### PR DESCRIPTION
Closes #774.

Reverts the 4-component scheme merged in #777 and switches to **3 components everywhere, including Hackage**.

## Why 3 components

- Matches the existing Git tag history exactly (`0.0.74`, `0.0.75`, …) — no change to the tag format.
- `cabal check` accepts a 3-component version (verified: *"No errors or warnings"*); PVP recommends but does not require 4.
- Hackage ordering stays valid: `0.0.76` > `0.0.0.75` (the last 4-component release), so the next upload is a clean increase.

## Changes

- `phino.cabal`: placeholder `0.0.0.0` → `0.0.0`.
- `.rultor.yml`: `@rultor release` now requires a 3-component tag with a leading `0` (`^0\.[0-9]+\.[0-9]+$`) and aborts otherwise; the tag is `sed` into the cabal `version:` line (anchored to avoid collisions).
- `haddock.yml`: build-dir path → `phino-0.0.0` (follows the cabal version).
- `README.md`: the `phino --version` example prints `0.0.0` (the dev placeholder).

`release-binary.yml` and `up.yml` already use the tag verbatim after #777, so they need no change. The leading `0` still encodes the pre-1.0 "version 0" concept.

Next release tag: `0.0.76`.
