### PR TITLE
fix(#947): express mg morphing rule as a premise that morphs ⊥

### DIFF
--- a/resources/morphing.yaml
+++ b/resources/morphing.yaml
@@ -115,4 +115,7 @@
 - name: mg
   match: Φ
   e-match: Φ
-  n-result: ⊥
+  n-result: 𝑛
+  premises:
+    - n-result: 𝑛
+      morph: ⊥

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1101,7 +1101,8 @@ spec = do
             , "\\end{phinoMorphingInference}"
             , "\\begin{phinoMorphingInference}"
             , "  \\phinoName{mg}"
-            , "  \\phinoConclusion{ \\phinoMorph{ Q }{ Q }{ s }{ T }{ s } }"
+            , "  \\phinoPremise{ \\phinoMorph{ T }{ e }{ s_1 }{ n }{ s_2 } }"
+            , "  \\phinoConclusion{ \\phinoMorph{ Q }{ Q }{ s_1 }{ n }{ s_2 } }"
             , "\\end{phinoMorphingInference}"
             ]
         ]


### PR DESCRIPTION
Closes #947.

## Problem

The `mg` rule in `resources/morphing.yaml` fired on 𝕄(Φ, Φ) and assigned its conclusion directly to the literal `⊥`, instead of following the premise-conclusion inference schema used by every other 𝕄 rule.

## Fix

Refactor `mg` to derive its result through a premise rather than naming the literal:

```yaml
- name: mg
  match: Φ
  e-match: Φ
  n-result: 𝑛
  premises:
    - n-result: 𝑛
      morph: ⊥
```

This expresses the rule as the inference "𝕄(Φ, Φ, s) → (𝑛, s)" derived from "𝕄(⊥, Φ, s) → (𝑛, s)", mirroring the way dataization's `none` rule delegates to `end` (#945). Behavior is unchanged: the premise morphs `⊥`, which matches the `dead` rule and returns `⊥`, so the final morphed term is identical.

## Tests

Updated the `explain --morph` LaTeX expectation in `test/CLISpec.hs` so the `mg` inference now renders its `morph ⊥` premise above the conclusion line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAB6P8hvGyr8a89BT9AnBw)_