### PR TITLE
bug(#883): render NOT_GREATER as \leq instead of non-standard \not>

### DIFF
--- a/src/Render.hs
+++ b/src/Render.hs
@@ -247,7 +247,7 @@ instance Render EQUAL where
   render EQUAL = "="
   render NOT_EQUAL = "\\not="
   render GREATER = ">"
-  render NOT_GREATER = "\\not>"
+  render NOT_GREATER = "\\leq"
 
 instance Render CONDITION where
   render CO_BELONGS{..} = render attr <> " " <> render belongs <> " " <> render set

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -981,7 +981,7 @@ spec = do
             , "\\phinoNormalizationRule{amiss}"
             , "  { [[ B ]] ( \\phiTerminal{\\alpha_{i}} -> e ) }"
             , "  { T }"
-            , "  { \\vert \\overline{ B } \\vert \\not> i }"
+            , "  { \\vert \\overline{ B } \\vert \\leq i }"
             , "  { }"
             , "\\phinoNormalizationRule{copy}"
             , "  { [[ B_1, \\tau -> ?, B_2 ]] ( \\tau -> k ) }"


### PR DESCRIPTION
Fixes #883.

`phino explain --normalize` rendered the `amiss` rule's side condition as `\vert \overline{ B } \vert \not> i`. The `\not>` came from `render NOT_GREATER = "\\not>"` (src/Render.hs:250), which is not standard LaTeX — there is no `\not>` glyph in math mode, so it renders as a slash awkwardly overstruck on `>` rather than a single relation symbol.

Since `¬(a > b)` is exactly `a ≤ b`, the correct and well-formed symbol is `\leq`. This changes `render NOT_GREATER` to emit `\leq`, which fixes every place `NOT_GREATER` is emitted, not just `amiss`. `NOT_EQUAL` / `\not=` and the other comparators are unaffected.

## Changes
- `src/Render.hs`: `render NOT_GREATER = "\\leq"` (was `"\\not>"`)
- `test/CLISpec.hs`: updated the `explain --normalize` expectation for the `amiss` side condition accordingly

Note: the Haskell toolchain (cabal/ghc) is not available in the web execution environment, so the test suite was not run here. CI should validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3bdesgk5V7AezbmueSHxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3bdesgk5V7AezbmueSHxW)_