### PR TITLE
Focus before compressing in focused LaTeX sequences

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -167,6 +167,17 @@ compressedRewrittens rewrittens ctx@LatexContext{..} =
   let (progs, rules) = unzip rewrittens
    in if _compress then zip (meetInPrograms progs ctx) rules else rewrittens
 
+-- Compress a sequence of focused sub-expressions the way 'compressedRewrittens'
+-- compresses whole programs: each expression is wrapped as a program so the
+-- meet machinery factors recurring sub-expressions out across the sequence.
+-- Focusing happens before this, so the meet never replaces a program root the
+-- focus must still descend through.
+compressedExpressions :: [Expression] -> LatexContext -> [Expression]
+compressedExpressions exprs ctx@LatexContext{..} =
+  if _compress then map unwrap (meetInPrograms (map Program exprs) ctx) else exprs
+  where
+    unwrap (Program expr) = expr
+
 rewrittensToLatex :: Rewrittens' -> LatexContext -> IO String
 rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{_focus = ExRoot} =
   pure
@@ -177,12 +188,12 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{_focus = ExRoot} =
         ]
     )
 rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{..} = do
-  let (progs, rules) = unzip (compressedRewrittens rewrittens ctx)
-  exprs <- mapM (locatedExpression _focus) progs
+  let (progs, rules) = unzip rewrittens
+  focused <- mapM (locatedExpression _focus) progs
   pure
     ( concat
         [ preamble ctx
-        , body (zip exprs rules) (\expr -> renderToLatex (expressionToCST expr) ctx)
+        , body (zip (compressedExpressions focused ctx) rules) (\expr -> renderToLatex (expressionToCST expr) ctx)
         , ending exceeded ctx
         ]
     )

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -874,6 +874,12 @@ spec = do
               ]
           ]
 
+    it "focuses a compressed sequence whose meet replaces a step root" $
+      withStdin "{[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]}" $
+        testCLISucceeded
+          ["dataize", "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--hide=Q.bytes", "--hide=Q.number", "--locator=Q.@", "--focus=Q.@", "--meet-length=5", "--meet-popularity=1"]
+          ["\\phiMeet{dataization:1}{ [[ @ -> |c| . |plus| ( 32 ), |c| -> 25 ]] } \\leadsto_{\\nameref{r:contextualize}}"]
+
     it "dataizes with --locator" $
       withStdin "{[[ ex -> [[ @ -> Q.x ]], x -> [[ D> 42- ]] ]]}" $
         testCLISucceeded ["dataize", "--locator=Q.ex"] ["42-"]


### PR DESCRIPTION
The focused branch of `rewrittensToLatex` used to compress whole programs first and only then pull out the focused sub-expression. Now it does the opposite: it locates the focus in each original program, then runs the meet over those focused sub-expressions.

The old order crashed with `Can't find object by locator: 'Φ.φ'` whenever `--focus` met `--compress`. The meet could pick a step's entire root formation as the most-frequent sub-expression and swap it for a `phiMeet`/`phiAgain` token, leaving a program with no formation at its root for `locatedExpression` to descend. It showed up after #826 because the recursive morphing now carries the whole program around as `ρ` context, making that root the prime meet candidate. Focusing first also keeps the meet abbreviations inside the focused subtree, so `phiAgain` references no longer dangle.

No existing test combined `--focus` with `--compress`, and the compress-only tests run through the unfocused branch, which is untouched. The whole suite passes except one pre-existing `explain` golden that already fails on master.

Closes #832