### PR TITLE
fix(#926): emit \phinoContextualize for the contextualize EXTRA

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -46,7 +46,7 @@ jobs:
             printf '\\documentclass{article}\n'
             printf '\\usepackage{mathtools}\n'
             printf '\\usepackage{eolang}\n'
-            printf '\\newcommand\\ctx[2]{#1 #2}\n'
+            printf '\\newcommand\\phinoContextualize[3]{#1 #2 #3}\n'
             printf '\\newcommand\\phinoEvaluate[1]{\\mathbb{E}( #1 )}\n'
             printf '\\newcommand\\phinoMorph[3]{\\mathbb{M}( #1, #2, #3 )}\n'
             printf '\\newcommand\\indexof[1]{#1}\n'

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -284,7 +284,7 @@ instance Render EXTRA_ARG where
   render ARG_BYTES{..} = render bytes
 
 instance Render EXTRA where
-  render EXTRA{func = "contextualize", args = arg : rest, ..} = render meta <> " \\coloneqq \\ctx{ " <> render arg <> " }{ " <> T.intercalate ", " (map render rest) <> " }"
+  render EXTRA{func = "contextualize", args = arg : rest, ..} = "\\phinoContextualize{ " <> render arg <> " }{ " <> T.intercalate ", " (map render rest) <> " }{ " <> render meta <> " }"
   -- 𝕄 carries the universe and threads a state, 𝕄(n, e, s_1), so a 'morph' extra
   -- renders with the universe metavariable 'e' and the incoming state 's_1' as its
   -- trailing arguments. This is a one-off application binding only 'meta', so the

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1007,7 +1007,7 @@ spec = do
             , "  { [[ B_1, \\tau -> n, B_2 ]] . \\tau }"
             , "  { e ( \\phiTerminal{\\rho} -> [[ B_1, \\tau -> n, B_2 ]] ) }"
             , "  { }"
-            , "  { e \\coloneqq \\ctx{ n }{ [[ B_1, \\tau -> n, B_2 ]] } }"
+            , "  { \\phinoContextualize{ n }{ [[ B_1, \\tau -> n, B_2 ]] }{ e } }"
             , "\\phinoNormalizationRule{miss}"
             , "  { [[ B ]] ( \\tau -> e ) }"
             , "  { T }"


### PR DESCRIPTION
Fixes #926.

## Problem

`phino explain --normalize` emitted the `dot` normalization rule's result row using the legacy `\ctx{}` macro:

```
{ e \coloneqq \ctx{ n }{ [[ B_1, \tau -> n, B_2 ]] } }
```

The project has standardized on the `\phinoContextualize{ input }{ context }{ result }` macro (helper at `src/LaTeX.hs:503-504`, used by the premise-conclusion rendering path). The two rendering paths disagreed.

## Fix

- `src/Render.hs:287` — the `Render EXTRA` instance for `func = "contextualize"` now emits `\phinoContextualize{ input }{ context }{ result }`, reusing the same `{ input }{ context }{ result }` order as `phinoContextualize` in `src/LaTeX.hs`. The result now reads:

  ```
  { \phinoContextualize{ n }{ [[ B_1, \tau -> n, B_2 ]] }{ e } }
  ```

- `test/CLISpec.hs` (~line 1010) — updated the matching expectation.

## Notes

No Haskell toolchain was available in this environment, so the test suite could not be run here. The change is a one-line rendering update whose output matches the updated `CLISpec` expectation by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xxvM4Q5PN3shfXiSapCBo

---
_Generated by [Claude Code](https://claude.ai/code/session_015xxvM4Q5PN3shfXiSapCBo)_