### PR TITLE
bug(#686): only collapse number/string data objects to sweet literals

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -11,7 +11,6 @@
 module CST where
 
 import AST
-import Data.Maybe (isJust)
 import qualified Data.Text as T
 import Misc
 import qualified Yaml as Y
@@ -362,7 +361,7 @@ instance ToCST Expression EXPRESSION where
         next = tabs + 1
         (ts', rs) = withoutRhosInPrimitives ex ts
         obj = ExApplication ex (head' ts')
-     in if length ts' == 1 && isJust (matchDataObject obj) && sweetCollapsible obj
+     in if length ts' == 1 && dataPrimitive obj && sweetCollapsible obj
           then applicationToPrimitive obj tabs rs
           else
             if null exs
@@ -389,6 +388,10 @@ instance ToCST Expression EXPRESSION where
     where
       primitives :: [T.Text]
       primitives = ["number", "string"]
+      dataPrimitive :: Expression -> Bool
+      dataPrimitive obj' = case matchDataObject obj' of
+        Just (label, _) -> label `elem` primitives
+        Nothing -> False
       withoutRhosInPrimitives :: Expression -> [Argument] -> ([Argument], [Argument])
       withoutRhosInPrimitives _ [] = ([], [])
       withoutRhosInPrimitives obj@(BaseObject label) bds@(rho@(ArTau AtRho _) : rest)

--- a/test-resources/cst/printing-packs/non-primitive-data-object.yaml
+++ b/test-resources/cst/printing-packs/non-primitive-data-object.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
+---
+program: |
+  Q -> [[ x -> Q.foo(~0 -> Q.bytes([[ D> 3F-F0-00-00-00-00-00-00 ]])) ]]
+result: |-
+  {⟦ x ↦ Φ.foo( Φ.bytes( ⟦ Δ ⤍ 3F-F0-00-00-00-00-00-00 ⟧ ) ) ⟧}


### PR DESCRIPTION
Closes #686.

## Problem

`phino rewrite` / `phino match` aborted with

```
applicationToPrimitive expects DataNumber or DataString
```

whenever a user supplied a phi input whose outermost application had the
data-object shape but a label other than `number`/`string`, e.g.
`Φ.foo(α0 ↦ Φ.bytes(⟦ Δ ⤍ 3F-F0-00-00-00-00-00-00 ⟧))`.

The CST guard collapsed such applications into sweet literals based on
`isJust (matchDataObject obj)`, but `matchDataObject` accepts *any* base-object
label, and `sweetCollapsible` returns `True` for non-numbers. So control reached
the partial `applicationToPrimitive`, which only handles `DataNumber`/`DataString`,
and panicked.

## Fix

Gate the collapse on the label actually being a primitive (`number`/`string`)
via a local `dataPrimitive` predicate, leaving `matchDataObject` general — it is
relied upon by `Functions._dataize` to match any label. A non-primitive
data object now pretty-prints as a plain application, and the `error` in
`applicationToPrimitive` is unreachable.

## Test

Added `test-resources/cst/printing-packs/non-primitive-data-object.yaml`,
mirroring the issue's counterexample. It panics without the fix and passes
with it.

`make test` (1062 examples, 0 failures), `make hlint`, and `make fourmolu`
are all green.
