### PR TITLE
fix(#955): drop dataization `end` rule so 𝔻(⊥) fails instead of yielding empty bytes

### DIFF
--- a/.github/workflows/latex.yml
+++ b/.github/workflows/latex.yml
@@ -59,7 +59,7 @@ jobs:
             printf '\\begin{document}\n'
             "${e}" explain --normalize
             printf '{[[ x -> [[ y -> ? ]].y ]]}' | "${e}" rewrite --normalize --output=latex --sequence
-            printf '{[[ x -> [[ y -> ? ]].y ]]}' | "${e}" dataize --output=latex --sequence --quiet
+            printf '{[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]]}' | "${e}" dataize --output=latex --sequence --quiet
             printf '\\end{document}\n'
           ) > article.tex
           pdflatex -shell-escape -interaction=errorstopmode -halt-on-error article

--- a/resources/dataization.yaml
+++ b/resources/dataization.yaml
@@ -22,9 +22,11 @@
 # 'norm' matches the bare meta 𝑛, which unifies with any expression, so it is
 # guarded to fire only when 𝑛 is neither a formation ('not (formation 𝑛)',
 # carving out 'delta', 'box', 'fire' and 'none') nor the termination ⊥
-# ('not (𝑛 = ⊥)', carving out 'end'). Without the guard 'norm' would behave
-# correctly only by being declared last; with it the clauses no longer rely on
-# their order.
+# ('not (𝑛 = ⊥)'). 𝔻 is partial: ⊥ (the terminator T) signals an error and
+# lies outside its domain, so it deliberately matches no clause and dataization
+# stops there — there is no 'end' rule mapping ⊥ to empty bytes (see #955).
+# Without the guard 'norm' would behave correctly only by being declared last;
+# with it the clauses no longer rely on their order.
 
 - name: delta
   label: \Delta
@@ -75,11 +77,6 @@
   premises:
     - d-result: δ
       dataize: ⊥
-
-- name: end
-  match: ⊥
-  e-match: 𝑒
-  d-result: '--'
 
 - name: norm
   match: 𝑛

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -157,12 +157,15 @@ dataize program@(Program univ) ctx@DataizeContext{..} = do
   ((bytes, seq), _state) <- dataize' (expr, (program, Nothing) :| []) univ emptyState ctx
   pure (bytes, reverse seq)
 
--- The Dataization function 𝔻 retrieves bytes from an expression. It is total and
--- ternary, 𝔻(n, e, s): besides the term 'n' it takes the universe 'e' ('univ'),
+-- The Dataization function 𝔻 retrieves bytes from an expression. It is partial
+-- and ternary, 𝔻(n, e, s): besides the term 'n' it takes the universe 'e' ('univ'),
 -- which it forwards to 𝕄, and the mutable state 's', returning the bytes together
 -- with the new state. Its rules come from 'dataization.yaml': 'delta' yields the
