### PR TITLE
fix(#902): guard the `none` dataization rule with a disjoint condition

### DIFF
--- a/resources/dataization.yaml
+++ b/resources/dataization.yaml
@@ -59,6 +59,10 @@
   match: ⟦𝐵⟧
   e-match: 𝑒
   d-result: '--'
+  when:
+    disjoint:
+      - [Δ, λ, φ]
+      - [𝐵]
 
 - name: bott
   label: bott

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1138,6 +1138,7 @@ spec = do
             , "\\begin{phinoInference}"
             , "  \\phinoName{none}"
             , "  \\phinoLabel{none}"
+            , "  \\phinoCondition{ [ D, L, @ ] \\cap \\lparen B \\rparen = \\emptyset }"
             , "  \\phinoConclusion{ \\phinoDataize{ [[ B ]] }{ e }{ -- } }"
             , "\\end{phinoInference}"
             , "\\begin{phinoInference}"


### PR DESCRIPTION
Fixes #902.

## Problem

The `none` rule in `resources/dataization.yaml` matched any formation `⟦𝐵⟧` and yielded empty bytes `--` with no `when` guard. It was correct only because 𝔻 walks rules top-to-bottom and stops at the first match (`firstMatch Y.dataizationRules`, `src/Dataize.hs:153`), so `none` happened to sit after `delta`, `box`, and `fire`. Reordering the rules would let `none` shadow those three specific clauses and wrongly return `--` for a formation that should dataize through its Δ, φ, or λ.

## Change

Added the same kind of guard `box` already uses:

```yaml
when:
  disjoint:
    - [Δ, λ, φ]
    - [𝐵]
```

This asserts the matched bindings `𝐵` carry none of Δ, λ, or φ. The `disjoint` condition (`src/Rule.hs:233`) holds when none of the listed attributes is present in the union of the named binding metas. With the guard in place, `none` is self-describing and the dataization rules can be applied in any order. The empty-formation case (`⟦⟧ ⇒ --`) still matches, since an empty binding set carries none of Δ, λ, φ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9gh4HKJb1EkBzLNCeajb2

---
_Generated by [Claude Code](https://claude.ai/code/session_01R9gh4HKJb1EkBzLNCeajb2)_