### PR TITLE
refactor: nest single-use helpers under where scope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,10 @@ BOX, NORM (dataization). All configuration is threaded through
 Most spec files load test cases from `test-resources/*-packs/*.yaml` at
 runtime via `runIO`. Each pack defines `input`/`output`/`rules`/`skip`.
 Test files map 1:1 with source modules (`RewriterSpec.hs` ↔ `Rewriter.hs`).
+
+### Style
+
+When introducing new function, put it under 'where' scope if it's possible.
+Don't use single char variables like 'a', 'b'; use more meaningful names.
+If two functions does the same but have different amount of arguments - name
+them with apostrophe: foo, foo':

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -17,31 +17,6 @@ import Options.Applicative
 import Paths_phino (version)
 import System.Exit (ExitCode (..), exitFailure)
 
-handler :: SomeException -> IO ()
-handler e = case fromException e of
-  Just ExitSuccess -> pure () -- prevent printing error on --version etc.
-  _ -> do
-    logError (displayException e)
-    exitFailure
-
-setLogger :: Command -> IO ()
-setLogger cmd =
-  let (level, lns) = case cmd of
-        CmdRewrite OptsRewrite{_logLevel, _logLines} -> (_logLevel, _logLines)
-        CmdDataize OptsDataize{_logLevel, _logLines} -> (_logLevel, _logLines)
-        CmdExplain OptsExplain{_logLevel, _logLines} -> (_logLevel, _logLines)
-        CmdMerge OptsMerge{_logLevel, _logLines} -> (_logLevel, _logLines)
-        CmdMatch OptsMatch{_logLevel, _logLines} -> (_logLevel, _logLines)
-   in setLogConfig level lns
-
-checkPin :: Maybe String -> IO ()
-checkPin Nothing = pure ()
-checkPin (Just expected)
-  | expected == actual = pure ()
-  | otherwise = throwIO (VersionMismatch expected actual)
-  where
-    actual = showVersion version
-
 runCLI :: [String] -> IO ()
 runCLI args = handle handler $ do
   CliArgs{_pin, _command} <- handleParseResult (execParserPure defaultPrefs parserInfo args)
@@ -53,3 +28,26 @@ runCLI args = handle handler $ do
     CmdExplain opts -> runExplain opts
     CmdMerge opts -> runMerge opts
     CmdMatch opts -> runMatch opts
+  where
+    handler :: SomeException -> IO ()
+    handler e = case fromException e of
+      Just ExitSuccess -> pure () -- prevent printing error on --version etc.
+      _ -> do
+        logError (displayException e)
+        exitFailure
+    setLogger :: Command -> IO ()
+    setLogger cmd =
+      let (level, lns) = case cmd of
+            CmdRewrite OptsRewrite{_logLevel, _logLines} -> (_logLevel, _logLines)
+            CmdDataize OptsDataize{_logLevel, _logLines} -> (_logLevel, _logLines)
+            CmdExplain OptsExplain{_logLevel, _logLines} -> (_logLevel, _logLines)
+            CmdMerge OptsMerge{_logLevel, _logLines} -> (_logLevel, _logLines)
+            CmdMatch OptsMatch{_logLevel, _logLines} -> (_logLevel, _logLines)
+       in setLogConfig level lns
+    checkPin :: Maybe String -> IO ()
+    checkPin Nothing = pure ()
+    checkPin (Just expected)
+      | expected == actual = pure ()
+      | otherwise = throwIO (VersionMismatch expected actual)
+      where
+        actual = showVersion version

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -183,12 +183,12 @@ normalized expr seq ctx@DataizeContext{..} = do
       seq' = rw :| rws <> NE.tail seq
   expr' <- locatedExpression _locator (fst rw)
   pure (expr', seq')
-
--- Switch the dataization context to a rewriting context for normalization,
--- disabling the must-checker and breakpoints.
-rewriteContext :: DataizeContext -> RewriteContext
-rewriteContext DataizeContext{..} =
-  RewriteContext _locator _maxDepth _maxCycles _depthSensitive _buildTerm MtDisabled Nothing _saveStep
+  where
+    -- Switch the dataization context to a rewriting context for normalization,
+    -- disabling the must-checker and breakpoints.
+    rewriteContext :: DataizeContext -> RewriteContext
+    rewriteContext DataizeContext{..} =
+      RewriteContext _locator _maxDepth _maxCycles _depthSensitive _buildTerm MtDisabled Nothing _saveStep
 
 -- Synthetic dataize function for internal usage inside atoms
 -- Here we modify original program from context by adding new binding


### PR DESCRIPTION
Adds a `### Style` section to `CLAUDE.md` (where-scope, no single-char names, `foo`/`foo'` naming) and applies the where-scope rule to the genuinely clean cases found by auditing `src/`.

## Changes

- `CLAUDE.md`: document the new style rules.
- `CLI.hs`: `handler`, `setLogger`, `checkPin` are each used only inside `runCLI`, so they move into its `where`.
- `Dataize.hs`: `rewriteContext` is used only inside `normalized`, so it moves into its `where`.

## Why only these two modules

An audit found ~38 non-exported single-call-site helpers, but on inspection the large majority are **justified exceptions** and were left untouched:

- `foo`/`foo'` pairs — endorsed by this very `CLAUDE.md` addition (`include'`/`exclude'`, `buildTerm'`, `printAlpha'`, `label'`, `recoverFormations'`, …).
- Mutually-recursive families (`Canonizer.canonize*`, `Tau.*Labels`, `Misc.recover*`, `Merge`).
- Cohesive helper families kept flat (`Builder.build*`, `XMIR.get*/has*`, `Functions.argTo*`, `Rule.nf/kMetaNames`).
- Flat parser-combinator idiom (`Parser`).
- Pattern-synonym usage that cannot be nested (`Misc.matchBaseObject`).
- Large documented routines (`Rule.extraSubstitutions`).

Going forward the rule applies to newly-introduced functions; the remaining cases are intentional.

## Checks

`make test` (1041 examples, `-Werror`), `make hlint`, and `make fourmolu` all pass.