### PR TITLE
fix(#888): rename the `lambda` engine function to `evaluate`

### DIFF
--- a/resources/dataization.yaml
+++ b/resources/dataization.yaml
@@ -10,7 +10,7 @@
 # matches the universe (binding the meta e), the rule yields the conclusion
 # 'd-result' (a premise bytes meta or a literal), provided 'when' holds and the
 # ordered 'premises' reduce as stated. A premise binds its 'n-result'/'d-result'
-# to one judgment — 𝔻 ('dataize'), 𝕄 ('morph'), 𝒩 ('normalize'), 𝔼 ('lambda')
+# to one judgment — 𝔻 ('dataize'), 𝕄 ('morph'), 𝒩 ('normalize'), 𝔼 ('evaluate')
 # or 𝒞 ('contextualize'). 'e-match' is the universe-argument matcher of
 # 𝔻(n, e); it is always the e meta. The single bytes result is named δ; derived
 # terms are 𝑛, 𝑛1, … in premise order, skipping the bare 𝑛 only when 'match'
@@ -48,7 +48,7 @@
   d-result: δ
   premises:
     - n-result: 𝑛
-      lambda: ⟦𝐵1, λ ⤍ 𝑓, 𝐵2⟧
+      evaluate: ⟦𝐵1, λ ⤍ 𝑓, 𝐵2⟧
     - n-result: 𝑛1
       normalize: 𝑛
     - d-result: δ

--- a/resources/morphing.yaml
+++ b/resources/morphing.yaml
@@ -15,7 +15,7 @@
 # matches the universe (binding the meta e), the rule yields the conclusion
 # 'n-result' (a premise meta or a literal), provided 'when' holds and the
 # ordered 'premises' reduce as stated. A premise binds 'n-result' to the result
-# of one judgment — 𝕄 ('morph'), 𝒩 ('normalize') or 𝔼 ('lambda'). 'e-match' is
+# of one judgment — 𝕄 ('morph'), 𝒩 ('normalize') or 𝔼 ('evaluate'). 'e-match' is
 # the universe-argument matcher of 𝕄(n, e); it is always the e meta. Derived
 # terms are named 𝑛, 𝑛1, … in premise order; the bare 𝑛 is skipped only when
 # 'match' already binds it.
@@ -38,7 +38,7 @@
   n-result: 𝑛2
   premises:
     - n-result: 𝑛
-      lambda: '⟦𝐵1, λ ⤍ 𝑓, 𝐵2⟧'
+      evaluate: '⟦𝐵1, λ ⤍ 𝑓, 𝐵2⟧'
     - n-result: 𝑛1
       normalize: '𝑛.𝜏'
     - n-result: 𝑛2

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -197,7 +197,7 @@ dataize' (expr, seq) univ ctx = do
     sides :: [Y.Premise] -> Subst -> IO Subst
     sides premises subst = foldM (sidePremise univ ctx) subst premises
     -- A spliced dataization step is labelled by its first side-computation —
-    -- 'box' by its 'contextualize', 'fire' by its 'lambda'; with none it is blank.
+    -- 'box' by its 'contextualize', 'fire' by its 'evaluate'; with none it is blank.
     labelOf :: [Y.Premise] -> String
     labelOf (premise : _) = verb premise.operation
     labelOf [] = ""
@@ -220,9 +220,9 @@ bytesProducer _ = const Nothing
 excluding :: [Y.Premise] -> [Y.Premise] -> [Y.Premise]
 excluding premises removed = filter (\premise -> premise.result `notElem` map (.result) removed) premises
 
--- Evaluate one side-computation premise — a 'morph', 'lambda' or 'contextualize'
+-- Evaluate one side-computation premise — a 'morph', 'evaluate' or 'contextualize'
 -- of an earlier term — in isolation, binding its result meta. These never splice
--- steps into the trace: 'morph' and 'lambda' reduce on a fresh chain and discard
+-- steps into the trace: 'morph' and 'evaluate' reduce on a fresh chain and discard
 -- it, 'contextualize' is pure.
 sidePremise :: Expression -> DataizeContext -> Subst -> Y.Premise -> IO Subst
 sidePremise univ ctx subst premise = do
@@ -241,7 +241,7 @@ sidePremise univ ctx subst premise = do
 verb :: Y.Operation -> String
 verb (Y.OpMorph _) = "morph"
 verb (Y.OpNormalize _) = "normalize"
-verb (Y.OpLambda _) = "lambda"
+verb (Y.OpEvaluate _) = "evaluate"
 verb (Y.OpContextualize _ _) = "contextualize"
 verb (Y.OpDataize _) = "dataize"
 
@@ -249,7 +249,7 @@ verb (Y.OpDataize _) = "dataize"
 verbArgs :: Y.Operation -> [ExtraArgument]
 verbArgs (Y.OpMorph expr) = [ArgExpression expr]
 verbArgs (Y.OpNormalize expr) = [ArgExpression expr]
-verbArgs (Y.OpLambda expr) = [ArgExpression expr]
+verbArgs (Y.OpEvaluate expr) = [ArgExpression expr]
 verbArgs (Y.OpContextualize expr context) = [ArgExpression expr, ArgExpression context]
 verbArgs (Y.OpDataize expr) = [ArgExpression expr]
 
@@ -327,25 +327,25 @@ atom "L_number_eq" self univ ctx = do
 atom func _ _ _ = throwIO (userError (printf "Atom '%s' does not exist" (T.unpack func)))
 
 -- Augment the injected, context-free term builder with the dataization and
--- morphing operations that need the universe: 'lambda' applies an atom and
+-- morphing operations that need the universe: 'evaluate' applies an atom and
 -- 'morph' morphs a sub-expression. Both receive the universe 'univ'. Every other
 -- function is delegated unchanged.
 execBuildTerm :: Expression -> DataizeContext -> BuildTermFunc
-execBuildTerm univ ctx "lambda" = _lambda univ ctx
+execBuildTerm univ ctx "evaluate" = _evaluate univ ctx
 execBuildTerm univ ctx "morph" = _morph univ ctx
 execBuildTerm _ ctx func = _buildTerm ctx func
 
-_lambda :: Expression -> DataizeContext -> BuildTermMethod
-_lambda univ ctx [ArgExpression expr] subst = do
+_evaluate :: Expression -> DataizeContext -> BuildTermMethod
+_evaluate univ ctx [ArgExpression expr] subst = do
   form <- buildExpressionThrows expr subst
   case form of
     ExFormation bds -> do
       resolved <- formation bds univ ctx
       case resolved of
         Just obj -> pure (TeExpression obj)
-        Nothing -> throwIO (userError "Function lambda() expects a formation with a λ binding")
-    _ -> throwIO (userError "Function lambda() expects a formation")
-_lambda _ _ _ _ = throwIO (userError "Function lambda() requires exactly 1 expression argument")
+        Nothing -> throwIO (userError "Function evaluate() expects a formation with a λ binding")
+    _ -> throwIO (userError "Function evaluate() expects a formation")
+_evaluate _ _ _ _ = throwIO (userError "Function evaluate() requires exactly 1 expression argument")
 
 -- The Morphing function 𝕄 exposed as a build-term function so a rule can morph
 -- a sub-expression in its 'where' (the 'dispatch' and 'application' rules morph

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -29,7 +29,7 @@ import qualified Yaml as Y
 -- 'Dataize.execBuildTerm', not by 'buildTerm'. They are available while
 -- executing dataization and morphing rules, but not rewriting rules.
 execFunctions :: [String]
-execFunctions = ["lambda", "morph"]
+execFunctions = ["evaluate", "morph"]
 
 buildTerm :: BuildTermFunc
 buildTerm func args subst = do

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -400,7 +400,7 @@ premiseToLatex premise = case premise.operation of
   Y.OpMorph arg -> phinoMorph (renderExpr arg) "e" (renderExpr (ExMeta premise.result))
   Y.OpDataize arg -> phinoDataize (renderExpr arg) "e" (renderBytes (BtMeta premise.result))
   Y.OpNormalize arg -> phinoNormalize (renderExpr arg) (renderExpr (ExMeta premise.result))
-  Y.OpLambda arg -> phinoEvaluate (renderExpr arg) (renderExpr (ExMeta premise.result))
+  Y.OpEvaluate arg -> phinoEvaluate (renderExpr arg) (renderExpr (ExMeta premise.result))
   Y.OpContextualize arg context -> phinoContextualize (renderExpr arg) (renderExpr context) (renderExpr (ExMeta premise.result))
 
 -- Assemble an inference block from a name, optional label, optional side

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -292,5 +292,5 @@ instance Render EXTRA where
   render EXTRA{..} = render meta <> " \\coloneqq " <> macro func <> "{ " <> T.intercalate ", " (map render args) <> " }"
     where
       macro :: String -> Text
-      macro "lambda" = "\\phinoEvaluate"
+      macro "evaluate" = "\\phinoEvaluate"
       macro name = "\\" <> T.pack name

--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -238,7 +238,7 @@ data Premise = Premise
 data Operation
   = OpMorph Expression
   | OpNormalize Expression
-  | OpLambda Expression
+  | OpEvaluate Expression
   | OpContextualize Expression Expression
   | OpDataize Expression
   deriving (Eq, Generic, Show)
@@ -299,7 +299,7 @@ premiseOperation o =
   asum
     [ OpMorph <$> o .: "morph"
     , OpNormalize <$> o .: "normalize"
-    , OpLambda <$> o .: "lambda"
+    , OpEvaluate <$> o .: "evaluate"
     , do
         vals <- o .: "contextualize"
         case vals of

--- a/test-resources/cli/evaluate-in-rewrite.yaml
+++ b/test-resources/cli/evaluate-in-rewrite.yaml
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# This rule references the 'lambda' function, which needs the evaluation
+# This rule references the 'evaluate' function, which needs the evaluation
 # context and is therefore only available to dataization/morphing rules.
 # It is used to test that 'rewrite' rejects such rules at load time.
-name: uses-lambda
+name: uses-evaluate
 pattern: '!e'
 result: '!e1'
 where:
   - meta: '!e1'
-    function: lambda
+    function: evaluate
     args:
       - '!e'

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -367,8 +367,8 @@ spec = do
     it "fails when a rewriting rule uses a dataization-only function" $
       withStdin "{⟦⟧}" $
         testCLIFailed
-          ["rewrite", rule "lambda-in-rewrite.yaml"]
-          ["Function 'lambda' in rule 'uses-lambda' is available only for dataization and morphing, not for rewriting"]
+          ["rewrite", rule "evaluate-in-rewrite.yaml"]
+          ["Function 'evaluate' in rule 'uses-evaluate' is available only for dataization and morphing, not for rewriting"]
 
     it "normalizes with --normalize flag" $
       testCLISucceeded

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -139,7 +139,7 @@ spec = do
     let verb op = case op of
           Yaml.OpMorph _ -> "morph"
           Yaml.OpNormalize _ -> "normalize"
-          Yaml.OpLambda _ -> "lambda"
+          Yaml.OpEvaluate _ -> "evaluate"
           Yaml.OpContextualize _ _ -> "contextualize"
           Yaml.OpDataize _ -> "dataize"
         allowed =
@@ -192,7 +192,7 @@ spec = do
                    , "alpha"
                    , "copy"
                    , "prim"
-                   , "lambda"
+                   , "evaluate"
                    , "applicationa"
                    , "alpha"
                    , "copy"


### PR DESCRIPTION
Closes #888.

## What

The 𝔼 judgment invoked by the morphing and dataization rules was named `lambda` in the rule files and the engine, even though the paper (and the existing LaTeX rendering, `\phinoEvaluate`) refers to it as **Evaluate**. This renames the function from `lambda` to `evaluate` so the naming is consistent with the reference.

## Changes

- `resources/morphing.yaml`, `resources/dataization.yaml` — the premise keyword `lambda:` → `evaluate:` (and the surrounding comments referencing `𝔼 ('lambda')`).
- `src/Yaml.hs` — `Operation` constructor `OpLambda` → `OpEvaluate`; the parser now reads the `evaluate` key.
- `src/Dataize.hs` — `verb`/`verbArgs`/`execBuildTerm` dispatch on `"evaluate"`, the backing `_lambda` function → `_evaluate`, its error messages, and the related comments.
- `src/Functions.hs` — `execFunctions` lists `evaluate` instead of `lambda`.
- `src/LaTeX.hs`, `src/Render.hs` — the `where`-extension/premise rendering paths map `evaluate` to `\phinoEvaluate`.
- Tests + fixture renamed (`lambda-in-rewrite.yaml` → `evaluate-in-rewrite.yaml`) and the expected step-label updated.

## Out of scope (intentionally kept)

- The **morphing rule** still named `lambda` — it is a rule (it handles the λ-binding formation), not the function.
- The λ **attribute/binding** (`AtLambda`, `BiLambda`, the parser `λ` token, `AT_LAMBDA`).

## Verification

`cabal test --ghc-options=-Werror` — **1065 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExsWBfnuoQWgRnjxYXkgtk)_