### PR TITLE
fix(#905): guard the `norm` dataization rule so clause order is not load-bearing

### DIFF
--- a/resources/dataization.yaml
+++ b/resources/dataization.yaml
@@ -15,6 +15,14 @@
 # 𝔻(n, e); it is always the e meta. The single bytes result is named δ; derived
 # terms are 𝑛, 𝑛1, … in premise order, skipping the bare 𝑛 only when 'match'
 # already binds it.
+#
+# The clauses are disjoint, so their relative order does not change behavior.
+# 'norm' matches the bare meta 𝑛, which unifies with any expression, so it is
+# guarded to fire only when 𝑛 is neither a formation ('not (formation 𝑛)',
+# carving out 'delta', 'box', 'fire' and 'none') nor the termination ⊥
+# ('not (𝑛 = ⊥)', carving out 'bott'). Without the guard 'norm' would behave
+# correctly only by being declared last; with it the clauses no longer rely on
+# their order.
 
 - name: delta
   label: \Delta
@@ -75,6 +83,14 @@
   match: 𝑛
   e-match: 𝑒
   d-result: δ
+  when:
+    and:
+      - not:
+          formation: 𝑛
+      - not:
+          eq:
+            - 𝑛
+            - ⊥
   premises:
     - n-result: 𝑛1
       morph: 𝑛

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1149,6 +1149,7 @@ spec = do
             , "\\begin{phinoInference}"
             , "  \\phinoName{norm}"
             , "  \\phinoLabel{norm}"
+            , "  \\phinoCondition{ \\phinoNotFormation{ n } \\;\\text{and}\\; n \\not= T }"
             , "  \\phinoPremise{ \\phinoMorph{ n }{ e }{ n_1 } }"
             , "  \\phinoPremise{ \\phinoDataize{ n_1 }{ e }{ \\delta } }"
             , "  \\phinoConclusion{ \\phinoDataize{ n }{ e }{ \\delta } }"

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -95,6 +95,27 @@ spec = do
       morph (chain, (Program ExRoot, Nothing) :| []) ExRoot (defaultDataizeContext ExRoot)
         `shouldThrow` (\e -> "Atom 'F' does not exist" `isInfixOf` show (e :: SomeException))
 
+  -- 'norm' matches the bare meta 𝑛, which unifies with any expression, so it is
+  -- guarded to fire only when 𝑛 is neither a formation ('not (formation 𝑛)',
+  -- left to 'delta'/'box'/'fire'/'none') nor the termination ⊥ ('not (𝑛 = ⊥)',
+  -- left to 'bott'). The dataization clauses are therefore disjoint and their
+  -- order in 'dataization.yaml' cannot change behavior.
+  describe "dataization 'norm' is disjoint from the specific clauses" $ do
+    let rctx = RuleContext (execBuildTerm ExRoot (defaultDataizeContext ExRoot))
+        dataizeRule :: String -> Yaml.DataizeRule
+        dataizeRule nm = fromMaybe (error ("no dataization rule named " ++ nm)) (find (\r -> r.name == nm) Yaml.dataizationRules)
+        asRule :: Yaml.DataizeRule -> Yaml.Rule
+        asRule r = Yaml.Rule r.name Nothing Nothing r.match ExRoot r.when Nothing Nothing
+    it "does not fire on a formation" $ do
+      substs <- matchExpressionWithRule' [substEmpty] (ExFormation [BiDelta (BtOne "00")]) (asRule (dataizeRule "norm")) rctx
+      substs `shouldBe` []
+    it "does not fire on the termination ⊥" $ do
+      substs <- matchExpressionWithRule' [substEmpty] ExTermination (asRule (dataizeRule "norm")) rctx
+      substs `shouldBe` []
+    it "still fires on a non-formation, non-termination normal form" $ do
+      substs <- matchExpressionWithRule' [substEmpty] (ExDispatch ExXi (AtLabel "x")) (asRule (dataizeRule "norm")) rctx
+      null substs `shouldBe` False
+
   describe "dataize" $
     test
       dataize'


### PR DESCRIPTION
Closes #905.

## Problem

The `norm` dataization rule (`resources/dataization.yaml`) matches the bare meta `𝑛`, which unifies with any expression. Rule selection in `dataize'` (`src/Dataize.hs`) walks the rules in fixed YAML order and takes the first match, so `norm` only behaved correctly because it is declared last and catches whatever the earlier clauses left over. This made the declaration order load-bearing: `norm` overlaps every preceding clause — `delta`, `box`, `fire`, `none` (all formations) and `bott` (`⊥`).

## Fix

Add a `when` guard so `norm` fires only when `𝑛` is neither a formation nor the termination `⊥`:

```yaml
when:
  and:
    - not:
        formation: 𝑛
    - not:
        eq:
          - 𝑛
          - ⊥
```

- `not (formation 𝑛)` reuses the existing `_isFormation` condition (`src/Rule.hs`), carving out `delta`, `box`, `fire` and `none`.
- `not (𝑛 = ⊥)` carves out `bott`. Since `T` and `⊥` both parse to `ExTermination`, the single check covers both.

With this guard the dataization clauses are disjoint and apply in any order — mirroring what morphing already did for `lambda`/`dispatch`. The header comment in `resources/dataization.yaml` is updated to document the invariant.

## Tests

Added a `dataization 'norm' is disjoint from the specific clauses` block in `test/DataizeSpec.hs` (mirroring the existing `dispatch`/`lambda` disjointness test) asserting `norm` does not fire on a formation or on `⊥`, but still fires on a non-formation, non-termination normal form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XoLXw5ve6cwjPBYymS2NXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoLXw5ve6cwjPBYymS2NXV)_