### PR TITLE
Replace remaining "xi-free" naming with "absolute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Condition:
   | nf: Expression'      # returns True if given expression in normal form
                          # which means that no more other normalization rules
                          # can be applied
-  | absolute: Expression' # returns True if given expression is absolute in
-                         # structure: it is Φ, a formation, a dispatch with an
-                         # absolute subject, or an application with an absolute
-                         # subject and argument (equivalently, no ξ leaks
-                         # outside of a formation). Combined with a normal-form
-                         # check by the '𝑘'/'!k' meta variable, which ranges
-                         # over the absolute expressions 𝒦 ⊆ 𝒩, used by Rcopy.
+  | absolute: Expression' # returns True if given expression is absolute, i.e.
+                         # it is in normal form and is Φ, a formation, a
+                         # dispatch with an absolute subject, or an application
+                         # with an absolute subject and argument (equivalently,
+                         # no ξ leaks outside of a formation). Ranges over the
+                         # absolute expressions 𝒦 ⊆ 𝒩; used by the '𝑘'/'!k'
+                         # meta variable and the Rcopy rule.
   | matches:             # returns True if given expression after dataization
       - String           # matches to given regex
       - Expression

--- a/README.md
+++ b/README.md
@@ -300,11 +300,11 @@ Condition:
                          # can be applied
   | absolute: Expression' # returns True if given expression is absolute, i.e.
                          # ξ-free and in normal form: it is Φ, a formation, a
-                         # dispatch with a ξ-free subject, or an application with
-                         # a ξ-free subject and argument (no ξ leaks outside of a
-                         # formation) and it is in normal form. Ranges over the
-                         # absolute expressions 𝒦 ⊆ 𝒩; used by the '𝑘'/'!k' meta
-                         # variable and the Rcopy rule.
+                         # dispatch with a ξ-free subject, or an application
+                         # with a ξ-free subject and argument (no ξ leaks
+                         # outside of a formation) and it is in normal form.
+                         # Ranges over the absolute expressions 𝒦 ⊆ 𝒩; used by
+                         # the '𝑘'/'!k' meta variable and the Rcopy rule.
   | matches:             # returns True if given expression after dataization
       - String           # matches to given regex
       - Expression

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Condition:
   | nf: Expression'      # returns True if given expression in normal form
                          # which means that no more other normalization rules
                          # can be applied
-  | absolute: Expression' # returns True if given expression is absolute, i.e.
-                         # it is in normal form and is Φ, a formation, a
-                         # dispatch with an absolute subject, or an application
-                         # with an absolute subject and argument (equivalently,
-                         # no ξ leaks outside of a formation). Ranges over the
-                         # absolute expressions 𝒦 ⊆ 𝒩; used by the '𝑘'/'!k'
-                         # meta variable and the Rcopy rule.
+  | absolute: Expression' # returns True if given expression is absolute in
+                         # structure: it is Φ, a formation, a dispatch with an
+                         # absolute subject, or an application with an absolute
+                         # subject and argument (equivalently, no ξ leaks
+                         # outside of a formation). Combined with a normal-form
+                         # check by the '𝑘'/'!k' meta variable, which ranges
+                         # over the absolute expressions 𝒦 ⊆ 𝒩, used by Rcopy.
   | matches:             # returns True if given expression after dataization
       - String           # matches to given regex
       - Expression

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Condition:
   | nf: Expression'      # returns True if given expression in normal form
                          # which means that no more other normalization rules
                          # can be applied
-  | absolute: Expression' # returns True if given expression is absolute in
-                         # structure: it is Φ, a formation, a dispatch with an
-                         # absolute subject, or an application with an absolute
-                         # subject and argument (equivalently, no ξ leaks
-                         # outside of a formation). Combined with a normal-form
-                         # check by the '𝑘'/'!k' meta variable, which ranges
-                         # over the absolute expressions 𝒦 ⊆ 𝒩, used by Rcopy.
+  | absolute: Expression' # returns True if given expression is absolute, i.e.
+                         # ξ-free and in normal form: it is Φ, a formation, a
+                         # dispatch with a ξ-free subject, or an application with
+                         # a ξ-free subject and argument (no ξ leaks outside of a
+                         # formation) and it is in normal form. Ranges over the
+                         # absolute expressions 𝒦 ⊆ 𝒩; used by the '𝑘'/'!k' meta
+                         # variable and the Rcopy rule.
   | matches:             # returns True if given expression after dataization
       - String           # matches to given regex
       - Expression
