### PR TITLE
fix(#978): keep compressed meet bodies on one line under --margin

### DIFF
--- a/src/Margin.hs
+++ b/src/Margin.hs
@@ -31,7 +31,7 @@ instance WithMargin EXPRESSION where
   withMargin' _ str@EX_STRING{} = str
   withMargin' cfg EX_DISPATCH{..} = EX_DISPATCH (withMargin' cfg expr) space attr
   withMargin' cfg EX_PHI_AGAIN{..} = EX_PHI_AGAIN prefix idx (withMargin' cfg expr)
-  withMargin' cfg EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (withMargin' cfg expr)
+  withMargin' _ EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (toSingleLine expr)
   withMargin' cfg@(extra, margin) ex@EX_APPLICATION{tab = tab@(TAB indt), ..} =
     let single = toSingleLine ex
         main = withMargin' cfg expr

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -80,6 +80,17 @@ spec = do
             parseExpression printed `shouldBe` Right expr
       )
 
+  describe "printExpression keeps a compressed meet atomic under a narrow margin" $
+    -- A \phinoMeet is a single \overbracket visual unit, so its body must stay
+    -- on one line even when the surrounding margin forces the outer formation to
+    -- wrap. A newline inside the braced argument would raise "! Missing }
+    -- inserted" in an aligned/gathered LaTeX context (see #978).
+    it "renders the meet body on a single line even when the margin wraps its parent" $ do
+      let body = ExFormation [BiTau (AtLabel "alpha") ExRoot, BiTau (AtLabel "beta") ExRoot, BiTau (AtLabel "gamma") ExRoot]
+          expr = ExFormation [BiTau (AtLabel "x") (ExPhiMeet Nothing 5 body)]
+          printed = printExpression' expr (SWEET, UNICODE, MULTILINE, 30)
+      printed `shouldContain` "\\phinoMeet{5}{ ⟦ alpha ↦ Φ, beta ↦ Φ, gamma ↦ Φ ⟧ }"
+
   describe "printExpression with default config" $
     forM_
       [ ("empty formation", ExFormation [BiVoid AtRho], "⟦⟧")


### PR DESCRIPTION
Fixes #978.

## Problem

When `--compress` and `--margin` are combined in LaTeX output, the margin pass wrapped the *inside* of a `\phinoMeet{id}{expr}` group whenever `expr` was wider than the margin. `withMargin'` recursed into the meet body at `src/Margin.hs:34`, and `render` at `src/Render.hs:208` then emitted that multi-line body between the `{ ... }` braces.

A `\phinoMeet` is drawn as a single `\overbracket` with a `Π` label — an atomic, one-line visual unit — so breaking lines inside its body is wrong. It also breaks typesetting: in an `aligned`/`gathered` context each newline becomes a row break (`\\`), and a row break inside a braced macro argument raises `! Missing } inserted`.

## Fix

In `src/Margin.hs`, the `EX_PHI_MEET` case now renders its body with `toSingleLine expr` (already imported and used in the module) instead of `withMargin' cfg expr`, so the meet argument never line-wraps. The margin config argument is unused in this case and is bound to `_`.

## Test

Added a regression test in `test/PrinterSpec.hs` that embeds a wide `ExPhiMeet` in a formation and prints it with a narrow margin (`MULTILINE`, margin `30`). The outer formation wraps, but the meet body must stay on a single line. Without the fix the body wraps and the assertion fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S21BqDo81wicpb4exuFDSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01S21BqDo81wicpb4exuFDSp)_