### PR TITLE
Refine GLOBE morphing rule to M(Q, Q) → T

### DIFF
--- a/resources/morphing.yaml
+++ b/resources/morphing.yaml
@@ -16,9 +16,10 @@
 # 'n-result' (a premise meta or a literal), provided 'when' holds and the
 # ordered 'premises' reduce as stated. A premise binds 'n-result' to the result
 # of one judgment — 𝕄 ('morph'), 𝒩 ('normalize') or 𝔼 ('lambda'). 'e-match' is
-# the universe-argument matcher of 𝕄(n, e); it is always the e meta. Derived
-# terms are named 𝑛, 𝑛1, … in premise order; the bare 𝑛 is skipped only when
-# 'match' already binds it.
+# the universe-argument matcher of 𝕄(n, e); usually the e meta, but a rule may
+# pin it to a literal (e.g. 'globe' fires only on 𝕄(Φ, Φ)). Derived terms are
+# named 𝑛, 𝑛1, … in premise order; the bare 𝑛 is skipped only when 'match'
+# already binds it.
 #
 # 'lambda' and 'dispatch' are kept mutually exclusive: 'dispatch' fires only
 # when its head 𝑛 is not a formation ('not (formation 𝑛)'), so every formation
@@ -117,5 +118,5 @@
 - name: globe
   label: globe
   match: Φ
-  e-match: 𝑒
+  e-match: Φ
   n-result: ⊥

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -72,8 +72,9 @@ formation bds univ ctx = do
 
 -- The Morphing function 𝕄 maps normal forms to formations. It is binary,
 -- 𝕄(n, e): besides the term 'n' it takes the universe 'e' ('univ') — a plain
--- expression — and matches it against the rule's 'e-match' pattern (always the
--- '𝑒' meta), which binds 'e' so the 'root' rule substitutes it. It is driven by
+-- expression — and matches it against the rule's 'e-match' pattern (usually the
+-- '𝑒' meta, which binds 'e' so the 'root' rule substitutes it, but a rule may
+-- pin it to a literal such as 'globe' matching Φ). It is driven by
 -- the ordered rules from 'morphing.yaml': the first matching rule's premises are
 -- evaluated and its conclusion 'nresult' is built, always forwarding the same
 -- universe. The 'morph' premise that produces the conclusion is the spine: when

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1104,7 +1104,7 @@ spec = do
             , "\\begin{phinoInference}"
             , "  \\phinoName{globe}"
             , "  \\phinoLabel{globe}"
-            , "  \\phinoConclusion{ \\phinoMorph{ Q }{ e }{ T } }"
+            , "  \\phinoConclusion{ \\phinoMorph{ Q }{ Q }{ T } }"
             , "\\end{phinoInference}"
             ]
         ]


### PR DESCRIPTION
Closes #897.

## What

The `globe` rule in `resources/morphing.yaml` matched `𝕄(Φ, e)` — the global object `Φ` against *any* universe `e`. The issue asks for the more precise `𝕄(Φ, Φ) → ⊥`.

The fix pins the rule's `e-match` from the `𝑒` meta to the literal `Φ`:

```yaml
- name: globe
  label: globe
  match: Φ
  e-match: Φ   # was: 𝑒
  n-result: ⊥
```

## Why it's behavior-preserving

The preceding `root` rule already fires for every `e ≠ Φ` (its guard is `not eq [𝑒, Φ]`), so `globe` was only ever reached when `e = Φ`. Pinning `e-match` to `Φ` simply makes that implicit precondition explicit. No reduction changes.

## Other changes

- Updated the explanatory comments in `morphing.yaml` and `Dataize.hs` that claimed `e-match` is "always the `𝑒` meta" — a rule may now pin it to a literal.
- Updated the `explain` CLI test expectation in `CLISpec.hs`: the globe rule's rendered conclusion is now `\phinoMorph{ Q }{ Q }{ T }` (the middle argument renders `e-match`, and `Φ` renders as `Q`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9qwg967SKMFRFydEkLNVv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9qwg967SKMFRFydEkLNVv)_