### PR TITLE
Speed up rewrite loop detection with a hashed program digest (#797)

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
@@ -6,6 +7,8 @@
 -- This module represents AST tree for parsed phi-calculus program
 module AST where
 
+import Data.Bits (xor)
+import Data.List (foldl')
 import Data.Text (Text)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
@@ -60,6 +63,70 @@ instance Show Attribute where
   show AtDelta = "Δ"
   show AtLambda = "λ"
   show (AtMeta meta) = '!' : T.unpack meta
+
+-- A cheap, fixed-size digest of an expression, used for fast (dirty) equality
+-- checks during loop detection. Equal expressions always produce the same
+-- digest, but distinct expressions may collide, so a positive digest match
+-- must always be confirmed with a full structural (==) comparison.
+hashExpression :: Expression -> Int
+hashExpression = goExpr fnvOffset
+  where
+    fnvPrime, fnvOffset :: Int
+    fnvPrime = 1099511628211
+    fnvOffset = 14695981039
+
+    -- FNV-1a style mixing step (Int multiplication wraps silently).
+    step :: Int -> Int -> Int
+    step h x = (h `xor` x) * fnvPrime
+
+    hashText :: Int -> Text -> Int
+    hashText = T.foldl' (\h c -> step h (fromEnum c))
+
+    hashString :: Int -> String -> Int
+    hashString = foldl' (\h c -> step h (fromEnum c))
+
+    hashMaybeString :: Int -> Maybe String -> Int
+    hashMaybeString h Nothing = step h 0
+    hashMaybeString h (Just s) = hashString (step h 1) s
+
+    goExpr :: Int -> Expression -> Int
+    goExpr h = \case
+      ExFormation bds -> foldl' goBinding (step h 1) bds
+      ExThis -> step h 2
+      ExGlobal -> step h 3
+      ExTermination -> step h 4
+      ExApplication ex bd -> goBinding (goExpr (step h 5) ex) bd
+      ExDispatch ex at -> goAttribute (goExpr (step h 6) ex) at
+      ExMeta t -> hashText (step h 7) t
+      ExMetaTail ex t -> hashText (goExpr (step h 8) ex) t
+      ExPhiMeet ms i ex -> goExpr (hashMaybeString (step (step h 9) i) ms) ex
+      ExPhiAgain ms i ex -> goExpr (hashMaybeString (step (step h 10) i) ms) ex
+
+    goBinding :: Int -> Binding -> Int
+    goBinding h = \case
+      BiTau at ex -> goExpr (goAttribute (step h 11) at) ex
+      BiDelta bts -> goBytes (step h 12) bts
+      BiVoid at -> goAttribute (step h 13) at
+      BiLambda t -> hashText (step h 14) t
+      BiMeta t -> hashText (step h 15) t
+      BiMetaLambda t -> hashText (step h 16) t
+
+    goBytes :: Int -> Bytes -> Int
+    goBytes h = \case
+      BtEmpty -> step h 17
+      BtOne s -> hashString (step h 18) s
+      BtMany ss -> foldl' hashString (step h 19) ss
+      BtMeta t -> hashText (step h 20) t
+
+    goAttribute :: Int -> Attribute -> Int
+    goAttribute h = \case
+      AtLabel t -> hashText (step h 21) t
+      AtAlpha i -> step (step h 22) i
+      AtPhi -> step h 23
+      AtRho -> step h 24
+      AtLambda -> step h 25
+      AtDelta -> step h 26
+      AtMeta t -> hashText (step h 27) t
 
 countNodes :: Expression -> Int
 countNodes (ExFormation bds) = 1 + sum (map nodesInBinding bds) + length bds

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -16,7 +16,7 @@ import Builder
 import Control.Exception (Exception, throwIO)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
-import qualified Data.Set as Set
+import qualified Data.Map.Strict as Map
 import Deps
 import Locator (locatedExpression, withLocatedExpression)
 import Logger (logDebug)
@@ -30,7 +30,23 @@ import qualified Rule as R
 import Text.Printf (printf)
 import qualified Yaml as Y
 
-type RewriteState = (NonEmpty Rewritten, Set.Set Expression, Bool)
+type RewriteState = (NonEmpty Rewritten, Seen, Bool)
+
+-- Loop-detection store. It maps a cheap fixed-size digest of a program (see
+-- 'hashExpression') to the full expressions that produced that digest. A
+-- digest collision is resolved by a slow, exact structural (==) comparison,
+-- so loops are still detected soundly while the common (no collision) case
+-- stays O(1) on the digest instead of O(programSize) per lookup/insert.
+type Seen = Map.Map Int [Expression]
+
+-- Has this exact program been seen before? The digest lookup is fast; the
+-- (==) check runs only on a digest match, guarding against hash collisions.
+seenMember :: Int -> Expression -> Seen -> Bool
+seenMember digest expr seen = maybe False (elem expr) (Map.lookup digest seen)
+
+-- Remember a program under its digest, keeping any earlier collisions.
+seenInsert :: Int -> Expression -> Seen -> Seen
+seenInsert digest expr = Map.insertWith (++) digest [expr]
 
 type Rewritten = (Program, Maybe String)
 
@@ -174,20 +190,21 @@ rewrite' state (rule : rest) iteration ctx@RewriteContext{..} = do
                       logDebug (printf "Applied '%s', no changes made" ruleName)
                       pure (_rewrittens, _unique, False)
                     else
-                      if Set.member expr _unique
-                        then throwIO (LoopingRewriting (printExpression expr) ruleName _count)
-                        else do
-                          logDebug
-                            ( printf
-                                "Applied '%s' (%d nodes -> %d nodes)\n%s"
-                                ruleName
-                                (countNodes expression)
-                                (countNodes expr)
-                                (printExpression expr)
-                            )
-                          prog <- withLocatedExpression _locator expr program
-                          _saveStep prog (((iteration - 1) * _maxDepth) + _count)
-                          _rewrite (leadsTo prog, Set.insert expr _unique, False) (_count + 1)
+                      let digest = hashExpression expr
+                       in if seenMember digest expr _unique
+                            then throwIO (LoopingRewriting (printExpression expr) ruleName _count)
+                            else do
+                              logDebug
+                                ( printf
+                                    "Applied '%s' (%d nodes -> %d nodes)\n%s"
+                                    ruleName
+                                    (countNodes expression)
+                                    (countNodes expr)
+                                    (printExpression expr)
+                                )
+                              prog <- withLocatedExpression _locator expr program
+                              _saveStep prog (((iteration - 1) * _maxDepth) + _count)
+                              _rewrite (leadsTo prog, seenInsert digest expr _unique, False) (_count + 1)
       where
         leadsTo :: Program -> NonEmpty Rewritten
         leadsTo _prog =
@@ -197,7 +214,7 @@ rewrite' state (rule : rest) iteration ctx@RewriteContext{..} = do
 -- Rewrite program by provided locator from RewriteContext
 rewrite :: Program -> [Y.Rule] -> RewriteContext -> IO Rewrittens
 rewrite prog rules ctx@RewriteContext{..} = do
-  (rewrittens, exceeded) <- _rewrite ((prog, Nothing) :| [], Set.empty, False) 0
+  (rewrittens, exceeded) <- _rewrite ((prog, Nothing) :| [], Map.empty, False) 0
   pure (NE.reverse rewrittens, exceeded)
   where
     _rewrite :: RewriteState -> Int -> IO Rewrittens


### PR DESCRIPTION
Fixes #797.

## Problem

The per-rule rewriting loop in `Rewriter.hs` kept a `Set Expression` (`_unique`) of every rewritten program to detect cycles. Because the set held **whole** program expressions:

- each `Set.member` / `Set.insert` hashed and compared the entire program (`Rewriter.hs:177,190`), and
- the set grew by one full-program copy per cycle.

So loop detection alone cost roughly `O(maxDepth × programSize)` per rule, which exploded on large classes (e.g. apache/commons-io `IOUtils`/`FileUtils`/`PathUtils` with the `streams/*` ruleset) while staying cheap on small ones.

## Fix (dirty-by-hash with a slow re-check)

Per the issue and the request on the ticket: do a **fast, dirty comparison by hash**, and whenever the hash says two programs are equal, **re-compare the old, slow way** to confirm. This is both faster and still sound.

- Added `hashExpression :: Expression -> Int` to `AST.hs` — a cheap fixed-size FNV-1a-style digest over the AST.
- Replaced `_unique :: Set Expression` with `Seen = Map Int [Expression]`, keyed by the digest, storing the full expressions that produced each digest.
- `seenMember` does an `O(1)` digest lookup; the exact structural `(==)` runs **only** on a digest match, so genuine loops are still detected exactly and digest collisions can never cause a false positive.

Loop detection is now `O(programSize)` per cycle for hashing plus `O(log n)` on the digest, instead of `O(maxDepth × programSize)`.

## Verification

- `cabal build` clean with `-Werror`
- `cabal test spec` — 1065 examples, 0 failures (incl. the existing "with looping rules" loop-detection test)
- `hlint` and `fourmolu --mode check` both clean on the changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01LNki8aBHp2noZNPj6g11Ja)_