### PR TITLE
chore(deps): update maxonfjvipon/deps-sentinel-action action to 0.0.4

### DIFF
--- a/.github/workflows/deps-sentinel.yml
+++ b/.github/workflows/deps-sentinel.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: maxonfjvipon/deps-sentinel-action@0.0.3
+      - uses: maxonfjvipon/deps-sentinel-action@0.0.4
         with:
           token: ${{ secrets.MERGE_TOKEN }}
           owner: yegor256


### PR DESCRIPTION
Bumps the auto-merge action from `0.0.3` to `0.0.4`.

GitHub started gating workflows triggered by the default `GITHUB_TOKEN` (the `version-up` pull request from `github-actions[bot]`) behind manual approval. Those runs produce no check runs, so the sentinel saw "no checks, unstable" and skipped forever — every version bump stalled with "16 workflows awaiting approval".

`0.0.4` teaches the action to approve runs awaiting approval on the bot pull request's head commit before merging, so CI can start and the merge proceeds. The `MERGE_TOKEN` actor (repo owner) differs from `github-actions[bot]`, which is what GitHub requires to approve.