@@ -382,10 +382,10 @@ This is the list of supported meta variables:
 * `!n` || `𝑛` - any expression that is already in normal form (behaves like
                 `!e`/`𝑒`, but only binds a sub-expression in NF, so no explicit
                 `nf:` guard is needed)
-* `!k` || `𝑘` - any expression that is absolute, i.e. absolute in structure
-                and in normal form (ranges over `𝒦 ⊆ 𝒩`); behaves like
-                `!e`/`𝑒` but only binds an absolute sub-expression, so no
-                explicit `absolute:` or `nf:` guard is needed
+* `!k` || `𝑘` - any expression that is absolute, i.e. ξ-free and in normal
+                form (ranges over `𝒦 ⊆ 𝒩`); behaves like `!e`/`𝑒` but only
+                binds an absolute sub-expression, so no explicit `absolute:`
+                or `nf:` guard is needed
 * `!B` || `𝐵` - list of bindings
 * `!d` || `δ` - bytes in meta delta binding
 * `!t` - tail after expression, a possibly empty sequence of applications

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ Condition:
   | nf: Expression'      # returns True if given expression in normal form
                          # which means that no more other normalization rules
                          # can be applied
-  | absolute: Expression' # returns True if given expression is xi-free, i.e.
-                         # there is no ξ outside of a formation: it is Φ, a
-                         # formation, a dispatch with a xi-free subject, or an
-                         # application with a xi-free subject and argument.
-                         # Combined with a normal-form check by the '𝑘'/'!k'
-                         # meta variable, which ranges over the absolute
-                         # expressions 𝒦 ⊆ 𝒩, used by the Rcopy rule.
+  | absolute: Expression' # returns True if given expression is absolute in
+                         # structure: it is Φ, a formation, a dispatch with an
+                         # absolute subject, or an application with an absolute
+                         # subject and argument (equivalently, no ξ leaks
+                         # outside of a formation). Combined with a normal-form
+                         # check by the '𝑘'/'!k' meta variable, which ranges
+                         # over the absolute expressions 𝒦 ⊆ 𝒩, used by Rcopy.
   | matches:             # returns True if given expression after dataization
       - String           # matches to given regex
       - Expression
@@ -382,10 +382,10 @@ This is the list of supported meta variables:
 * `!n` || `𝑛` - any expression that is already in normal form (behaves like
                 `!e`/`𝑒`, but only binds a sub-expression in NF, so no explicit
                 `nf:` guard is needed)
