### PR TITLE
fix(#981): indent multi-line --sequence steps from base tab 1

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -251,6 +251,14 @@ data EXTRA = EXTRA {meta :: EXTRA_ARG, func :: String, args :: [EXTRA_ARG]}
 expressionToCST :: Expression -> EXPRESSION
 expressionToCST = toCST'
 
+-- Like 'expressionToCST', but lays the expression out from a given base tab
+-- instead of column 0. Used when an expression sits on an already-indented
+-- line (e.g. a '\leadsto' continuation step in the LaTeX --sequence output),
+-- so its wrapped member lines nest one level below that line and its closing
+-- bracket aligns with the opening one.
+expressionToCSTFrom :: Int -> Expression -> EXPRESSION
+expressionToCSTFrom tabs expr = toCST expr (tabs, EOL)
+
 -- A number can be rendered with the sweet numeric literal only when it is
 -- finite. NaN and the infinities have no such literal — and the bare `show`
 -- tokens (`NaN`, `Infinity`, `-Infinity`) would collide with object/function

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -153,17 +153,27 @@ preamble ctx@LatexContext{..} =
     , maybe "" (printf "\\phiExpression{%s} ") _expression
     ]
 
-body :: [(a, Maybe String)] -> (a -> String) -> String
+-- Join the rendered steps with '\leadsto'. Every step after the first carries
+-- the two-space '\leadsto' indent, so it is rendered from base tab 1 rather
+-- than 0 (via 'baseTab'); this keeps a wrapped multi-line step's members nested
+-- one level below its '\leadsto [[' line and its closing bracket aligned with
+-- that line. The first step has no '\leadsto' prefix and stays at base tab 0.
+body :: [(a, Maybe String)] -> (Int -> a -> String) -> String
 body printed toLatex =
   intercalate
     "\n  \\leadsto "
-    ( map
-        ( \(item, maybeName) ->
-            let item' = toLatex item
+    ( zipWith
+        ( \idx (item, maybeName) ->
+            let item' = toLatex (baseTab idx) item
              in maybe item' (printf "%s \\leadsto_{\\nameref{r:%s}}" item') maybeName
         )
+        [0 ..]
         printed
     )
+  where
+    baseTab :: Int -> Int
+    baseTab 0 = 0
+    baseTab _ = 1
 
 ending :: Bool -> LatexContext -> String
 ending True ctx = printf " \\leadsto\n  \\leadsto \\dots\n\\end{%s}" (phiquation ctx)
@@ -202,7 +212,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{_focus = ExRoot} =
   pure
     ( concat
         [ preamble ctx
-        , body (canonizedRewrittens (compressedRewrittens rewrittens ctx) ctx) (\expr -> renderToLatex (expressionToCST expr) ctx)
+        , body (canonizedRewrittens (compressedRewrittens rewrittens ctx) ctx) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
         , ending exceeded ctx
         ]
     )
@@ -212,7 +222,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{..} = do
   pure
     ( concat
         [ preamble ctx
-        , body (zip (canonizedExpressions (compressedExpressions focused ctx) ctx) rules) (\expr -> renderToLatex (expressionToCST expr) ctx)
+        , body (zip (canonizedExpressions (compressedExpressions focused ctx) ctx) rules) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
         , ending exceeded ctx
         ]
     )

--- a/test/LaTeXSpec.hs
+++ b/test/LaTeXSpec.hs
@@ -10,10 +10,12 @@ module LaTeXSpec where
 
 import AST (Expression (ExMeta))
 import Control.Monad (forM_)
+import Data.List (intercalate)
 import Data.Text qualified as T
-import LaTeX (LatexContext (..), conditionToLatex, defaultLatexContext, meetInExpression, meetInExpressions)
+import LaTeX (LatexContext (..), conditionToLatex, defaultLatexContext, meetInExpression, meetInExpressions, rewrittensToLatex)
+import Lining (LineFormat (MULTILINE))
 import Parser (parseExpressionThrows)
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldContain)
 import Yaml qualified as Y
 
 spec :: Spec
@@ -48,6 +50,27 @@ spec = do
       case meetInExpressions exprs ctx of
         (firstStep : _) -> T.count "ExPhiMeet" (T.pack (show firstStep)) `shouldBe` 2
         [] -> expectationFailure "meetInExpressions returned no expressions"
