### PR TITLE
bug(#878): dataize ⟦𝐵⟧ and ⊥ to empty bytes (--) so 𝔻 is total

### DIFF
--- a/resources/dataization.yaml
+++ b/resources/dataization.yaml
@@ -40,14 +40,14 @@
       normalize: 𝑒
 
 - name: none
-  description: '𝔻(⟦𝐵⟧) ⟿ nothing'
+  description: '𝔻(⟦𝐵⟧) ⟿ --'
   match: ⟦𝐵⟧
-  then: nothing
+  then: '--'
 
 - name: bott
-  description: '𝔻(⊥) ⟿ nothing'
+  description: '𝔻(⊥) ⟿ --'
   match: ⊥
-  then: nothing
+  then: '--'
 
 - name: norm
   description: '𝔻(n) ⟿ 𝔻(𝕄(n)) otherwise'

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -147,9 +147,9 @@ runDataize OptsDataize{..} = do
       canonize = if _canonize then C.canonize else id
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
-  (maybeBytes, chain) <- dataize (context loc prog printCtx)
+  (bytes, chain) <- dataize (context loc prog printCtx)
   when _sequence (printRewrittens printCtx (canonize $ exclude $ include chain, False) >>= putStrLn)
-  unless _quiet (putStrLn (maybe (P.printExpression ExTermination) P.printBytes maybeBytes))
+  unless _quiet (putStrLn (P.printBytes bytes))
   where
     validateOpts :: IO ()
     validateOpts = do

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -29,7 +29,7 @@ import Text.Printf (printf)
 import Yaml (ExtraArgument (..), normalizationRules)
 import qualified Yaml as Y
 
-type Dataized = (Maybe Bytes, [Rewritten])
+type Dataized = (Bytes, [Rewritten])
 
 type Dataizable = (Expression, NonEmpty Rewritten)
 
@@ -113,15 +113,15 @@ morph (expr, seq) ctx@DataizeContext{..} = do
 dataize :: DataizeContext -> IO Dataized
 dataize ctx@DataizeContext{..} = do
   expr <- locatedExpression _locator _program
-  (maybeBytes, seq) <- dataize' (expr, (_program, Nothing) :| []) ctx
-  pure (maybeBytes, reverse seq)
+  (bytes, seq) <- dataize' (expr, (_program, Nothing) :| []) ctx
+  pure (bytes, reverse seq)
 
--- The Dataization function 𝔻 retrieves bytes from an expression. It is driven
--- by the ordered rules from 'dataization.yaml': 'delta' yields the asset bytes,
--- 'none' (a formation) and 'bott' (⊥) yield nothing, 'box' contextualizes the
--- φ-body and keeps dataizing (its step is labelled by the operation,
--- 'contextualize'), and 'norm' reduces through morphing, splicing the morphing
--- steps into the chain.
+-- The Dataization function 𝔻 retrieves bytes from an expression. It is total.
+-- It is driven by the ordered rules from 'dataization.yaml': 'delta' yields the
+-- asset bytes, 'none' (a formation) and 'bott' (⊥) yield empty bytes (--), 'box'
+-- contextualizes the φ-body and keeps dataizing (its step is labelled by the
+-- operation, 'contextualize'), and 'norm' reduces through morphing, splicing the
+-- morphing steps into the chain.
 dataize' :: Dataizable -> DataizeContext -> IO Dataized
 dataize' (expr, seq) ctx = do
   matched <- firstMatch Y.dataizationRules
@@ -142,8 +142,7 @@ dataize' (expr, seq) ctx = do
     apply rule subst = case rule.then_ of
       Y.DoData bytes -> do
         bts <- buildBytesThrows bytes subst
-        pure (Just bts, NE.toList seq)
-      Y.DoNothing -> pure (Nothing, NE.toList seq)
+        pure (bts, NE.toList seq)
       Y.DoDataize (Y.DaExpr result) -> do
         built <- buildExpressionThrows result subst
         seq' <- leadsTo seq (operation rule) built ctx
@@ -194,7 +193,7 @@ normalized expr seq ctx@DataizeContext{..} = do
 -- Here we modify original program from context by adding new binding
 -- which refers to expression we want to dataize. As a caller of 𝔻, it first
 -- reduces the expression to a normal form, since 𝔻 only accepts normal forms.
-_dataize :: Expression -> DataizeContext -> IO (Maybe Bytes)
+_dataize :: Expression -> DataizeContext -> IO Bytes
 _dataize expr ctx@DataizeContext{_buildTerm = buildTerm, _program = Program (ExFormation bds)} = do
   (TeAttribute attr) <- buildTerm "random-tau" [] substEmpty
   let prog = Program (ExFormation (BiTau attr expr : bds))
@@ -204,34 +203,31 @@ _dataize expr ctx@DataizeContext{_buildTerm = buildTerm, _program = Program (ExF
   pure bts
 _dataize _ _ = throwIO (userError "Can't call _dataize from atoms with non-formation program")
 
+-- A number atom only operates on numeric data. Empty bytes (the result of
+-- dataizing a bare formation ⟦𝐵⟧ or ⊥ now that 𝔻 is total) carry no number,
+-- so the operand is rejected and the atom yields ⊥.
+asNumber :: Bytes -> Maybe Double
+asNumber BtEmpty = Nothing
+asNumber bts = Just (either toDouble id (btsToNum bts))
+
 atom :: T.Text -> Expression -> DataizeContext -> IO Expression
 atom "L_number_plus" self ctx = do
   left <- _dataize (ExDispatch self (AtLabel "x")) ctx
   right <- _dataize (ExDispatch self AtRho) ctx
-  case (left, right) of
-    (Just left', Just right') -> do
-      let first = either toDouble id (btsToNum left')
-          second = either toDouble id (btsToNum right')
-          sum = first + second
-      pure (DataNumber (numToBts sum))
+  case (asNumber left, asNumber right) of
+    (Just first, Just second) -> pure (DataNumber (numToBts (first + second)))
     _ -> pure ExTermination
 atom "L_number_times" self ctx = do
   left <- _dataize (ExDispatch self (AtLabel "x")) ctx
   right <- _dataize (ExDispatch self AtRho) ctx
-  case (left, right) of
-    (Just left', Just right') -> do
-      let first = either toDouble id (btsToNum left')
-          second = either toDouble id (btsToNum right')
-          sum = first * second
-      pure (DataNumber (numToBts sum))
+  case (asNumber left, asNumber right) of
+    (Just first, Just second) -> pure (DataNumber (numToBts (first * second)))
     _ -> pure ExTermination
 atom "L_number_eq" self ctx = do
   x <- _dataize (ExDispatch self (AtLabel "x")) ctx
   rho <- _dataize (ExDispatch self AtRho) ctx
-  case (x, rho) of
-    (Just x', Just rho') -> do
-      let self' = either toDouble id (btsToNum rho')
-          first = either toDouble id (btsToNum x')
+  case (asNumber x, asNumber rho) of
+    (Just first, Just self') ->
       if self' == first
         then pure (DataNumber (numToBts first))
         else pure (ExDispatch self (AtLabel "y"))

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -400,7 +400,6 @@ explainDataizeRule rule =
     dataizeOutcome (Y.DoDataize (Y.DaMorph expr)) = dataize (morph (renderToLatex (expressionToCST expr) defaultLatexContext))
     dataizeOutcome (Y.DoDataize (Y.DaNormalize expr)) = dataize (normalize (renderToLatex (expressionToCST expr) defaultLatexContext))
     dataizeOutcome (Y.DoData bytes) = T.unpack (render (toLaTeX (toCST' bytes :: BYTES)))
-    dataizeOutcome Y.DoNothing = "\\varnothing"
 
 -- Render a single rule row through the given macro (one of
 -- \phinoMorphingRule, \phinoNormalizationRule, \phinoDataizationRule): an

--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -238,11 +238,10 @@ data MorphArg
 
 -- The right-hand side of a dataization reduction 𝔻(match) ⟿ then.
 -- A mapping ('{ dataize: arg }') keeps reducing under 𝔻; a bare bytes scalar
--- yields data; the 'nothing' keyword marks the function as undefined.
+-- yields data. 𝔻 is total: every rule yields data or reduces further.
 data DataizeOutcome
   = DoDataize DataizeArg
   | DoData Bytes
-  | DoNothing
   deriving (Eq, Generic, Show)
 
 -- The argument of a dataization continuation: a plain expression ('𝔻(e)'),
@@ -268,7 +267,7 @@ data MorphRule = MorphRule
   deriving (Generic, Show)
 
 -- One ordered dataization rule, structured like 'MorphRule' but reducing
--- under 𝔻 and able to terminate with bytes or 'nothing'.
+-- under 𝔻 and terminating with bytes.
 data DataizeRule = DataizeRule
   { name :: String
   , label :: Maybe String
@@ -296,7 +295,6 @@ instance FromJSON DataizeOutcome where
   parseJSON (Object o) = do
     validateYamlObject o ["dataize"]
     DoDataize <$> o .: "dataize"
-  parseJSON (String "nothing") = pure DoNothing
   parseJSON v = DoData <$> parseJSON v
 
 instance FromJSON DataizeArg where

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -867,9 +867,9 @@ spec = do
       withStdin "Q -> [[ D> 01- ]]" $
         testCLISucceeded ["dataize"] ["01-"]
 
-    it "dataizes to dead" $
+    it "dataizes empty object to empty bytes" $
       withStdin "Q -> [[ ]]" $
-        testCLISucceeded ["dataize"] ["⊥"]
+        testCLISucceeded ["dataize"] ["--"]
 
     it "dataizes with --sequence" $
       withStdin "{[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]]}" $
@@ -1114,12 +1114,12 @@ spec = do
             , "  { e \\coloneqq \\phinoEvaluate{ [[ B_1, L> F, B_2 ]] } }"
             , "\\phinoDataizationRule{none}"
             , "  { \\phinoDataize{ [[ B ]] } }"
-            , "  { \\varnothing }"
+            , "  { -- }"
             , "  { }"
             , "  { }"
             , "\\phinoDataizationRule{bott}"
             , "  { \\phinoDataize{ T } }"
-            , "  { \\varnothing }"
+            , "  { -- }"
             , "  { }"
             , "  { }"
             , "\\phinoDataizationRule{norm}"

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -22,7 +22,7 @@ import Yaml qualified
 defaultDataizeContext :: Expression -> Program -> DataizeContext
 defaultDataizeContext loc prog = DataizeContext loc prog 25 25 False buildTerm dontSaveStep
 
-test :: (Eq a, Show a) => ((Expression, NonEmpty Rewritten) -> DataizeContext -> IO (Maybe a, [Rewritten])) -> [(String, Expression, Expression, Maybe a)] -> Spec
+test :: (Eq a, Show a) => ((Expression, NonEmpty Rewritten) -> DataizeContext -> IO (a, [Rewritten])) -> [(String, Expression, Expression, a)] -> Spec
 test func useCases =
   forM_ useCases $ \(desc, input, expr, output) ->
     it desc $ do
@@ -45,7 +45,7 @@ testDataize useCases =
       prog' <- parseProgramThrows prog
       loc' <- parseExpressionThrows loc
       (value, _) <- dataize (defaultDataizeContext loc' prog')
-      value `shouldBe` Just res
+      value `shouldBe` res
 
 spec :: Spec
 spec = do
@@ -67,13 +67,14 @@ spec = do
   describe "dataize" $
     test
       dataize'
-      [ ("[[ D> 00- ]] => 00-", ExFormation [BiDelta (BtOne "00")], ExRoot, Just (BtOne "00"))
-      , ("T => X", ExTermination, ExRoot, Nothing)
+      [ ("[[ D> 00- ]] => 00-", ExFormation [BiDelta (BtOne "00")], ExRoot, BtOne "00")
+      , ("T => --", ExTermination, ExRoot, BtEmpty)
+      , ("[[ ]] => --", ExFormation [], ExRoot, BtEmpty)
       ,
         ( "[[ @ -> [[ D> 00-]] ]] => 00-"
         , ExFormation [BiTau AtPhi (ExFormation [BiDelta (BtOne "00"), BiVoid AtRho]), BiVoid AtRho]
         , ExRoot
-        , Just (BtOne "00")
+        , BtOne "00"
         )
       ,
         ( "[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]] => 01-"
@@ -99,7 +100,7 @@ spec = do
                 )
             ]
         , ExRoot
-        , Just (BtOne "01")
+        , BtOne "01"
         )
       ]
 


### PR DESCRIPTION
Fixes #878.

## Problem

The `none` and `bott` rules in `resources/dataization.yaml` both reduced with `then: nothing`, mapping a bare formation `⟦𝐵⟧` and `⊥` onto a `Nothing` byte result. The CLI printed that as `⊥` and `explain` rendered it as `∅` (`\varnothing`).

That contradicts the definition of dataization: 𝔻 maps a normal form to *data*, yet `nothing` is neither (`⊥` is an expression, `∅` the empty set), so 𝔻 leaked a non-data value and stopped being total. Dataizing the empty object `Q ↦ ⟦ ⟧` should yield empty bytes `--`, not the termination object `⊥`.

## Change

- `resources/dataization.yaml`: `none` and `bott` now reduce with `then: '--'`, yielding `BtEmpty` through `DoData` and rendering as `--`.
- With no rule emitting `nothing`, the now-dead paths are dropped to make 𝔻 total in the types:
  - `DoNothing` constructor and its `"nothing"` parser (`Yaml.hs`)
  - the `\varnothing` LaTeX branch (`LaTeX.hs`)
  - the `Maybe` in `Dataized` and the `Nothing` print fallback (`Dataize.hs`, `CLI/Runners.hs`)
- The number atoms previously relied on the absent (`Nothing`) byte result to bail out to `⊥`. Now that empty/bottom dataize to `BtEmpty`, they reject empty (non-numeric) operands via a new `asNumber` helper and still yield `⊥` — this also avoids a `btsToNum` crash on empty bytes.

### Caveat (per the issue)

Collapsing `⊥` into `--` erases the distinction between "computed to empty data" and "failed to dataize". This is intentional: it is what makes 𝔻 total.

## Tests

- `DataizeSpec.hs`: `Nothing` expectations become `BtEmpty`; added `⟦ ⟧ => --`.
- `CLISpec.hs`: "dataizes to dead" (`⊥`) becomes empty bytes (`--`); the `explain --dataize` rows for `none`/`bott` now render `--` instead of `\varnothing`.

> ⚠️ No Haskell toolchain was available in the execution environment, so the suite was not run locally — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7HKa3oM92fc3fdjbgZcAh)_