### PR TITLE
Drop tabular wrapper from explain LaTeX output

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -437,19 +437,10 @@ extraArgumentsToLatex (Just extras) =
    in braced ("where " <> intercalate " and " extras')
 
 explainRules :: [Y.Rule] -> String
-explainRules = explainTabular . map explainRule
+explainRules = intercalate "\n" . map explainRule
 
 explainMorphRules :: [Y.MorphRule] -> String
-explainMorphRules = explainTabular . map explainMorphRule
+explainMorphRules = intercalate "\n" . map explainMorphRule
 
 explainDataizeRules :: [Y.DataizeRule] -> String
-explainDataizeRules = explainTabular . map explainDataizeRule
-
-explainTabular :: [String] -> String
-explainTabular rows =
-  intercalate
-    "\n"
-    [ "\\begin{tabular}{rl}"
-    , intercalate "\n" rows
-    , "\\end{tabular}"
-    ]
+explainDataizeRules = intercalate "\n" . map explainDataizeRule

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -944,27 +944,24 @@ spec = do
       testCLISucceeded
         ["explain", "--rule=resources/normalize/copy.yaml"]
         [ unlines
-            [ "\\begin{tabular}{rl}"
-            , "\\phinoNormalizationRule{copy}"
+            [ "\\phinoNormalizationRule{copy}"
             , "  { [[ B_1, \\tau -> ?, B_2 ]] ( \\tau -> k ) }"
             , "  { [[ B_1, \\tau -> k, B_2 ]] }"
             , "  { }"
             , "  { }"
-            , "\\end{tabular}"
             ]
         ]
 
     it "explains multiple rules" $
       testCLISucceeded
         ["explain", "--rule=resources/normalize/copy.yaml", "--rule=resources/normalize/alpha.yaml"]
-        ["\\begin{tabular}{rl}", "\\phinoNormalizationRule{copy}", "\\phinoNormalizationRule{alpha}"]
+        ["\\phinoNormalizationRule{copy}", "\\phinoNormalizationRule{alpha}"]
 
     it "explains normalization rules" $
       testCLISucceeded
         ["explain", "--normalize"]
         [ unlines
-            [ "\\begin{tabular}{rl}"
-            , "\\phinoNormalizationRule{alpha}"
+            [ "\\phinoNormalizationRule{alpha}"
             , "  { [[ B_1, \\tau -> ?, B_2 ]] ( \\alpha_{i} -> e ) }"
             , "  { [[ B_1, \\tau -> ?, B_2 ]] ( \\tau -> e ) }"
             , "  { if $ i = \\vert \\overline{ B_1 } \\vert $ }"
@@ -1024,7 +1021,6 @@ spec = do
             , "  { T }"
             , "  { if $ \\tau \\notin B \\;\\text{and}\\; @ \\notin B \\;\\text{and}\\; L \\notin B $ }"
             , "  { }"
-            , "\\end{tabular}"
             ]
         ]
 
@@ -1032,8 +1028,7 @@ spec = do
       testCLISucceeded
         ["explain", "--morph"]
         [ unlines
-            [ "\\begin{tabular}{rl}"
-            , "\\phinoMorphingRule{prim}"
+            [ "\\phinoMorphingRule{prim}"
             , "  { \\mathbb{M}( [[ B ]] ) }"
             , "  { [[ B ]] }"
             , "  { }"
@@ -1068,7 +1063,6 @@ spec = do
             , "  { T }"
             , "  { }"
             , "  { }"
-            , "\\end{tabular}"
             ]
         ]
 
@@ -1076,8 +1070,7 @@ spec = do
       testCLISucceeded
         ["explain", "--dataize"]
         [ unlines
-            [ "\\begin{tabular}{rl}"
-            , "\\phinoDataizationRule{delta}"
+            [ "\\phinoDataizationRule{delta}"
             , "  { \\mathbb{D}( [[ B_1, D> \\delta, B_2 ]] ) }"
             , "  { \\delta }"
             , "  { }"
@@ -1107,7 +1100,6 @@ spec = do
             , "  { \\mathbb{D}( \\mathbb{M}( n ) ) }"
             , "  { }"
             , "  { }"
-            , "\\end{tabular}"
             ]
         ]
 
@@ -1135,8 +1127,7 @@ spec = do
             testCLISucceeded ["explain", "--normalize", printf "--target=%s" path] []
             content <- readFile path
             _ <- evaluate (length content)
-            content `shouldContain` "\\begin{tabular}{rl}"
-            content `shouldContain` "\\end{tabular}"
+            content `shouldContain` "\\phinoNormalizationRule{alpha}"
         )
 
   describe "merge" $ do


### PR DESCRIPTION
Fixes #847.

The `explain` command wrapped its rule rows in a `\begin{tabular}{rl} ... \end{tabular}` environment via `explainTabular` in `src/LaTeX.hs`. Since phino's LaTeX output is meant to be embedded in a document the caller controls, hardcoding the `tabular` environment (with an `rl` column spec) forced consumers to strip our wrapper before placing the rules inside their own environment (a different `tabular`, an `align`, a custom list).

## Changes

- `explainRules`, `explainMorphRules`, and `explainDataizeRules` now join their rendered rows with newlines directly (`intercalate "\n" . map explain...`).
- Removed the now-unused `explainTabular` helper.
- Updated the `\begin{tabular}{rl}` / `\end{tabular}` expectations in `test/CLISpec.hs` to match the unwrapped output (the "writes to target file" test now asserts on a `\phinoNormalizationRule` row).

The output is now only the `\trrule` rows; the surrounding environment belongs to the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4dnSCXE7WpUarKPt1R2wL

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4dnSCXE7WpUarKPt1R2wL)_