### PR TITLE
fix(#890): render Δ terminal as D, consistent with λ→L

### DIFF
--- a/src/Render.hs
+++ b/src/Render.hs
@@ -71,7 +71,7 @@ instance Render RHO where
 
 instance Render DELTA where
   render DELTA = "Δ"
-  render DELTA' = "\\Delta"
+  render DELTA' = "D"
 
 instance Render XI where
   render XI = "ξ"

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1121,7 +1121,7 @@ spec = do
             , "\\begin{phinoInference}"
             , "  \\phinoName{box}"
             , "  \\phinoLabel{box}"
-            , "  \\phinoCondition{ [ \\Delta, L ] \\cap ( B_1 \\cup B_2 ) = \\emptyset }"
+            , "  \\phinoCondition{ [ D, L ] \\cap ( B_1 \\cup B_2 ) = \\emptyset }"
             , "  \\phinoPremise{ \\phinoContextualize{ e_1 }{ [[ B_1, @ -> e_1, B_2 ]] }{ n } }"
             , "  \\phinoPremise{ \\phinoNormalize{ n }{ n_1 } }"
             , "  \\phinoPremise{ \\phinoDataize{ n_1 }{ e }{ \\delta } }"


### PR DESCRIPTION
Fixes #890.

`explain --dataize` rendered the `box` rule's disjoint condition as `{ [ \Delta, L ] \cap ( B_1 \cup B_2 ) = \emptyset }`. The `Δ` terminal attribute was emitted as the LaTeX macro `\Delta` while its sibling `λ` terminal was emitted as a plain `L`, so the two terminals were typeset differently. This also contradicted the codebase's `D>`/`L>` binding-arrow convention (`PA_DELTA' = "D> "` pairs with `PA_LAMBDA' = "L> "`).

## Changes

- `src/Render.hs`: change `render DELTA' = "\\Delta"` to `render DELTA' = "D"`, aligning the terminal with `LAMBDA'` and the `D>`/`L>` convention. The `\Delta` form was a leftover from #780.
- `test/CLISpec.hs`: update the `explain --dataize` expectation so the `box` condition reads `[ D, L ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oanHmpv53dagVBgPc4UMa

---
_Generated by [Claude Code](https://claude.ai/code/session_016oanHmpv53dagVBgPc4UMa)_