--- asset bytes, 'end' (⊥) yields empty bytes (--) and 'none' (a formation with no
--- Δ/λ/φ) delegates to 'end' by dataizing ⊥,
+-- asset bytes and 'none' (a formation with no Δ/λ/φ) has nothing to dataize, so
+-- it dataizes ⊥. The terminator ⊥ signals an error and lies outside 𝔻's domain,
+-- so it matches no clause (there is no 'end' rule mapping it to empty bytes) and
+-- dataization stops there; a data-less formation therefore fails through the
+-- same path (see #955).
 -- 'box' contextualizes the φ-body and keeps dataizing (its step is labelled by
 -- its 'contextualize' side-computation), and 'norm' reduces through morphing,
 -- splicing the morphing steps into the chain. The clauses are disjoint (see
@@ -181,8 +184,15 @@ dataize' (expr, seq) univ state ctx = do
   matched <- firstMatch rules
   case matched of
     Just (rule, subst) -> reduce rule subst
-    Nothing -> throwIO (userError "no dataization rule matched")
+    Nothing -> throwIO (userError (unmatched expr))
   where
+    -- 𝔻 is partial: the terminator ⊥ signals an error and lies outside its
+    -- domain (see #955), so it matches no clause and lands here. Name it in the
+    -- message rather than reporting the generic "no dataization rule matched",
+    -- which would otherwise hide that the computation reached a dead end.
+    unmatched :: Expression -> String
+    unmatched ExTermination = "dataization reached the terminator ⊥, which signals an error and cannot be dataized"
+    unmatched _ = "no dataization rule matched"
     firstMatch :: [Y.DataizeRule] -> IO (Maybe (Y.DataizeRule, Subst))
     firstMatch [] = pure Nothing
     firstMatch (rule : rest) = do
@@ -345,9 +355,9 @@ _dataize expr univ state ctx@DataizeContext{_buildTerm = buildTerm} = case univ 
     pure (bts, state')
   _ -> throwIO (userError "Can't call _dataize from atoms with non-formation universe")
 
--- A number atom only operates on numeric data. Empty bytes (the result of
--- dataizing a bare formation ⟦𝐵⟧ or ⊥ now that 𝔻 is total) carry no number,
--- so the operand is rejected and the atom yields ⊥.
+-- A number atom only operates on numeric data. Empty bytes — a genuine
+-- zero-length byte array ⟦Δ ⤍ --⟧ — carry no number, so the operand is rejected
+-- and the atom yields ⊥.
 asNumber :: Bytes -> Maybe Double
 asNumber BtEmpty = Nothing
 asNumber bts = Just (either toDouble id (btsToNum bts))

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -867,9 +867,9 @@ spec = do
       withStdin "Q -> [[ D> 01- ]]" $
         testCLISucceeded ["dataize"] ["01-"]
 
-    it "dataizes empty object to empty bytes" $
+    it "fails to dataize an empty object, which dataizes the terminator ⊥" $
       withStdin "Q -> [[ ]]" $
-        testCLISucceeded ["dataize"] ["--"]
+        testCLIFailed ["dataize"] ["terminator ⊥"]
 
     it "dataizes with --sequence" $
       withStdin "{[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]]}" $
@@ -1138,10 +1138,6 @@ spec = do
             , "  \\phinoCondition{ [ D \\char44{} L \\char44{} @ ] \\cap B = \\emptyset }"
             , "  \\phinoPremise{ \\phinoDataize{ T }{ e }{ s_1 }{ \\delta }{ s_2 } }"
             , "  \\phinoConclusion{ \\phinoDataize{ [[ B ]] }{ e }{ s_1 }{ \\delta }{ s_2 } }"
-            , "\\end{phinoDataizationInference}"
-            , "\\begin{phinoDataizationInference}"
-            , "  \\phinoName{end}"
-            , "  \\phinoConclusion{ \\phinoDataize{ T }{ e }{ s }{ |--| }{ s } }"
             , "\\end{phinoDataizationInference}"
             , "\\begin{phinoDataizationInference}"
             , "  \\phinoName{norm}"

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -127,9 +127,10 @@ spec = do
 
   -- 'norm' matches the bare meta 𝑛, which unifies with any expression, so it is
   -- guarded to fire only when 𝑛 is neither a formation ('not (formation 𝑛)',
-  -- left to 'delta'/'box'/'fire'/'none') nor the termination ⊥ ('not (𝑛 = ⊥)',
-  -- left to 'end'). The dataization clauses are therefore disjoint and their
-  -- order in 'dataization.yaml' cannot change behavior.
+  -- left to 'delta'/'box'/'fire'/'none') nor the termination ⊥ ('not (𝑛 = ⊥)').
+  -- 𝔻 is partial: ⊥ matches no clause and lands on the unmatched-term error
+  -- (#955). The dataization clauses are therefore disjoint and their order in
+  -- 'dataization.yaml' cannot change behavior.
   describe "dataization 'norm' is disjoint from the specific clauses" $ do
     let rctx = RuleContext (execBuildTerm ExRoot (defaultDataizeContext ExRoot))
         dataizeRule :: String -> Yaml.DataizeRule
@@ -150,8 +151,6 @@ spec = do
     test
       dataize'
       [ ("[[ D> 00- ]] => 00-", ExFormation [BiDelta (BtOne "00")], ExRoot, BtOne "00")
-      , ("T => --", ExTermination, ExRoot, BtEmpty)
-      , ("[[ ]] => --", ExFormation [], ExRoot, BtEmpty)
       ,
         ( "[[ @ -> [[ D> 00-]] ]] => 00-"
         , ExFormation [BiTau AtPhi (ExFormation [BiDelta (BtOne "00"), BiVoid AtRho]), BiVoid AtRho]
@@ -185,6 +184,19 @@ spec = do
         , BtOne "01"
         )
       ]
+
+  -- 𝔻 is partial (#955): the terminator ⊥ signals an error and lies outside its
+  -- domain, so it matches no dataization clause and 𝔻 stops there instead of
+  -- yielding empty bytes. A data-less formation ⟦⟧ ('none') dataizes ⊥, so it
+  -- fails through the very same path — it has nothing to dataize.
+  describe "fails to dataize the terminator" $ do
+    let failsOn desc input =
+          it desc $
+            let prog = Program ExRoot
+             in dataize' (input, (prog, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
+                  `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
+    failsOn "throws on ⊥ instead of mapping it to empty bytes" ExTermination
+    failsOn "throws on a data-less formation, which dataizes ⊥" (ExFormation [])
 
   describe "labels every step with a defined rule or operation" $ do
     let verb op = case op of
@@ -261,12 +273,14 @@ spec = do
     it "dataizes a located reference through the expected rules" $ do
       labels <- labelsOf "Q.foo.bar" "Q -> [[ foo -> [[ bar -> [[ @ -> Q.x ]] ]], x -> [[ D> 42- ]] ]]"
       labels `shouldBe` ["contextualize", "md", "dot", "copy", "mf"]
-    -- The 'none' rule no longer emits '--' itself: it delegates to 'end' by
-    -- dataizing ⊥, so the empty formation reduces through one labelled 'dataize'
-    -- step (𝔻(⟦⟧) → 𝔻(⊥)) before 'end' yields the empty bytes (#942).
-    it "dataizes an empty formation by delegating to end" $ do
-      labels <- labelsOf "Q" "Q -> [[ ]]"
-      labels `shouldBe` ["dataize"]
+    -- The 'none' rule dataizes ⊥ (𝔻(⟦⟧) → 𝔻(⊥)), which matches no clause now
+    -- that there is no 'end' rule, so an empty formation reduces through one
+    -- labelled 'dataize' step and then fails: it has nothing to dataize (#955).
+    it "fails to dataize an empty formation, which dataizes ⊥" $ do
+      prog <- parseProgramThrows "Q -> [[ ]]"
+      loc <- parseExpressionThrows "Q"
+      dataize prog (defaultDataizeContext loc)
+        `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
   testDataize
     [


### PR DESCRIPTION
Fixes #955.

## Problem

The `end` rule in `resources/dataization.yaml` matched the terminator `⊥` and concluded `d-result: '--'`, so `𝔻(⊥)` returned empty bytes. This conflated two distinct outcomes:

- **the computation reached a dead end** (`⊥`, the terminator `T`, which *signals an error*), and
- **the computation produced empty data** (`--`, a legitimate zero-length byte array `⟦Δ ⤍ --⟧`).

A program that fails became indistinguishable from one that genuinely yields empty bytes. It also contradicted the calculus paper, where `𝔻` is a *partial* function (`⇀`): `⊥` should lie outside its domain rather than map to a value.

## Fix

- **`resources/dataization.yaml`** — remove the `end` rule so `𝔻(⊥)` matches no clause. The `norm` guard (`not (𝑛 = ⊥)`) still keeps `norm` from matching `⊥`, so dataization simply stops at `⊥`.
- **`src/Dataize.hs`** — the unmatched-term path (`no dataization rule matched`) now names the terminator: `dataization reached the terminator ⊥, which signals an error and cannot be dataized`. Updated the surrounding doc comments (`𝔻` is now partial, not total; `asNumber`'s empty-bytes note).
- Since `none` already routes a data-less formation `⟦𝐵⟧` through `dataize: ⊥`, such a formation now fails through the same path — consistent, as it has nothing to dataize.

## Tests

- `test/DataizeSpec.hs` — replaced the `T => --` and `⟦⟧ => --` success cases with a `fails to dataize the terminator` block asserting both `⊥` and a data-less formation throw; the empty-formation label-sequence test now expects a throw.
- `test/CLISpec.hs` — the empty-object case now expects failure with `terminator ⊥`; removed the `end` block from the `explain --dataize` expected output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1gTXUxAwcMnkNCfbH45vD)_