### PR TITLE
feat(#887): define contextualization in YAML and add `explain --contextualize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,9 @@ d >> 68-65-6C-6C-6F
 ## Explain
 
 You can _explain_ the built-in rules by printing them in [LaTeX][latex]
-format. Pass exactly one of `--normalize`, `--morph` or `--dataize` for
-the rewriting, morphing (𝕄) or dataization (𝔻) rules (or `--rule` for a
-custom rule file):
+format. Pass exactly one of `--normalize`, `--morph`, `--dataize` or
+`--contextualize` for the rewriting, morphing (𝕄), dataization (𝔻) or
+contextualization (𝒞) rules (or `--rule` for a custom rule file):
 
 ```bash
 $ phino explain --normalize
@@ -266,6 +266,22 @@ $ phino explain --dataize
   { }
   { }
 \end{tabular}
+```
+
+```bash
+$ phino explain --contextualize
+\begin{phinoInference}
+  \phinoName{cxi}
+  \phinoLabel{xi}
+  \phinoConclusion{ \phinoContextualize{ \phiTerminal{\xi} }{ k }{ k } }
+\end{phinoInference}
+...
+\begin{phinoInference}
+  \phinoName{cdispatch}
+  \phinoLabel{disp}
+  \phinoPremise{ \phinoContextualize{ n }{ k }{ n_1 } }
+  \phinoConclusion{ \phinoContextualize{ n . \tau }{ k }{ n_1 . \tau } }
+\end{phinoInference}
 ```
 
 For more details, use `phino [COMMAND] --help` option.

--- a/resources/contextualization.yaml
+++ b/resources/contextualization.yaml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Contextualization 𝒞 — applied top-to-bottom, first matching clause wins. It is
+# binary, 𝒞(n, c): n is the term being contextualized and c is the context (the
+# expression that every free ξ inside n stands for). 𝒞 walks the term
+# structurally, replacing each ξ with the context c, descending through
+# dispatches and applications and stopping at formations — which introduce their
+# own scope and are returned untouched — and at the global Φ and termination ⊥.
+#
+# Each rule is an inference rule: when 'match' matches the term and 'c-match'
+# matches the context (binding the meta c), the rule yields the conclusion
+# 'c-result' (a premise meta or a literal), provided the ordered 'premises'
+# reduce as stated. A premise binds its 'n-result' to one 𝒞 ('contextualize')
+# judgment. 'c-match' is the context-argument matcher of 𝒞(n, c); it is always
+# the c meta. Derived terms are named 𝑛, 𝑛1, … in premise order; the bare 𝑛 is
+# skipped only when 'match' already binds it.
+
+- name: cglobe
+  label: globe
+  match: Φ
+  c-match: 𝑘
+  c-result: Φ
+
+- name: cxi
+  label: xi
+  match: ξ
+  c-match: 𝑘
+  c-result: 𝑘
+
+- name: cdead
+  label: dead
+  match: ⊥
+  c-match: 𝑘
+  c-result: ⊥
+
+- name: cprim
+  label: prim
+  match: ⟦𝐵⟧
+  c-match: 𝑘
+  c-result: ⟦𝐵⟧
+
+- name: cdispatch
+  label: disp
+  match: '𝑛.𝜏'
+  c-match: 𝑘
+  c-result: '𝑛1.𝜏'
+  premises:
+    - n-result: 𝑛1
+      contextualize:
+        - 𝑛
+        - 𝑘
+
+- name: capplication
+  label: app
+  match: '𝑛(𝜏 ↦ 𝑒1)'
+  c-match: 𝑘
+  c-result: '𝑛1(𝜏 ↦ 𝑛2)'
+  premises:
+    - n-result: 𝑛1
+      contextualize:
+        - 𝑛
+        - 𝑘
+    - n-result: 𝑛2
+      contextualize:
+        - 𝑒1
+        - 𝑘
+
+- name: capplicationa
+  label: appa
+  match: '𝑛(α𝑖 ↦ 𝑒1)'
+  c-match: 𝑘
+  c-result: '𝑛1(α𝑖 ↦ 𝑛2)'
+  premises:
+    - n-result: 𝑛1
+      contextualize:
+        - 𝑛
+        - 𝑘
+    - n-result: 𝑛2
+      contextualize:
+        - 𝑒1
+        - 𝑘

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -180,6 +180,9 @@ optMorph = switch (long "morph" <> help "Explain built-in morphing rules")
 optDataize :: Parser Bool
 optDataize = switch (long "dataize" <> help "Explain built-in dataization rules")
 
+optContextualize :: Parser Bool
+optContextualize = switch (long "contextualize" <> help "Explain built-in contextualization rules")
+
 optTarget :: Parser (Maybe FilePath)
 optTarget = optional (strOption (long "target" <> short 't' <> metavar "FILE" <> help "File to save output to"))
 
@@ -234,6 +237,7 @@ explainParser =
             <*> optNormalize
             <*> optMorph
             <*> optDataize
+            <*> optContextualize
             <*> optShuffle
             <*> optTarget
         )

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -22,7 +22,7 @@ import Dataize
 import Encoding
 import qualified Filter as F
 import Functions (buildTerm)
