### PR TITLE
chore(deps): update haskell-actions/run-fourmolu action to v13

### DIFF
--- a/.github/workflows/fourmolu.yml
+++ b/.github/workflows/fourmolu.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: haskell-actions/run-fourmolu@v12
+      - uses: haskell-actions/run-fourmolu@v13
         with:
           version: '0.17.0.0'
           pattern: |


### PR DESCRIPTION
Bumps `haskell-actions/run-fourmolu` from v12 to v13 in the fourmolu workflow.

```yaml
- uses: haskell-actions/run-fourmolu@v13
  with:
    version: '0.17.0.0'
```

v13 adds support for the zipfile distribution format that fourmolu uses from `0.20.0.0` onward, while staying backwards compatible with the raw-binary format of `0.17.0.0` that we pin today. The bump is harmless now and unblocks moving to a newer fourmolu later.

This mirrors Renovate PR #841, which went red only because it was branched from a stale `master` carrying an unrelated, since-fixed test failure. This branch sits on top of current `master`, so CI starts clean.
