### PR TITLE
feat(#815): add `make phino` target to build executable in repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ cabal.sandbox.config
 coverage-report/
 dist
 dist-*
+/phino
+/phino.exe
 docs/site
 node_modules
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .ONESHELL:
 .SHELLFLAGS := -e -o pipefail -c
-.PHONY: all test hlint fourmolu coverage bench binary clean
+.PHONY: all test hlint fourmolu coverage bench binary phino clean
 
 SHELL := bash
 
@@ -73,6 +73,11 @@ binary:
 	mkdir -p dist-release
 	cp "$$(cabal list-bin phino)" dist-release/phino$(BIN_EXT)
 	strip dist-release/phino$(BIN_EXT)
+
+.SILENT:
+phino:
+	cabal build phino
+	cp "$$(cabal list-bin phino)" $(CURDIR)/phino$(BIN_EXT)
 
 .SILENT:
 clean:

--- a/README.md
+++ b/README.md
@@ -489,6 +489,19 @@ To generate a local coverage report for development, run:
 make coverage
 ```
 
+To build a `phino` executable into the root of the repository, run:
+
+```bash
+make phino
+```
+
+This produces an executable `phino` (or `phino.exe` on Windows) in the
+project root, which you can run directly for quick local testing:
+
+```bash
+./phino --version
+```
+
 You will need [GHC ≥ 9.6.7][GHC] and [Cabal ≥ 3.0 (recommended)][cabal]
 or [Stack ≥ 3.0][stack] installed.
 


### PR DESCRIPTION
Closes #815.

## What

`make phino` previously failed because the `Makefile` had no `phino` target. This PR adds one.

## Changes

- **`Makefile`**: add a `phino` target (declared `.PHONY`) that runs `cabal build phino` and copies the resulting binary into the repo root as `phino` (or `phino.exe` on Windows, reusing the existing `BIN_EXT` logic). This mirrors the existing `binary` target, which copies into `dist-release/`.
- **`.gitignore`**: ignore the produced `/phino` and `/phino.exe` binaries so they aren't accidentally committed.
- **`README.md`**: document `make phino` in the "How to Contribute" section.

## Notes

After running `make phino` you get an executable in the project root:

```bash
make phino
./phino --version
```

This environment has no Haskell toolchain, so the full `cabal build` could not be executed here; the recipe was verified via `make -n phino` and mirrors the already-working `binary` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9qw5U6zDBgAV1N6cgWg7B)_