-import LaTeX (explainDataizeRules, explainMorphRules, explainRules)
+import LaTeX (explainContextualizeRules, explainDataizeRules, explainMorphRules, explainRules)
 import Logger
 import Margin (defaultMargin)
 import Merge (merge)
@@ -189,12 +189,13 @@ runExplain OptsExplain{..} = do
     explained
       | _morph = pure (explainMorphRules Y.morphingRules)
       | _dataize = pure (explainDataizeRules Y.dataizationRules)
+      | _contextualize = pure (explainContextualizeRules Y.contextualizationRules)
       | otherwise = explainRules <$> getRules _normalize _shuffle _rules
     validateOpts :: IO ()
     validateOpts = do
-      let selected = length (filter id [not (null _rules), _normalize, _morph, _dataize])
-      when (selected == 0) (invalidCLIArguments "Either --rule, --normalize, --morph or --dataize must be specified")
-      when (selected > 1) (invalidCLIArguments "Only one of --rule, --normalize, --morph or --dataize can be specified")
+      let selected = length (filter id [not (null _rules), _normalize, _morph, _dataize, _contextualize])
+      when (selected == 0) (invalidCLIArguments "Either --rule, --normalize, --morph, --dataize or --contextualize must be specified")
+      when (selected > 1) (invalidCLIArguments "Only one of --rule, --normalize, --morph, --dataize or --contextualize can be specified")
 
 runMerge :: OptsMerge -> IO ()
 runMerge OptsMerge{..} = do

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -108,6 +108,7 @@ data OptsExplain = OptsExplain
   , _normalize :: Bool
   , _morph :: Bool
   , _dataize :: Bool
+  , _contextualize :: Bool
   , _shuffle :: Bool
   , _targetFile :: Maybe FilePath
   }

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -12,6 +12,7 @@ module LaTeX
   ( explainRules
   , explainMorphRules
   , explainDataizeRules
+  , explainContextualizeRules
   , rewrittensToLatex
   , programToLaTeX
   , expressionToLaTeX
@@ -392,6 +393,17 @@ explainDataizeRule rule =
     (map premiseToLatex rule.premises)
     (phinoDataize (renderExpr rule.match) (renderExpr rule.ematch) (renderBytes rule.dresult))
 
+-- Render a contextualization rule as a LaTeX inference rule, with 𝒞(match, c) ⟿
+-- c-result as the conclusion below the line.
+explainContextualizeRule :: Y.ContextualizeRule -> String
+explainContextualizeRule rule =
+  inference
+    rule.name
+    rule.label
+    Nothing
+    (map premiseToLatex rule.premises)
+    (phinoContextualize (renderExpr rule.match) (renderExpr rule.cmatch) (renderExpr rule.cresult))
+
 -- One premise judgment, rendered per its operation. 𝕄 ('morph') and 𝔻
 -- ('dataize') are binary and carry the universe 'e' they were given; the rest
 -- are unary.
@@ -487,3 +499,6 @@ explainMorphRules = intercalate "\n" . map explainMorphRule
 
 explainDataizeRules :: [Y.DataizeRule] -> String
 explainDataizeRules = intercalate "\n" . map explainDataizeRule
+
+explainContextualizeRules :: [Y.ContextualizeRule] -> String
+explainContextualizeRules = intercalate "\n" . map explainContextualizeRule

--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -272,6 +272,20 @@ data DataizeRule = DataizeRule
   }
   deriving (Generic, Show)
 
