### PR TITLE
fix(#976): factor every recurring sub-expression per step, not just one

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -93,9 +93,13 @@ meetInExpression expr len = meetIn expr
 
 {- | Here we're trying to compress a sequence of expressions with \phinoMeet{} and \phinoAgain LaTeX functions.
 We process the sequence of expressions and trying to find all sub-expressions in the first expression which are present
-in the following expressions. Then we find ONE expression which is the most frequently encountered.
+in the following expressions. Then we find the one which is the most frequently encountered.
 If it's encountered in more than specific percentage (_meetPopularity) of the following expressions - we replace
 it with \phinoAgain{} in the following expressions and with \phinoMeet{} in the first expression.
+We then keep re-scanning that same first expression for further meets: the parts already factored out become
+\phinoMeet{}/\phinoAgain{}, which the scanner skips, so each pass yields strictly fewer candidates and the loop
+terminates. This lets a single step host several \phinoMeet{}s when it carries several independent recurring
+sub-expressions, rather than only the single most frequent one.
 -}
 meetInExpressions :: [Expression] -> LatexContext -> [Expression]
 meetInExpressions exprs LatexContext{..} = go exprs 1
@@ -127,7 +131,7 @@ meetInExpressions exprs LatexContext{..} = go exprs 1
                       rest' = zipWith (\other exprs' -> replaceExpression (other, exprs', map (const (ExPhiAgain _meetPrefix idx)) exprs')) rest met'
                       found = filter (not . null) met'
                    in if length met' > 1 && toDouble (length found) / toDouble (length met') >= popularity
-                        then withAgain : go rest' (idx + 1)
+                        then go (withAgain : rest') (idx + 1)
                         else next
                 [] -> next
             _ -> next

--- a/test/LaTeXSpec.hs
+++ b/test/LaTeXSpec.hs
@@ -10,7 +10,8 @@ module LaTeXSpec where
 
 import AST (Expression (ExMeta))
 import Control.Monad (forM_)
-import LaTeX (conditionToLatex, meetInExpression)
+import Data.Text qualified as T
+import LaTeX (LatexContext (..), conditionToLatex, defaultLatexContext, meetInExpression, meetInExpressions)
 import Parser (parseExpressionThrows)
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Yaml qualified as Y
@@ -32,6 +33,20 @@ spec = do
           res <- traverse parseExpressionThrows exprs
           meetInExpression ptn 4 tgt `shouldBe` res
       )
+
+  describe "meets several sub-expressions in a single step" $
+    -- A step routinely carries several independent recurring sub-expressions.
+    -- The first step here holds two distinct recurring formations
+    -- ([[ p -> Q.a ]] and [[ q -> Q.b ]]); both must be factored, so the first
+    -- rendered step ends up with two \phinoMeet{}s, not just the single most
+    -- frequent one (see #976).
+    it "factors every recurring sub-expression, not only one" $ do
+      let step :: String -> String
+          step lastAttr = "[[ r -> [[ p -> Q.a ]], s -> [[ q -> Q.b ]], tag -> Q." <> lastAttr <> " ]]"
+      exprs <- traverse parseExpressionThrows [step "one", step "two", step "three"]
+      let ctx = defaultLatexContext{_compress = True, _meetLength = 6, _meetPopularity = 1}
+          firstStep = head (meetInExpressions exprs ctx)
+      T.count "ExPhiMeet" (T.pack (show firstStep)) `shouldBe` 2
 
   describe "renders the 'formation' condition" $
     forM_

--- a/test/LaTeXSpec.hs
+++ b/test/LaTeXSpec.hs
@@ -13,7 +13,7 @@ import Control.Monad (forM_)
 import Data.Text qualified as T
 import LaTeX (LatexContext (..), conditionToLatex, defaultLatexContext, meetInExpression, meetInExpressions)
 import Parser (parseExpressionThrows)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
 import Yaml qualified as Y
 
 spec :: Spec
@@ -45,8 +45,9 @@ spec = do
           step lastAttr = "[[ r -> [[ p -> Q.a ]], s -> [[ q -> Q.b ]], tag -> Q." <> lastAttr <> " ]]"
       exprs <- traverse parseExpressionThrows [step "one", step "two", step "three"]
       let ctx = defaultLatexContext{_compress = True, _meetLength = 6, _meetPopularity = 1}
-          firstStep = head (meetInExpressions exprs ctx)
-      T.count "ExPhiMeet" (T.pack (show firstStep)) `shouldBe` 2
+      case meetInExpressions exprs ctx of
+        (firstStep : _) -> T.count "ExPhiMeet" (T.pack (show firstStep)) `shouldBe` 2
+        [] -> expectationFailure "meetInExpressions returned no expressions"
 
   describe "renders the 'formation' condition" $
     forM_


### PR DESCRIPTION
Fixes #976.

## Problem

When `dataize --output=latex --sequence --compress` renders a derivation, each step could host **at most one** `\phinoMeet`. `meetInExpressions` (`src/LaTeX.hs`) picked the single most frequent recurring sub-expression of the first expression, factored it into `\phinoMeet`/`\phinoAgain`, and then recursed on the *tail* (`withAgain : go rest' (idx + 1)`), dropping `first` and never re-scanning it. Any other independent recurring sub-expression in that same step stayed printed verbatim in every step.

## Fix

Recurse on `go (withAgain : rest') (idx + 1)` instead, so the just-factored first expression is re-scanned for further meets before descending to the next step. Factored parts become `ExPhiMeet`/`ExPhiAgain`, which `meetIn` already skips (guards at `src/LaTeX.hs:77-78`), so the candidate set strictly shrinks each pass and the loop terminates. `idx` keeps incrementing across the added iterations, so meet indices stay unique.

The docstring above `meetInExpressions` is updated to describe the multi-meet behaviour.

## Why existing golden tests are unaffected

- The `--compress` golden tests in `test/CLISpec.hs` each carry exactly one recurring sub-expression per step at their chosen `--meet-length` (the other sub-parts are either too small or differ across steps because of `?`/`\phinoAgain` markers), so the re-scan finds nothing new.
- The two dataize compression tests factor the *whole* first expression into meet 1; re-scanning that root `ExPhiMeet` yields nothing.

## Test

Added a `meetInExpressions` unit test in `test/LaTeXSpec.hs`: a three-step sequence whose first step holds two distinct recurring formations (`[[ p -> Q.a ]]` and `[[ q -> Q.b ]]`). It asserts the first rendered step now contains two `ExPhiMeet` factorings rather than one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAoAWdj2vdV9hYicuP65id

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAoAWdj2vdV9hYicuP65id)_