-* `!k` || `𝑘` - any expression that is absolute, i.e. xi-free and in normal
-                form (ranges over `𝒦 ⊆ 𝒩`); behaves like `!e`/`𝑒` but only
-                binds an absolute sub-expression, so no explicit `absolute:`
-                or `nf:` guard is needed
+* `!k` || `𝑘` - any expression that is absolute, i.e. absolute in structure
+                and in normal form (ranges over `𝒦 ⊆ 𝒩`); behaves like
+                `!e`/`𝑒` but only binds an absolute sub-expression, so no
+                explicit `absolute:` or `nf:` guard is needed
 * `!B` || `𝐵` - list of bindings
 * `!d` || `δ` - bytes in meta delta binding
 * `!t` - tail after expression, a possibly empty sequence of applications

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -175,12 +175,12 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   _ -> pure []
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
--- An expression is absolute (ranges over 𝒦 ⊆ 𝒩) when, being a normal form, it
--- is Φ, a formation, a dispatch with an absolute subject, or an application
--- with an absolute subject and argument (equivalently, no ξ leaks outside of a
--- formation). This checks that structure; the '𝑘' meta-variable applies this
--- check first (cheap, structural, rules out the recursion the normal-form check
--- could loop on) and the normal-form check second.
+-- Checks the structural part of absoluteness: an expression is absolute in
+-- structure when it is Φ, a formation, a dispatch with an absolute subject, or
+-- an application with an absolute subject and argument (equivalently, no ξ
+-- leaks outside of a formation). It does not enforce normal form on its own;
+-- the '𝑘' meta-variable combines this structural check (applied first, since it
+-- is cheap) with the normal-form check, so that 𝒦 ⊆ 𝒩.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
@@ -378,18 +378,14 @@ matchExpressionBy matcher expr rule ctx =
           logDebug (printf "Pattern from rule '%s' was not matched:\n%s" name (printExpression' ptn logPrintConfig))
           pure []
         else do
-          -- A '𝑘' meta-variable is absolute (𝒦 ⊆ 𝒩): check its absolute
-          -- structure first (cheap, structural), then fold its name into the
-          -- same normal-form check used for '𝑛' metas, so 'isNF' is applied in
-          -- a single place.
-          inAbsolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
-          inNf <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) inAbsolute (nfMetaNames ptn ++ kMetaNames ptn)
-          if null inNf
+          absolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
+          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn ++ kMetaNames ptn)
+          if null normal
             then do
               logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
               pure []
             else do
-              when' <- meetMaybeCondition rule.when inNf ctx
+              when' <- meetMaybeCondition rule.when normal ctx
               if null when'
                 then do
                   logDebug "The 'when' condition wasn't met"

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -175,17 +175,16 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   _ -> pure []
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
--- Checks the structural part of absoluteness, the ξ-free property: an
--- expression is ξ-free when it is Φ, a formation, a dispatch with a ξ-free
+-- An expression is absolute (it ranges over 𝒦 ⊆ 𝒩) when it is ξ-free and in
+-- normal form. It is ξ-free when it is Φ, a formation, a dispatch with a ξ-free
 -- subject, or an application with a ξ-free subject and argument (equivalently,
--- no ξ leaks outside of a formation). It does not enforce normal form on its
--- own; the '𝑘' meta-variable combines this structural check (applied first,
--- since it is cheap) with the normal-form check, so that 𝒦 ⊆ 𝒩.
+-- no ξ leaks outside of a formation). The ξ-free check is cheap, so it runs
+-- before the normal-form check.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
   _ -> pure []
-_absolute expr subst _ = pure [subst | xiFree expr]
+_absolute expr subst ctx = pure [subst | xiFree expr && isNF expr ctx]
   where
     xiFree :: Expression -> Bool
     xiFree (ExFormation _) = True
@@ -379,10 +378,10 @@ matchExpressionBy matcher expr rule ctx =
           pure []
         else do
           absolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
-          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn ++ kMetaNames ptn)
+          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn)
           if null normal
             then do
-              logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
+              logDebug "A '𝑛' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
               pure []
             else do
               when' <- meetMaybeCondition rule.when normal ctx

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -175,24 +175,24 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   _ -> pure []
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
--- An expression is absolute (it ranges over 𝒦 ⊆ 𝒩) when it is in normal form
--- and is Φ, a formation, a dispatch with an absolute subject, or an application
--- with an absolute subject and argument (equivalently, no ξ leaks outside of a
--- formation). Only a normal form may be absolute, so the structural shape and
--- the normal-form check are both required; the structural check is cheap, so it
--- runs first.
+-- Checks the structural part of absoluteness, the ξ-free property: an
+-- expression is ξ-free when it is Φ, a formation, a dispatch with a ξ-free
+-- subject, or an application with a ξ-free subject and argument (equivalently,
+-- no ξ leaks outside of a formation). It does not enforce normal form on its
+-- own; the '𝑘' meta-variable combines this structural check (applied first,
+-- since it is cheap) with the normal-form check, so that 𝒦 ⊆ 𝒩.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
   _ -> pure []
-_absolute expr subst ctx = pure [subst | absolute expr && isNF expr ctx]
+_absolute expr subst _ = pure [subst | xiFree expr]
   where