+-- One contextualization rule in inference-rule form, structured like 'MorphRule'
+-- but binary in 𝒞(n, c): the second argument is the context 'c' ('cmatch',
+-- always the 'c' meta) rather than the universe 'e', and the conclusion is the
+-- contextualized term 'cresult'.
+data ContextualizeRule = ContextualizeRule
+  { name :: String
+  , label :: Maybe String
+  , match :: Expression
+  , cmatch :: Expression
+  , cresult :: Expression
+  , premises :: [Premise]
+  }
+  deriving (Generic, Show)
+
 instance FromJSON Premise where
   parseJSON =
     withObject
@@ -338,6 +352,20 @@ instance FromJSON DataizeRule where
             <*> o .:? "premises" .!= []
       )
 
+instance FromJSON ContextualizeRule where
+  parseJSON =
+    withObject
+      "ContextualizeRule"
+      ( \o ->
+          ContextualizeRule
+            <$> o .: "name"
+            <*> o .:? "label"
+            <*> o .: "match"
+            <*> o .: "c-match"
+            <*> o .: "c-result"
+            <*> o .:? "premises" .!= []
+      )
+
 decodeRules :: (FromJSON a) => FilePath -> BS.ByteString -> [a]
 decodeRules path bs = case Yaml.decodeEither' bs of
   Right rs -> rs
