### PR TITLE
bug(#824): stop randomString looping on literal-only patterns

### DIFF
--- a/src/Random.hs
+++ b/src/Random.hs
@@ -40,6 +40,11 @@ regenerate pat set = do
       pure next
 
 randomString :: String -> IO String
-randomString pat = do
-  set <- readIORef strings
-  regenerate pat set
+randomString pat
+  | randomized pat = readIORef strings >>= regenerate pat
+  | otherwise = generate pat
+  where
+    randomized :: String -> Bool
+    randomized [] = False
+    randomized ('%' : ch : rest) = ch == 'd' || ch == 'x' || randomized rest
+    randomized (_ : rest) = randomized rest

--- a/test/RandomSpec.hs
+++ b/test/RandomSpec.hs
@@ -12,6 +12,7 @@ module RandomSpec where
 import Data.Char (isDigit, isHexDigit)
 import Data.Set qualified as Set
 import Random (randomString)
+import System.Timeout (timeout)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
 spec :: Spec
@@ -25,6 +26,12 @@ spec = do
     it "returns literal unchanged" $ do
       result <- randomString "hello"
       result `shouldBe` "hello"
+
+  describe "randomString called twice with the same literal pattern" $
+    it "does not loop forever on the second call" $ do
+      _ <- randomString "repeated"
+      result <- timeout 1000000 (randomString "repeated")
+      result `shouldBe` Just "repeated"
 
   describe "randomString with literal pattern containing spaces" $
     it "returns literal with spaces" $ do


### PR DESCRIPTION
Closes #824.

## Problem

`randomString` (`src/Random.hs`) always routed through `regenerate`, which recurses until it produces a value not already in the global `strings` set. For a pattern with no `%d`/`%x` placeholder (a plain literal like `"hello"`, or one whose `%`-escapes are all unknown like `"%q"`), `generate` is deterministic — it always yields the same output. The first call caches it, and the second call with the same pattern loops forever looking for a fresh value that cannot exist. This is reachable via the `random-string` built-in, so a user rule with a constant argument hangs the rewriter.

The existing suite hid the bug because each `describe` block used a unique literal only once per process, so the second collision never happened.

## Fix

Skip the uniqueness loop when the pattern contains no randomized placeholder, returning `generate pat` directly. This also stops the global `strings` set from growing for literal-only patterns.

## Test

Added a timeout-guarded test that calls `randomString` twice with the same literal pattern. Verified it fails (timeout → `Nothing`) against the unpatched code and passes with the fix.

## Follow-up

The global `strings` set still leaks for the lifetime of the process; capping or scoping it per run is worth a separate issue, as noted in #824.