### PR TITLE
Preserve negative zero (-0.0) through parse/render pipeline

### DIFF
--- a/src/Misc.hs
+++ b/src/Misc.hs
@@ -310,6 +310,8 @@ toHex w = [digit (w `shiftR` 4), digit (w .&. 0x0F)]
 -- Right Infinity
 -- >>> btsToNum (BtMany ["FF", "F0", "00", "00", "00", "00", "00", "00"])
 -- Right (-Infinity)
+-- >>> btsToNum (BtMany ["80", "00", "00", "00", "00", "00", "00", "00"])
+-- Right (-0.0)
 btsToNum :: Bytes -> Either Int Double
 btsToNum hx =
   let bytes = btsToWord8 hx
@@ -318,7 +320,7 @@ btsToNum hx =
         else
           let word = toWord64BE bytes
               val = wordToDouble word
-           in if isNaN val || isInfinite val
+           in if isNaN val || isInfinite val || isNegativeZero val
                 then Right val
                 else case properFraction val of
                   (n, 0.0) -> Left n

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -177,11 +177,12 @@ number = do
   return
     ( DataNumber
         ( numToBts
-            ( toRealFloat
-                ( case sign of
-                    Just '-' -> negate unsigned
-                    _ -> unsigned
-                )
+            ( case sign of
+                -- Negate the Double rather than the Scientific so that a zero
+                -- literal preserves its sign: Scientific has no negative zero,
+                -- but negate on Double yields -0.0, a distinct IEEE-754 value.
+                Just '-' -> negate (toRealFloat unsigned)
+                _ -> toRealFloat unsigned
             )
         )
     )

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -356,6 +356,9 @@ spec = do
     test
       parseNumber
       [ ("0", Just (DataNumber (BtMany ["00", "00", "00", "00", "00", "00", "00", "00"])))
+      , ("-0", Just (DataNumber (BtMany ["80", "00", "00", "00", "00", "00", "00", "00"])))
+      , ("-0.0", Just (DataNumber (BtMany ["80", "00", "00", "00", "00", "00", "00", "00"])))
+      , ("+0", Just (DataNumber (BtMany ["00", "00", "00", "00", "00", "00", "00", "00"])))
       , ("1", Just (DataNumber (BtMany ["3F", "F0", "00", "00", "00", "00", "00", "00"])))
       , ("-1", Just (DataNumber (BtMany ["BF", "F0", "00", "00", "00", "00", "00", "00"])))
       , ("+1", Just (DataNumber (BtMany ["3F", "F0", "00", "00", "00", "00", "00", "00"])))


### PR DESCRIPTION
Fixes #793.

## Problem

`-0.0` and `+0.0` are distinct IEEE-754 values, but `phino` collapsed the sign in two places:

1. **`btsToNum` (`src/Misc.hs`)** — for bytes `80-00-00-00-00-00-00-00`, `wordToDouble` yields `-0.0`, which is neither NaN nor infinite, so `properFraction (-0.0)` returns `(0, 0.0)` and the `(n, 0.0) -> Left n` branch stored `Left 0`. The sweet renderer then printed the bare `Int` `0`, and on reassembly the value became `+0.0`.

2. **`number` parser (`src/Parser.hs`)** — the literal sign was applied via `negate` on the `Scientific` value, but `Scientific` has no negative zero, so even `-0.0` parsed to `+0.0`.

This surfaced in JEO→phino→JEO round-tripping of `org.json.JSONObject`, where `getNumber` returns `Double.valueOf(-0.0)`.

## Fix

- In `btsToNum`, guard the integral branch with `isNegativeZero val` so `-0.0` is returned as `Right val` (mirroring the existing NaN/Infinity guard added in #789/#790).
- In the `number` parser, negate the `Double` (after `toRealFloat`) rather than the `Scientific`, which yields a distinct `-0.0`.

## Tests

- Added a `btsToNum` doctest for `80-00-00-00-00-00-00-00 -> Right (-0.0)`.
- Added parser cases for `-0`, `-0.0`, and `+0` in `ParserSpec`.

Note: I was unable to run the Haskell test suite in this environment (no GHC/Cabal toolchain present), so CI verification is needed.

https://claude.ai/code/session_01UMXZzubf56smTRG4naSqpD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMXZzubf56smTRG4naSqpD)_