### PR TITLE
Render Δ as \Delta in explain --dataize LaTeX output

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -46,7 +46,7 @@ data PHI = PHI | AT
 data RHO = RHO | CARET
   deriving (Eq, Show)
 
-data DELTA = DELTA
+data DELTA = DELTA | DELTA'
   deriving (Eq, Show)
 
 data XI = XI | DOLLAR

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -227,6 +227,7 @@ instance ToLaTeX ATTRIBUTE where
   toLaTeX AT_LABEL{..} = AT_LABEL (piped label)
   toLaTeX AT_META{..} = AT_META (toLaTeX meta)
   toLaTeX AT_LAMBDA{} = AT_LAMBDA LAMBDA'
+  toLaTeX AT_DELTA{} = AT_DELTA DELTA'
   toLaTeX AT_REST{} = AT_REST DOTS'
   toLaTeX attr = attr
 

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -70,6 +70,7 @@ instance Render RHO where
 
 instance Render DELTA where
   render DELTA = "Δ"
+  render DELTA' = "\\Delta"
 
 instance Render XI where
   render XI = "ξ"

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1051,7 +1051,7 @@ spec = do
             , "\\trrule{box}"
             , "  { \\mathbb{D}( [[ B_1, @ -> e, B_2 ]] ) }"
             , "  { \\mathbb{D}( e_1 ) }"
-            , "  { if $ [ Δ, L ] \\cap ( B_1 \\cup B_2 ) = \\emptyset $ }"
+            , "  { if $ [ \\Delta, L ] \\cap ( B_1 \\cup B_2 ) = \\emptyset $ }"
             , "  { where $ e_1 \\coloneqq \\ctx{ e }{ [[ B_1, @ -> e, B_2 ]] } $ }"
             , "\\trrule{norm}"
             , "  { \\mathbb{D}( e ) }"


### PR DESCRIPTION
Running `phino explain --dataize` was leaking a raw Unicode `Δ` into the generated LaTeX. In the `box` rule's disjoint condition the row came out as `[ Δ, L ]` — the `λ` attribute was already converted to `L`, but the `Δ` attribute slipped through untouched and printed the literal glyph. This change makes it emit `\Delta` instead, so the row now reads `[ \Delta, L ]`.

The cause was the `ToLaTeX ATTRIBUTE` instance in `src/LaTeX.hs`: it handled `AT_LAMBDA` but had no case for `AT_DELTA`, so the attribute fell through to the catch-all and rendered via `render DELTA = "Δ"`. I added a `DELTA'` token that renders as `\Delta` and a matching `AT_DELTA` case, mirroring how `AT_LAMBDA` is already handled. A raw Unicode glyph in math mode doesn't compile portably, which is why this matters for the academic LaTeX output.

The existing `explains dataization rules` test in `test/CLISpec.hs` was updated to expect `\Delta`, and the full suite passes under `-Werror` along with hlint and fourmolu.

Closes #780