### PR TITLE
fix(#969): canonize after meet compression so --compress still dedups

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -9,6 +9,7 @@ module CLI.Helpers where
 import AST
 import CLI.Types
 import CLI.Validators (invalidCLIArguments)
+import Canonizer (canonize)
 import Control.Exception
 import Control.Monad ((>=>))
 import Data.Functor ((<&>))
@@ -24,7 +25,7 @@ import Logger
 import Parser (parseExpressionThrows)
 import qualified Printer as P
 import qualified Random as R
-import Rewriter (Rewrittens')
+import Rewriter (Rewritten, Rewrittens')
 import System.IO (getContents')
 import Text.Printf (printf)
 import XMIR (expressionToXMIR, parseXMIRThrows, printXMIR, xmirToPhi)
@@ -62,11 +63,17 @@ parseInput phi PHI = parseExpressionThrows phi
 parseInput xmir XMIR = parseXMIRThrows xmir >>= xmirToPhi
 parseInput _ LATEX = invalidCLIArguments "LaTeX cannot be used as input format"
 
+-- The LaTeX sequence path canonizes inside 'rewrittensToLatex', after the meet
+-- compression (see 'canonizedRewrittens' there); the remaining formats have no
+-- meet pass, so canonization happens here right before rendering.
 printRewrittens :: PrintContext -> Rewrittens' -> IO String
 printRewrittens ctx@PrintCtx{..} rewrittens@(chain, _)
   | _outputFormat == LATEX && _sequence = rewrittensToLatex rewrittens (printCtxToLatexCtx ctx)
-  | _focus == ExRoot = mapM (printInFormat ctx . fst) chain <&> intercalate "\n"
-  | otherwise = mapM (\(expr, _) -> locatedExpression _focus expr >>= printExpression ctx) chain <&> intercalate "\n"
+  | _focus == ExRoot = mapM (printInFormat ctx . fst) (canonized chain) <&> intercalate "\n"
+  | otherwise = mapM (\(expr, _) -> locatedExpression _focus expr >>= printExpression ctx) (canonized chain) <&> intercalate "\n"
+  where
+    canonized :: [Rewritten] -> [Rewritten]
+    canonized = if _canonize then canonize else id
 
 printExpression :: PrintContext -> Expression -> IO String
 printExpression ctx@PrintCtx{..} ex = case _outputFormat of
@@ -83,7 +90,7 @@ printInFormat ctx@PrintCtx{..} expr = case _outputFormat of
 
 printCtxToLatexCtx :: PrintContext -> LatexContext
 printCtxToLatexCtx PrintCtx{..} =
-  LatexContext _sugar _line _margin _nonumber _compress _meetPopularity _meetLength _focus _expression _label _meetPrefix
+  LatexContext _sugar _line _margin _nonumber _compress _canonize _meetPopularity _meetLength _focus _expression _label _meetPrefix
 
 -- Get rules for rewriting depending on provided flags
 getRules :: Bool -> Bool -> [FilePath] -> IO [Y.Rule]

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -11,7 +11,6 @@ import AST
 import CLI.Helpers
 import CLI.Types
 import CLI.Validators
-import qualified Canonizer as C
 import Condition (parseConditionThrows)
 import Control.Exception
 import Control.Monad (unless, when)
@@ -57,11 +56,10 @@ runRewrite OptsRewrite{..} = do
         (_, _, _) -> (\rewritten -> P.printExpression' rewritten (_sugarType, UNICODE, _flat, _margin))
       xmirCtx = XmirContext _omitListing _omitComments listing
       printCtx = toPrintCtx xmirCtx foc
-      canonize = if _canonize then C.canonize else id
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
   (rewrittens, exceeded) <- rewrite expr rules (context loc printCtx)
-  let rewrittens' = canonize $ exclude $ include (if _sequence then NE.toList rewrittens else [NE.last rewrittens])
+  let rewrittens' = exclude $ include (if _sequence then NE.toList rewrittens else [NE.last rewrittens])
   logDebug (printf "Printing rewritten 𝜑-expression as %s" (show _outputFormat))
   exprs <- printRewrittens printCtx (rewrittens', exceeded)
   output _targetFile exprs
@@ -124,6 +122,7 @@ runRewrite OptsRewrite{..} = do
         xmirCtx
         _nonumber
         _compress
+        _canonize
         _sequence
         (justMeetPopularity _meetPopularity)
         (justMeetLength _meetLength)
@@ -144,11 +143,10 @@ runDataize OptsDataize{..} = do
   expr <- parseInput input _inputFormat
   seedTaus expr
   let printCtx = toPrintCtx foc
-      canonize = if _canonize then C.canonize else id
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
   (bytes, chain) <- dataize expr (context loc printCtx)
-  when _sequence (printRewrittens printCtx (canonize $ exclude $ include chain, False) >>= putStrLn)
+  when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (putStrLn (P.printBytes bytes))
   where
     validateOpts :: IO ()
@@ -171,6 +169,7 @@ runDataize OptsDataize{..} = do
         defaultXmirContext
         _nonumber
         _compress
+        _canonize
         _sequence
         (justMeetPopularity _meetPopularity)
         (justMeetLength _meetLength)
@@ -220,6 +219,7 @@ runMerge OptsMerge{..} = do
         _flat
         _margin
         xmirCtx
+        False
         False
         False
         False

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -22,6 +22,7 @@ data PrintContext = PrintCtx
   , _xmirCtx :: XmirContext
   , _nonumber :: Bool
   , _compress :: Bool
+  , _canonize :: Bool
   , _sequence :: Bool
   , _meetPopularity :: Int
   , _meetLength :: Int

--- a/src/Canonizer.hs
+++ b/src/Canonizer.hs
@@ -4,7 +4,7 @@
 -- Canonization is the process of replacing function names attrached to
 -- lambda bindings with numbered identifiers started from 'F'
 -- like 'F1', 'F2', etc.
-module Canonizer (canonize) where
+module Canonizer (canonize, canonizeExpr) where
 
 import AST
 import qualified Data.Text as T
@@ -34,6 +34,12 @@ canonizeExpression (ExApplication expr arg) idx =
   let (expr', idx') = canonizeExpression expr idx
       (arg', idx'') = canonizeArgument arg idx'
    in (ExApplication expr' arg', idx'')
+canonizeExpression (ExPhiMeet prefix num expr) idx =
+  let (expr', idx') = canonizeExpression expr idx
+   in (ExPhiMeet prefix num expr', idx')
+canonizeExpression (ExPhiAgain prefix num expr) idx =
+  let (expr', idx') = canonizeExpression expr idx
+   in (ExPhiAgain prefix num expr', idx')
 canonizeExpression expr idx = (expr, idx)
 
 canonizeArgument :: Argument -> Int -> (Argument, Int)
@@ -44,6 +50,11 @@ canonizeArgument (ArAlpha alpha expr) idx =
   let (expr', idx') = canonizeExpression expr idx
    in (ArAlpha alpha expr', idx')
 
+-- Canonize a single expression, restarting the 'F' counter from 1 so the
+-- numbering is local to that expression.
+canonizeExpr :: Expression -> Expression
+canonizeExpr expr = fst (canonizeExpression expr 1)
+
 canonize :: [Rewritten] -> [Rewritten]
 canonize [] = []
-canonize ((expr, maybeRule) : rest) = (fst (canonizeExpression expr 1), maybeRule) : canonize rest
+canonize ((expr, maybeRule) : rest) = (canonizeExpr expr, maybeRule) : canonize rest

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -26,6 +26,7 @@ module LaTeX
 
 import AST
 import CST
+import Canonizer (canonize, canonizeExpr)
 import Data.List (intercalate, nub)
 import Data.Maybe (isJust)
 import qualified Data.Text as T
@@ -49,6 +50,7 @@ data LatexContext = LatexContext
   , _margin :: Int
   , _nonumber :: Bool
   , _compress :: Bool
+  , _canonize :: Bool
   , _meetPopularity :: Int
   , _meetLength :: Int
   , _focus :: Expression
@@ -58,7 +60,7 @@ data LatexContext = LatexContext
   }
 
 defaultLatexContext :: LatexContext
-defaultLatexContext = LatexContext SWEET SINGLELINE defaultMargin False False defaultMeetPopularity defaultMeetLength ExRoot Nothing Nothing Nothing
+defaultLatexContext = LatexContext SWEET SINGLELINE defaultMargin False False False defaultMeetPopularity defaultMeetLength ExRoot Nothing Nothing Nothing
 
 defaultMeetPopularity :: Int
 defaultMeetPopularity = 50
@@ -168,6 +170,21 @@ compressedRewrittens rewrittens ctx@LatexContext{..} =
   let (exprs, rules) = unzip rewrittens
    in if _compress then zip (meetInExpressions exprs ctx) rules else rewrittens
 
+-- Canonization runs after the meet compression, never before it: 'canonize'
+-- renumbers λ bindings by traversal position and restarts the counter for every
+-- expression, so the same logical lambda ends up with a different 'Fn' in
+-- different steps. Feeding those unstable names to the meet pass (which compares
+-- sub-expressions by structural equality) would stop identical sub-expressions
+-- from ever matching. So the meet pass sees the original names first, and only
+-- its output is canonized.
+canonizedRewrittens :: [Rewritten] -> LatexContext -> [Rewritten]
+canonizedRewrittens rewrittens LatexContext{_canonize = shouldCanonize} =
+  if shouldCanonize then canonize rewrittens else rewrittens
+
+canonizedExpressions :: [Expression] -> LatexContext -> [Expression]
+canonizedExpressions exprs LatexContext{_canonize = shouldCanonize} =
+  if shouldCanonize then map canonizeExpr exprs else exprs
+
 -- Compress a sequence of focused sub-expressions the way 'compressedRewrittens'
 -- compresses whole expressions: the meet machinery factors recurring
 -- sub-expressions out across the sequence. Focusing happens before this, so the
@@ -181,7 +198,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{_focus = ExRoot} =
   pure
     ( concat
         [ preamble ctx
-        , body (compressedRewrittens rewrittens ctx) (\expr -> renderToLatex (expressionToCST expr) ctx)
+        , body (canonizedRewrittens (compressedRewrittens rewrittens ctx) ctx) (\expr -> renderToLatex (expressionToCST expr) ctx)
         , ending exceeded ctx
         ]
     )
@@ -191,7 +208,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{..} = do
   pure
     ( concat
         [ preamble ctx
-        , body (zip (compressedExpressions focused ctx) rules) (\expr -> renderToLatex (expressionToCST expr) ctx)
+        , body (zip (canonizedExpressions (compressedExpressions focused ctx) ctx) rules) (\expr -> renderToLatex (expressionToCST expr) ctx)
         , ending exceeded ctx
         ]
     )

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -894,6 +894,12 @@ spec = do
           ["dataize", "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--hide=Q.bytes", "--hide=Q.number", "--locator=Q.@", "--focus=Q.@", "--meet-length=5", "--meet-popularity=1"]
           ["\\phinoMeet{dataization:1}{ [[ @ -> |c| . |plus| ( 32 ), |c| -> 25 ]] } \\leadsto_{\\nameref{r:contextualize}}"]
 
+    it "compresses a canonized whole-expression sequence into a meet" $
+      withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
+        testCLISucceeded
+          ["dataize", "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--meet-length=5", "--meet-popularity=1"]
+          ["\\phinoMeet{dataization:1}"]
+
     it "dataizes with --locator" $
       withStdin "[[ ex -> [[ @ -> Q.x ]], x -> [[ D> 42- ]] ]]" $
         testCLISucceeded ["dataize", "--locator=Q.ex"] ["42-"]


### PR DESCRIPTION
Closes #969.

## Problem

When `--compress` and `--canonize` are combined for LaTeX sequence output
(e.g. `dataize --output=latex --sequence --compress --canonize`),
structurally identical sub-expressions across reduction steps were **not**
factored out into `\phinoMeet`/`\phinoAgain` — they were printed in full over
and over.

The cause was ordering: `canonize` ran *before* the meet compression. It
renames each step's λ-bindings to `F1`, `F2`, … numbering by traversal
position and **restarting the counter for every expression**. Because the
counter restarts per step and numbers by position, the *same* logical lambda
got a *different* `Fn` in different steps. The meet pass compares candidates by
structural equality, so `Function "F3"` and `Function "F4"` looked distinct and
the enclosing sub-expressions never matched — `--canonize` silently sabotaged
the deduplication `--compress` is meant to perform.

## Fix

Canonization now runs **after** the meet compression, so the meet pass sees the
stable, original lambda names:

- The `_canonize` flag is threaded through `PrintContext`/`LatexContext` and
  applied at render time rather than pre-applied to the chain in the runners
  (`runRewrite`/`runDataize` no longer canonize up front).
- For the LaTeX sequence path, `rewrittensToLatex` feeds un-canonized
  expressions to `meetInExpressions` (via `compressedRewrittens` /
  `compressedExpressions`) and canonizes only its output
  (`canonizedRewrittens` / `canonizedExpressions`).
- For the other output formats (no meet pass), `printRewrittens` canonizes just
  before rendering, preserving the previous behavior.
- `canonizeExpression` gains `ExPhiMeet`/`ExPhiAgain` cases so lambdas inside a
  factored-out `\phinoMeet{…}` body still get renamed.

## Tests

Added a `dataize --output=latex --compress --canonize --sequence` CLI test over
a whole-expression sequence that asserts a `\phinoMeet` is produced — the
scenario that previously collapsed only when `--canonize` was dropped. The
existing focused compress+canonize test continues to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJxZDChgfupZEqUMbtSzHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJxZDChgfupZEqUMbtSzHm)_