### PR TITLE
fix(#858): fail loudly when no morphing/dataization rule matches

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -76,7 +76,7 @@ morph (expr, seq) ctx@DataizeContext{..} = do
   matched <- firstMatch Y.morphingRules
   case matched of
     Just (rule, subst) -> apply rule.then_ rule.name subst
-    Nothing -> pure (expr, seq)
+    Nothing -> throwIO (userError "no morphing rule matched")
   where
     firstMatch :: [Y.MorphRule] -> IO (Maybe (Y.MorphRule, Subst))
     firstMatch [] = pure Nothing
@@ -127,7 +127,7 @@ dataize' (expr, seq) ctx = do
   matched <- firstMatch Y.dataizationRules
   case matched of
     Just (rule, subst) -> apply rule subst
-    Nothing -> pure (Nothing, NE.toList seq)
+    Nothing -> throwIO (userError "no dataization rule matched")
   where
     firstMatch :: [Y.DataizeRule] -> IO (Maybe (Y.DataizeRule, Subst))
     firstMatch [] = pure Nothing


### PR DESCRIPTION
Closes #858.

## Problem

`morph` (`src/Dataize.hs:79`) and `dataize'` (`src/Dataize.hs:130`) silently returned their input unchanged / "no data" when `firstMatch` returned `Nothing`. This is behavior that exists only in Haskell — it is not expressed by any rule in `resources/morphing.yaml` or `resources/dataization.yaml`.

Both rule sets already end with a catch-all rule (`match: 𝑛`) that matches every expression, so the `Nothing` branch is unreachable dead code in correct operation. As a silent fallback it also violates fail-fast: if the rule set ever loses its catch-all, these functions would quietly return a no-op the rules never sanctioned instead of surfacing that the rule set is incomplete.

## Fix

- `src/Dataize.hs:79`: `Nothing -> throwIO (userError "no morphing rule matched")`
- `src/Dataize.hs:130`: `Nothing -> throwIO (userError "no dataization rule matched")`

`throwIO` was already imported. A reachable "no rule matched" state is now treated as the invariant violation it is.

## Testing

The local environment has no Haskell toolchain (`cabal`/`ghc` unavailable), so `make test` could not be run here — CI will exercise the suite. The change touches only an unreachable branch, and no existing test relies on the old silent-fallback behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z3NG3LvWzE7oCANgv8K4k

---
_Generated by [Claude Code](https://claude.ai/code/session_016z3NG3LvWzE7oCANgv8K4k)_