+
+  describe "indents wrapped continuation steps in a --sequence" $
+    -- Regression test for #981. Every step after the first is joined onto a
+    -- two-space '\leadsto' line, so it is laid out from base tab 1 rather than
+    -- column 0. A multi-line continuation step must then nest its members one
+    -- level below the '\leadsto' word and align its closing bracket with it;
+    -- before the fix the members shared the '\leadsto' indent and the closing
+    -- bracket landed at column 0, left of its own opening bracket.
+    it "nests members below \\leadsto and aligns the closing bracket" $ do
+      firstStep <- parseExpressionThrows "[[ x -> Q.y ]]"
+      secondStep <- parseExpressionThrows "[[ a -> Q.b, c -> Q.d ]]"
+      let ctx = defaultLatexContext{_line = MULTILINE, _margin = 20}
+      latex <- rewrittensToLatex ([(firstStep, Just "first"), (secondStep, Just "second")], False) ctx
+      latex
+        `shouldContain` intercalate
+          "\n"
+          [ "  \\leadsto [["
+          , "    |a| -> Q . |b|,"
+          , "    |c| -> Q . |d|"
+          , "  ]] \\leadsto_{\\nameref{r:second}}"
+          ]
 
   describe "renders the 'formation' condition" $
     forM_

--- a/test/LaTeXSpec.hs
+++ b/test/LaTeXSpec.hs
@@ -51,18 +51,12 @@ spec = do
         (firstStep : _) -> T.count "ExPhiMeet" (T.pack (show firstStep)) `shouldBe` 2
         [] -> expectationFailure "meetInExpressions returned no expressions"
 
-  describe "indents wrapped continuation steps in a --sequence" $
-    -- Regression test for #981. Every step after the first is joined onto a
-    -- two-space '\leadsto' line, so it is laid out from base tab 1 rather than
-    -- column 0. A multi-line continuation step must then nest its members one
-    -- level below the '\leadsto' word and align its closing bracket with it;
-    -- before the fix the members shared the '\leadsto' indent and the closing
-    -- bracket landed at column 0, left of its own opening bracket.
-    it "nests members below \\leadsto and aligns the closing bracket" $ do
-      firstStep <- parseExpressionThrows "[[ x -> Q.y ]]"
-      secondStep <- parseExpressionThrows "[[ a -> Q.b, c -> Q.d ]]"
+  describe "indents wrapped continuation steps in a --sequence (#981)" $
+    it "nests a wrapped step's members below its two-space \\leadsto line and aligns the closing bracket with it, rather than laying the step out from column 0" $ do
+      start <- parseExpressionThrows "[[ x -> Q.y ]]"
+      wrapped <- parseExpressionThrows "[[ a -> Q.b, c -> Q.d ]]"
       let ctx = defaultLatexContext{_line = MULTILINE, _margin = 20}
-      latex <- rewrittensToLatex ([(firstStep, Just "first"), (secondStep, Just "second")], False) ctx
+      latex <- rewrittensToLatex ([(start, Just "first"), (wrapped, Just "second")], False) ctx
       latex
         `shouldContain` intercalate
           "\n"


### PR DESCRIPTION
Closes #981.

## Problem

When `--output=latex --sequence` renders a rewriting chain, `body` in `src/LaTeX.hs` joins every step after the first onto a two-space `\leadsto` line. But each step's expression was rendered through `expressionToCST` (`toCST (0, EOL)`), i.e. from absolute column 0. So a multi-line formation/application sitting on a `\leadsto` line ignored the two-space offset: its member lines got the same indent as the `\leadsto` word (one level too shallow) and its closing `]]` / `)` landed at column 0 — to the left of its own opening bracket, giving non-monotonic indentation.

## Fix

- Add `expressionToCSTFrom :: Int -> Expression -> EXPRESSION` in `src/CST.hs`, which lays an expression out from a given base tab instead of column 0.
- In `body`, render each step with a per-step base tab: the first step (no `\leadsto` prefix) stays at base tab 0; every continuation step is rendered from base tab 1. Its members then nest one level below the `\leadsto [[` line and its closing bracket aligns with it.

The wrap/no-wrap decision for each step is unchanged (the top-level margin check runs on the flattened, indent-free single line), so only the indentation of already-wrapped continuation steps shifts. Flat (`--flat`) output is unaffected because `toSingleLine` collapses all tabs regardless of the base.

## Testing

Added a regression test in `test/LaTeXSpec.hs` that drives `rewrittensToLatex` with a two-step sequence whose second step wraps under a small margin, asserting the members indent below `\leadsto` and the closing bracket aligns with it.

Note: no Haskell toolchain was available in this environment, so the change was verified by tracing the render pipeline rather than by running `make test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSwbZSkp7CW69fLjQTxUtJ)_