### PR TITLE
bug: fix master CI breakage from merge ordering

### DIFF
--- a/test-resources/condition-packs/gt-domain.yaml
+++ b/test-resources/condition-packs/gt-domain.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-expression: '[[ x -> $, w -> $ ]](a0 -> Q)'
+expression: '[[ x -> $, w -> $ ]](α0 -> Q)'
 pattern: '[[ !B ]](α𝑖 ↦ Q)'
 condition:
   gt:

--- a/test-resources/condition-packs/not-gt.yaml
+++ b/test-resources/condition-packs/not-gt.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 failure: true
-expression: '[[ x -> $, w -> $ ]](a3 -> Q)'
+expression: '[[ x -> $, w -> $ ]](α3 -> Q)'
 pattern: '[[ !B ]](α𝑖 ↦ Q)'
 condition:
   gt:

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -979,7 +979,7 @@ spec = do
             , "  { i = \\vert \\overline{ B_1 } \\vert }"
             , "  { }"
             , "\\phinoNormalizationRule{amiss}"
-            , "  { [[ B ]] ( \\alpha_{i} -> e ) }"
+            , "  { [[ B ]] ( \\phiTerminal{\\alpha_{i}} -> e ) }"
             , "  { T }"
             , "  { \\vert \\overline{ B } \\vert \\not> i }"
             , "  { }"


### PR DESCRIPTION
Master CI is red ([run 28171915100](https://github.com/objectionary/phino/actions/runs/28171915100)) with 3 test failures. All three are merge-ordering breakages: #874 ("Reduce out-of-range positional application … to ⊥") landed alongside #875 (restore `~` as the ASCII alpha prefix) and #871 (wrap LaTeX terminals in `\phiTerminal{}`), but #874's new test fixtures were written against the pre-merge state.

## Failures and fixes

**1 & 2 — `Rule/check conditions/{gt-domain,not-gt}.yaml`** ("List of matched substitutions is empty which is not expected")

These packs wrote positional arguments as `a0` / `a3`. With the `~`/`α` alpha prefix restored, `a0` parses as a plain label attribute, so the pattern `[[ !B ]](α𝑖 ↦ Q)` no longer matched and the substitution list came back empty — before the `gt` condition was even evaluated. Switched to `α0` / `α3`, matching how the `e-ami` rewriter pack writes `α2` against the same pattern.

**3 — `CLI/explain/explains normalization rules`**

The expectation rendered the `amiss` rule's `α𝑖` as bare `\alpha_{i}`, but terminals are now wrapped, so the real output is `\phiTerminal{\alpha_{i}}`. Updated the expectation to match — consistent with the `alpha` and `dca` rules in the same expected block, which already use `\phiTerminal{\alpha_{i}}`.

## Verification

The Haskell toolchain isn't available in this environment, so I relied on CI to verify. The fixes match the failure output exactly and are internally consistent with fixtures that already pass (`e-ami` → `α2`; `alpha`/`dca` → `\phiTerminal{\alpha_{i}}`). No source/behavior changes — only test fixtures and one expected string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9csBxJu36f5MY7xff2JW8)_