### PR TITLE
Use a primitive 𝑝 meta-variable in the Mprim morphing rule

### DIFF
--- a/resources/morphing.yaml
+++ b/resources/morphing.yaml
@@ -4,11 +4,9 @@
 # Morphing 𝕄 — applied top-to-bottom, first matching clause wins.
 
 - name: Mprim
-  description: '𝕄(e) ⟿ e if e ∈ 𝒫'
-  match: 𝑒
-  when:
-    primitive: 𝑒
-  then: 𝑒
+  description: '𝕄(p) ⟿ p'
+  match: 𝑝
+  then: 𝑝
 
 - name: Mnmz
   description: '𝕄(e) ⟿ 𝕄(𝒩(e)) if e ∉ NF'

--- a/src/AST.hs
+++ b/src/AST.hs
@@ -128,6 +128,17 @@ hashExpression = goExpr fnvOffset
       AtDelta -> step h 26
       AtMeta t -> hashText (step h 27) t
 
+-- A primitive is the termination ⊥ or a formation without a λ binding.
+primitive :: Expression -> Bool
+primitive ExTermination = True
+primitive (ExFormation bds) = not (any lambda bds)
+  where
+    lambda :: Binding -> Bool
+    lambda (BiLambda _) = True
+    lambda (BiMetaLambda _) = True
+    lambda _ = False
+primitive _ = False
+
 countNodes :: Expression -> Int
 countNodes (ExFormation bds) = 1 + sum (map nodesInBinding bds) + length bds
   where

--- a/src/CST.hs
+++ b/src/CST.hs
@@ -84,6 +84,8 @@ data META_HEAD
   | N' -- n
   | K -- 𝑘
   | K' -- k
+  | P -- 𝑝
+  | P' -- p
   | A -- a
   | TAU -- 𝜏
   | TAU' -- \tau
@@ -286,12 +288,13 @@ metaTail = T.drop 1
 
 -- The first character of an expression meta name encodes its kind:
 -- 'n'-prefixed names are normal-form-constrained '𝑛' metas, 'k'-prefixed
--- names are absolute-constrained '𝑘' metas, everything else is an
--- ordinary '𝑒' meta.
+-- names are absolute-constrained '𝑘' metas, 'p'-prefixed names are
+-- primitive-constrained '𝑝' metas, everything else is an ordinary '𝑒' meta.
 exMetaHead :: T.Text -> META_HEAD
 exMetaHead mt
   | T.isPrefixOf "n" mt = N
   | T.isPrefixOf "k" mt = K
+  | T.isPrefixOf "p" mt = P
   | otherwise = E
 
 -- This class is used to convert AST to CST