-    absolute :: Expression -> Bool
-    absolute (ExFormation _) = True
-    absolute ExGlobal = True
-    absolute (ExApplication e (BiTau _ te)) = absolute e && absolute te
-    absolute (ExDispatch e _) = absolute e
-    absolute _ = False
+    xiFree :: Expression -> Bool
+    xiFree (ExFormation _) = True
+    xiFree ExGlobal = True
+    xiFree (ExApplication e (BiTau _ te)) = xiFree e && xiFree te
+    xiFree (ExDispatch e _) = xiFree e
+    xiFree _ = False
 
 _matches :: String -> Expression -> Subst -> RuleContext -> IO [Subst]
 _matches pat (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
@@ -379,10 +379,10 @@ matchExpressionBy matcher expr rule ctx =
           pure []
         else do
           absolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
-          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn)
+          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn ++ kMetaNames ptn)
           if null normal
             then do
-              logDebug "A '𝑛' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
+              logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
               pure []
             else do
               when' <- meetMaybeCondition rule.when normal ctx

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -175,17 +175,17 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   _ -> pure []
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
--- Checks the structural part of absoluteness: an expression is absolute in
--- structure when it is Φ, a formation, a dispatch with an absolute subject, or
--- an application with an absolute subject and argument (equivalently, no ξ
--- leaks outside of a formation). It does not enforce normal form on its own;
--- the '𝑘' meta-variable combines this structural check (applied first, since it
--- is cheap) with the normal-form check, so that 𝒦 ⊆ 𝒩.
+-- An expression is absolute (it ranges over 𝒦 ⊆ 𝒩) when it is in normal form
+-- and is Φ, a formation, a dispatch with an absolute subject, or an application
+-- with an absolute subject and argument (equivalently, no ξ leaks outside of a
+-- formation). Only a normal form may be absolute, so the structural shape and
+-- the normal-form check are both required; the structural check is cheap, so it
+-- runs first.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
   _ -> pure []
-_absolute expr subst _ = pure [subst | absolute expr]
+_absolute expr subst ctx = pure [subst | absolute expr && isNF expr ctx]
   where
     absolute :: Expression -> Bool
     absolute (ExFormation _) = True
@@ -379,10 +379,10 @@ matchExpressionBy matcher expr rule ctx =
           pure []
         else do
           absolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
-          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn ++ kMetaNames ptn)
+          normal <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) absolute (nfMetaNames ptn)
           if null normal
             then do
-              logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
+              logDebug "A '𝑛' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
               pure []
             else do
               when' <- meetMaybeCondition rule.when normal ctx

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -175,24 +175,24 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   _ -> pure []
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
--- An expression is xi-free when it contains no ξ outside of a formation: it is
--- Φ, a formation, a dispatch with a xi-free subject, or an application with a
--- xi-free subject and argument. Together with a normal-form check this is what
--- makes an expression absolute (𝒦 ⊆ 𝒩); the '𝑘' meta-variable applies this
--- xi-free check first (cheap, structural, rules out the ξ-recursion the
--- normal-form check could loop on) and the normal-form check second.
+-- An expression is absolute (ranges over 𝒦 ⊆ 𝒩) when, being a normal form, it
+-- is Φ, a formation, a dispatch with an absolute subject, or an application
+-- with an absolute subject and argument (equivalently, no ξ leaks outside of a
+-- formation). This checks that structure; the '𝑘' meta-variable applies this
+-- check first (cheap, structural, rules out the recursion the normal-form check
+-- could loop on) and the normal-form check second.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
   _ -> pure []
-_absolute expr subst _ = pure [subst | xiFree expr]
+_absolute expr subst _ = pure [subst | absolute expr]
   where
