### PR TITLE
Render disjoint condition without parens for a single group

### DIFF
--- a/src/Render.hs
+++ b/src/Render.hs
@@ -273,9 +273,13 @@ instance Render CONDITION where
   render CO_DISJOINT{..} =
     "[ "
       <> T.intercalate " \\char44{} " (map render attrs)
-      <> " ] \\cap \\lparen "
-      <> T.intercalate " \\cup " (map render groups)
-      <> " \\rparen = \\emptyset"
+      <> " ] \\cap "
+      <> renderGroups groups
+      <> " = \\emptyset"
+    where
+      renderGroups :: [BINDING] -> Text
+      renderGroups [group] = render group
+      renderGroups gs = "\\lparen " <> T.intercalate " \\cup " (map render gs) <> " \\rparen"
   render CO_EMPTY = ""
 
 renderFunc :: Render a => Text -> a -> Text

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1132,7 +1132,7 @@ spec = do
             , "\\end{phinoDataizationInference}"
             , "\\begin{phinoDataizationInference}"
             , "  \\phinoName{none}"
-            , "  \\phinoCondition{ [ D \\char44{} L \\char44{} @ ] \\cap \\lparen B \\rparen = \\emptyset }"
+            , "  \\phinoCondition{ [ D \\char44{} L \\char44{} @ ] \\cap B = \\emptyset }"
             , "  \\phinoPremise{ \\phinoDataize{ T }{ e }{ s_1 }{ \\delta }{ s_2 } }"
             , "  \\phinoConclusion{ \\phinoDataize{ [[ B ]] }{ e }{ s_1 }{ \\delta }{ s_2 } }"
             , "\\end{phinoDataizationInference}"


### PR DESCRIPTION
## What

`phino explain --dataize` printed the `none` rule's disjoint condition as:

```
[ D \char44{} L \char44{} @ ] \cap \lparen B \rparen = \emptyset
```

The `\lparen`/`\rparen` wrapped a single group `B`. Those parentheses only group the `\cup` operator — with one group there is no `\cup` and nothing to disambiguate, so they are noise. They are warranted only when two or more groups are joined (e.g. the `box` rule's `\lparen B_1 \cup B_2 \rparen`).

## How

In `render CO_DISJOINT` (`src/Render.hs`), the wrapping is now conditional via a `where`-bound `renderGroups` helper: a lone group renders without delimiters, two or more are joined with `\cup` inside `\lparen ... \rparen`.

The `none` rule now renders as:

```
[ D \char44{} L \char44{} @ ] \cap B = \emptyset
```

Updated the corresponding expectation in `test/CLISpec.hs` ("explains dataization rules"). The `box` rule's two-group output is unchanged.

Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB9u2UjvXXLKpXZrTP5bBw)_