--- a/src/Encoding.hs
+++ b/src/Encoding.hs
@@ -33,6 +33,7 @@ instance ToASCII EXPRESSION where
   toASCII EX_APPLICATION_EXPRS{..} = EX_APPLICATION_EXPRS (toASCII expr) space eol tab (toASCII args) eol' tab' indent
   toASCII EX_META{meta = META{hd = N, ..}} = EX_META (META EXCL N' rest)
   toASCII EX_META{meta = META{hd = K, ..}} = EX_META (META EXCL K' rest)
+  toASCII EX_META{meta = META{hd = P, ..}} = EX_META (META EXCL P' rest)
   toASCII EX_META{..} = EX_META (META EXCL E' (rest meta))
   toASCII EX_META_TAIL{..} = EX_META_TAIL (toASCII expr) meta
   toASCII EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (toASCII expr)

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -267,6 +267,7 @@ instance ToLaTeX META_HEAD where
   toLaTeX E = E'
   toLaTeX N = N'
   toLaTeX K = K'
+  toLaTeX P = P'
   toLaTeX A = TAU'
   toLaTeX TAU = TAU'
   toLaTeX B = B'

--- a/src/Matcher.hs
+++ b/src/Matcher.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
@@ -9,7 +11,7 @@ import AST
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
-import Data.Text (Text)
+import Data.Text (Text, isPrefixOf)
 
 -- Meta value
 -- The right part of substitution
@@ -117,7 +119,9 @@ tailExpressions ptn tgt = case tailExpressionsReversed ptn tgt of
       substs -> Just (substs, [])
 
 matchExpression' :: MatchExpressionFunc
-matchExpression' (ExMeta meta) tgt = [substSingle meta (MvExpression tgt)]
+matchExpression' (ExMeta meta) tgt
+  | "p" `isPrefixOf` meta = [substSingle meta (MvExpression tgt) | primitive tgt]
+  | otherwise = [substSingle meta (MvExpression tgt)]
 matchExpression' ExThis ExThis = [substEmpty]
 matchExpression' ExGlobal ExGlobal = [substEmpty]
 matchExpression' ExTermination ExTermination = [substEmpty]

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -388,6 +388,7 @@ exHead =
     , try (ExMeta <$> meta' 'e' "𝑒")
     , try (ExMeta <$> meta' 'n' "𝑛")
     , try (ExMeta <$> meta' 'k' "𝑘")
+    , try (ExMeta <$> meta' 'p' "𝑝")
     , ExDispatch ExThis <$> attribute
     ]
     <?> "expression head"

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -117,6 +117,8 @@ instance Render META_HEAD where
   render N' = "n"
   render K = "𝑘"
   render K' = "k"
+  render P = "𝑝"
+  render P' = "p"
   render A = "a"
   render TAU = "𝜏"
   render TAU' = "\\tau"

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -222,15 +222,6 @@ _primitive (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _primitive expr (Subst mp) ctx
   _ -> pure []
 _primitive expr subst _ = pure [subst | primitive expr]
-  where
-    primitive :: Expression -> Bool
-    primitive ExTermination = True
-    primitive (ExFormation bds) = not (any lambda bds)
-    primitive _ = False
-    lambda :: Binding -> Bool
-    lambda (BiLambda _) = True
-    lambda (BiMetaLambda _) = True
-    lambda _ = False
 
 -- Hold if none of the given attributes is present in the union of the
 -- bindings captured by the given binding metas.

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1010,9 +1010,9 @@ spec = do
         [ unlines
             [ "\\begin{tabular}{rl}"
             , "\\trrule{Mprim}"
-            , "  { \\mathbb{M}( e ) }"
-            , "  { e }"
-            , "  { if $ e \\in \\mathcal{P} $ }"
+            , "  { \\mathbb{M}( p ) }"
+            , "  { p }"
+            , "  { }"
             , "  { }"
             , "\\trrule{Mnmz}"
             , "  { \\mathbb{M}( e ) }"

--- a/test/MatcherSpec.hs
+++ b/test/MatcherSpec.hs
@@ -361,6 +361,30 @@ spec = do
         , substs [[("e", MvExpression ExGlobal)]]
         )
       ,
+        ( "!p => T => [(!p >> T)]"
+        , ExMeta "p"
+        , ExTermination
+        , substs [[("p", MvExpression ExTermination)]]
+        )
+      ,
+        ( "!p => [[ x -> Q ]] => [(!p >> [[ x -> Q ]])]"
+        , ExMeta "p"
+        , ExFormation [BiTau (AtLabel "x") ExGlobal]
+        , substs [[("p", MvExpression (ExFormation [BiTau (AtLabel "x") ExGlobal]))]]
+        )
+      ,
+        ( "!p => Q => []"
+        , ExMeta "p"
+        , ExGlobal
+        , substs []
+        )
+      ,
+        ( "!p => [[ L> Func ]] => []"
+        , ExMeta "p"
+        , ExFormation [BiLambda "Func"]
+        , substs []
+        )
+      ,
         ( "!e => Q.org(x -> $) => [(!e >> Q.org(x -> $))]"
         , ExMeta "e"
         , ExApplication (ExDispatch ExGlobal (AtLabel "org")) (BiTau (AtLabel "x") ExThis)


### PR DESCRIPTION
Running `phino explain --morph` printed the Mprim rule as `𝕄(e) ⟿ e if e ∈ 𝒫`. The letter `p` already means "a primitive" in the calculus, so spelling out the `e ∈ 𝒫` side condition was just noise. This rewrites the rule to `𝕄(p) ⟿ p` with no condition at all.

To keep the rule honest rather than only cosmetic, `𝑝` is a real meta-variable kind now, sitting next to the existing `𝑛` and `𝑘` kinds. It parses (`!p` or `𝑝`), renders to `p` in LaTeX, and — the important part — the matcher binds it only when the target is actually a primitive. So Mprim still fires exactly when it used to, just without the explicit `when: primitive` guard. The shared `primitive` check moved into `AST` so the matcher and the condition code use the same definition.

The dataization `norm` rule keeps its `e ∉ 𝒫` form on purpose: that one is a negated condition where the `p` convention does not read naturally, so it stays out of scope here.

Closes #802