@@ -350,3 +378,7 @@ morphingRules = decodeRules "resources/morphing.yaml" $(embedFile "resources/mor
 dataizationRules :: [DataizeRule]
 {-# NOINLINE dataizationRules #-}
 dataizationRules = decodeRules "resources/dataization.yaml" $(embedFile "resources/dataization.yaml")
+
+contextualizationRules :: [ContextualizeRule]
+{-# NOINLINE contextualizationRules #-}
+contextualizationRules = decodeRules "resources/contextualization.yaml" $(embedFile "resources/contextualization.yaml")

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1155,15 +1155,62 @@ spec = do
             ]
         ]
 
+    it "explains contextualization rules" $
+      testCLISucceeded
+        ["explain", "--contextualize"]
+        [ unlines
+            [ "\\begin{phinoInference}"
+            , "  \\phinoName{cglobe}"
+            , "  \\phinoLabel{globe}"
+            , "  \\phinoConclusion{ \\phinoContextualize{ Q }{ k }{ Q } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{cxi}"
+            , "  \\phinoLabel{xi}"
+            , "  \\phinoConclusion{ \\phinoContextualize{ \\phiTerminal{\\xi} }{ k }{ k } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{cdead}"
+            , "  \\phinoLabel{dead}"
+            , "  \\phinoConclusion{ \\phinoContextualize{ T }{ k }{ T } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{cprim}"
+            , "  \\phinoLabel{prim}"
+            , "  \\phinoConclusion{ \\phinoContextualize{ [[ B ]] }{ k }{ [[ B ]] } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{cdispatch}"
+            , "  \\phinoLabel{disp}"
+            , "  \\phinoPremise{ \\phinoContextualize{ n }{ k }{ n_1 } }"
+            , "  \\phinoConclusion{ \\phinoContextualize{ n . \\tau }{ k }{ n_1 . \\tau } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{capplication}"
+            , "  \\phinoLabel{app}"
+            , "  \\phinoPremise{ \\phinoContextualize{ n }{ k }{ n_1 } }"
+            , "  \\phinoPremise{ \\phinoContextualize{ e_1 }{ k }{ n_2 } }"
+            , "  \\phinoConclusion{ \\phinoContextualize{ n ( \\tau -> e_1 ) }{ k }{ n_1 ( \\tau -> n_2 ) } }"
+            , "\\end{phinoInference}"
+            , "\\begin{phinoInference}"
+            , "  \\phinoName{capplicationa}"
+            , "  \\phinoLabel{appa}"
+            , "  \\phinoPremise{ \\phinoContextualize{ n }{ k }{ n_1 } }"
+            , "  \\phinoPremise{ \\phinoContextualize{ e_1 }{ k }{ n_2 } }"
+            , "  \\phinoConclusion{ \\phinoContextualize{ n ( \\phiTerminal{\\alpha_{i}} -> e_1 ) }{ k }{ n_1 ( \\phiTerminal{\\alpha_{i}} -> n_2 ) } }"
+            , "\\end{phinoInference}"
+            ]
+        ]
+
     it "fails with no rules specified" $
       testCLIFailed
         ["explain"]
-        ["Either --rule, --normalize, --morph or --dataize must be specified"]
+        ["Either --rule, --normalize, --morph, --dataize or --contextualize must be specified"]
 
     it "fails when more than one rule set is specified" $
       testCLIFailed
         ["explain", "--morph", "--dataize"]
-        ["Only one of --rule, --normalize, --morph or --dataize can be specified"]
+        ["Only one of --rule, --normalize, --morph, --dataize or --contextualize can be specified"]
 
     it "writes to target file" $
       bracket

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -167,11 +167,12 @@ spec = do
         (expectationFailure ("Dataization emitted step labels with no defining rule or operation: " ++ show orphans))
 
   describe "names every rule uniquely across rule sets" $
-    it "shares no rule name between morphing, dataization and normalization" $ do
+    it "shares no rule name between morphing, dataization, normalization and contextualization" $ do
       let names =
             map (.name) Yaml.morphingRules
               ++ map (.name) Yaml.dataizationRules
               ++ map (.name) Yaml.normalizationRules
+              ++ map (.name) Yaml.contextualizationRules
           clashes = nub (filter (\n -> length (filter (== n) names) > 1) names)
       clashes `shouldBe` []
 


### PR DESCRIPTION
Closes #887.

## Problem

Normalization, morphing and dataization all have YAML definitions and can be printed in LaTeX via `phino explain`. Contextualization (𝒞) was the odd one out — implemented only in Haskell (`Builder.contextualize`) — so it could not be printed in LaTeX.

## Changes

- **`resources/contextualization.yaml`** — the 𝒞(n, c) rules expressed in the same inference-rule form as `morphing.yaml`/`dataization.yaml`. The second argument is the context `c` (matched by `c-match`, always the `𝑘` meta), and the conclusion is `c-result`. The rule set mirrors `Builder.contextualize`: `cglobe` (Φ stays), `cxi` (ξ → context), `cdead` (⊥ stays), `cprim` (formation stays), and the structural `cdispatch`/`capplication`/`capplicationa` rules that recurse via `contextualize` premises.
- **`src/Yaml.hs`** — new `ContextualizeRule` type, its `FromJSON` instance, and the `file-embed`-backed `contextualizationRules`.
- **`src/LaTeX.hs`** — `explainContextualizeRule`/`explainContextualizeRules`, rendering each rule as a `phinoInference` block via the existing `phinoContextualize` macro and `premiseToLatex`.
- **`src/CLI/{Types,Parsers,Runners}.hs`** — new `--contextualize` flag on `explain`, mutually exclusive with `--rule`/`--normalize`/`--morph`/`--dataize`; validation messages updated accordingly.
- **`README.md`** — documents the new flag with an example.

## Usage

```
$ phino explain --contextualize
\begin{phinoInference}
  \phinoName{cxi}
  \phinoLabel{xi}
  \phinoConclusion{ \phinoContextualize{ \phiTerminal{\xi} }{ k }{ k } }
\end{phinoInference}
...
```

## Tests

- `CLISpec`: new "explains contextualization rules" case asserting the full LaTeX output; updated the two `explain` validation-message cases.
- `DataizeSpec`: the rule-name uniqueness test now also covers `contextualizationRules` (which forces the new YAML to parse).

Note: the executor still uses `Builder.contextualize` at runtime; the YAML is the printable specification (this PR is scoped to the LaTeX-printability problem described in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UMpen7VKAK7N1k3LUCiJCm)_