-    xiFree :: Expression -> Bool
-    xiFree (ExFormation _) = True
-    xiFree ExGlobal = True
-    xiFree (ExApplication e (BiTau _ te)) = xiFree e && xiFree te
-    xiFree (ExDispatch e _) = xiFree e
-    xiFree _ = False
+    absolute :: Expression -> Bool
+    absolute (ExFormation _) = True
+    absolute ExGlobal = True
+    absolute (ExApplication e (BiTau _ te)) = absolute e && absolute te
+    absolute (ExDispatch e _) = absolute e
+    absolute _ = False
 
 _matches :: String -> Expression -> Subst -> RuleContext -> IO [Subst]
 _matches pat (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
@@ -378,14 +378,15 @@ matchExpressionBy matcher expr rule ctx =
           logDebug (printf "Pattern from rule '%s' was not matched:\n%s" name (printExpression' ptn logPrintConfig))
           pure []
         else do
-          -- A '𝑘' meta-variable is absolute (𝒦 ⊆ 𝒩): check it is xi-free first
-          -- (cheap, structural), then fold its name into the same normal-form
-          -- check used for '𝑛' metas, so 'isNF' is applied in a single place.
-          inXiFree <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
-          inNf <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) inXiFree (nfMetaNames ptn ++ kMetaNames ptn)
+          -- A '𝑘' meta-variable is absolute (𝒦 ⊆ 𝒩): check its absolute
+          -- structure first (cheap, structural), then fold its name into the
+          -- same normal-form check used for '𝑛' metas, so 'isNF' is applied in
+          -- a single place.
+          inAbsolute <- foldlM (\substs nm -> meetCondition (Y.Absolute (ExMeta nm)) substs ctx) matched (kMetaNames ptn)
+          inNf <- foldlM (\substs nm -> meetCondition (Y.NF (ExMeta nm)) substs ctx) inAbsolute (nfMetaNames ptn ++ kMetaNames ptn)
           if null inNf
             then do
-              logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not xi-free"
+              logDebug "A '𝑛'/'𝑘' meta-variable is not in normal form, or a '𝑘' meta-variable is not absolute"
               pure []
             else do
               when' <- meetMaybeCondition rule.when inNf ctx

--- a/test-resources/condition-packs/absolute-application.yaml
+++ b/test-resources/condition-packs/absolute-application.yaml
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# The application of a formation is a copy-redex, so '!e' is not in normal
+# form. Absolute means ξ-free and in normal form, so the condition must not
+# hold here.
+failure: true
 expression: '[[ x -> [[ y -> ? ]](y -> Q.z) ]]'
 pattern: '[[ x -> !e ]]'
 condition:

--- a/test-resources/condition-packs/absolute-application.yaml
+++ b/test-resources/condition-packs/absolute-application.yaml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# The application of a formation is a copy-redex, so '!e' is not in normal
+# form. Only a normal form may be absolute, so the condition must not hold.
+failure: true
 expression: '[[ x -> [[ y -> ? ]](y -> Q.z) ]]'
 pattern: '[[ x -> !e ]]'
 condition:

--- a/test-resources/condition-packs/absolute-application.yaml
+++ b/test-resources/condition-packs/absolute-application.yaml
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# The application of a formation is a copy-redex, so '!e' is not in normal
-# form. Only a normal form may be absolute, so the condition must not hold.
-failure: true
 expression: '[[ x -> [[ y -> ? ]](y -> Q.z) ]]'
 pattern: '[[ x -> !e ]]'
 condition:


### PR DESCRIPTION
Follow-up to #786 (issue #785).

@yegor256 noted that "xi-free" terminology was still in the code and everything should be phrased as **absolute**.

To clarify: the `CO_XIFREE` *constructor* was already removed in #786 (it's `CO_ABSOLUTE` now). What remained was the structural helper `xiFree` (plus the `inXiFree` binding, comments, a log message, and README wording). That recursion is exactly the formal absolute definition — Φ, a formation, a dispatch with an absolute subject, or an application with an absolute subject and argument — so this renames it to `absolute` and drops the "xi-free" naming everywhere.

**Pure rename, no behavioural change.** The `𝑘` meta still binds only absolute normal forms (absolute structure checked first, then normal form), and `isNF` is still applied in a single place.

⚠️ No GHC/Cabal toolchain in this environment, so I couldn't run `make test`/`hlint`/`fourmolu` locally — relying on CI.

https://claude.ai/code/session_01XDkkUWQv7ZZ4x8thamU8bQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDkkUWQv7ZZ4x8thamU8bQ)_