### PR TITLE
fix(#980): record the delta extraction as the final --sequence step

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -26,6 +26,13 @@ data Expression
   | ExMeta Text
   | ExPhiMeet (Maybe String) Int Expression
   | ExPhiAgain (Maybe String) Int Expression
+  | {- | Bare data 𝛿 — the raw bytes extracted by the 'delta' dataization rule.
+    It is not a phi-calculus term but a rendering-only chain node, so a
+    '--sequence' derivation can terminate at the data itself rather than at
+    the data object it was pulled out of (see #980). It never flows into the
+    matcher, builder or the dataization relation.
+    -}
+    ExBytes Bytes
   deriving (Eq, Ord, Show, Generic)
 
 data Argument
@@ -110,6 +117,7 @@ hashExpression = goExpr fnvOffset
       ExMeta t -> hashText (step h 7) t
       ExPhiMeet ms i ex -> goExpr (hashMaybeString (step (step h 9) i) ms) ex
       ExPhiAgain ms i ex -> goExpr (hashMaybeString (step (step h 10) i) ms) ex
+      ExBytes bts -> goBytes (step h 8) bts
     goBinding :: Int -> Binding -> Int
     goBinding h = \case
       BiTau at ex -> goExpr (goAttribute (step h 11) at) ex

--- a/src/CST.hs
+++ b/src/CST.hs
@@ -177,6 +177,7 @@ data EXPRESSION
   | EX_META {meta :: META}
   | EX_PHI_MEET {prefix :: Maybe String, idx :: Int, expr :: EXPRESSION}
   | EX_PHI_AGAIN {prefix :: Maybe String, idx :: Int, expr :: EXPRESSION}
+  | EX_BYTES {bytes :: BYTES} -- bare data 𝛿, a rendering-only terminal chain node (see #980)
   deriving (Eq, Show)
 
 data ATTRIBUTE
@@ -310,6 +311,7 @@ instance ToCST Expression EXPRESSION where
   toCST ExXi _ = EX_XI XI
   toCST (ExMeta mt) _ = EX_META (META NO_EXCL (exMetaHead mt) (metaTail mt))
   toCST ExTermination _ = EX_TERMINATION DEAD
+  toCST (ExBytes bts) ctx = EX_BYTES (toCST bts ctx)
   toCST (ExPhiMeet prefix idx expr) ctx = EX_PHI_MEET prefix idx (toCST expr ctx)
   toCST (ExPhiAgain prefix idx expr) ctx = EX_PHI_AGAIN prefix idx (toCST expr ctx)
   toCST (ExFormation [BiVoid AtRho]) ctx = toCST (ExFormation []) ctx

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -205,11 +205,6 @@ dataize' (expr, seq) univ state ctx = do
     asRule rule = Y.Rule rule.name Nothing Nothing rule.match ExRoot rule.when Nothing Nothing
     reduce :: Y.DataizeRule -> Subst -> IO (Dataized, State)
     reduce rule subst = case bytesProducer rule.dresult rule.premises of
-      -- The bytes result is a literal or a matched meta with no producing
-      -- premise — the 'delta' rule that extracts the bare data 𝛿. Record that
-      -- extraction as the final chain step so '--sequence' terminates at 𝛿
-      -- (rendered through the 'ExBytes' node) rather than at the data object it
-      -- was pulled out of (see #980).
       Nothing -> do
         (final, state') <- sides rule.premises subst
         bts <- buildBytesThrows rule.dresult final

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -205,10 +205,16 @@ dataize' (expr, seq) univ state ctx = do
     asRule rule = Y.Rule rule.name Nothing Nothing rule.match ExRoot rule.when Nothing Nothing
     reduce :: Y.DataizeRule -> Subst -> IO (Dataized, State)
     reduce rule subst = case bytesProducer rule.dresult rule.premises of
+      -- The bytes result is a literal or a matched meta with no producing
+      -- premise — the 'delta' rule that extracts the bare data 𝛿. Record that
+      -- extraction as the final chain step so '--sequence' terminates at 𝛿
+      -- (rendered through the 'ExBytes' node) rather than at the data object it
+      -- was pulled out of (see #980).
       Nothing -> do
         (final, state') <- sides rule.premises subst
         bts <- buildBytesThrows rule.dresult final
-        pure ((bts, NE.toList seq), state')
+        seq' <- leadsTo seq rule.name (ExBytes bts) ctx
+        pure ((bts, NE.toList seq'), state')
       Just concl@(Y.Premise _ (Y.OpDataize arg)) -> case producer arg rule.premises of
         -- 𝔻(𝒩(e)) records the producing step (the 'box' contextualization or the
         -- 'fire' λ-application), then normalizes its result back to a normal form

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -240,6 +240,7 @@ instance ToLaTeX EXPRESSION where
   toLaTeX EX_PHI_AGAIN{..} = EX_PHI_AGAIN prefix idx (toLaTeX expr)
   toLaTeX EX_META{..} = EX_META (toLaTeX meta)
   toLaTeX EX_XI{} = EX_XI XI'
+  toLaTeX EX_BYTES{..} = EX_BYTES (toLaTeX bytes)
   toLaTeX expr = expr
 
 instance ToLaTeX ATTRIBUTE where

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -207,6 +207,7 @@ instance Render EXPRESSION where
   render EX_META{..} = render meta
   render EX_PHI_MEET{..} = "\\phinoMeet{" <> maybe "" (\p -> T.pack p <> ":") prefix <> render idx <> "}{ " <> render expr <> " }"
   render EX_PHI_AGAIN{..} = "\\phinoAgain{" <> maybe "" (\p -> T.pack p <> ":") prefix <> render idx <> "}"
+  render EX_BYTES{..} = render bytes
 
 instance Render [ATTRIBUTE] where
   render attrs = T.intercalate ", " (map render attrs)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -889,10 +889,6 @@ spec = do
               ]
           ]
 
-    -- The delta extraction is part of the derivation, so '--sequence' ends the
-    -- chain at the bare data 𝛿 even under '--quiet', which only governs the
-    -- separate bare-data console print (see #980, #480). Before the fix the
-    -- equation terminated at the data object and '--quiet' dropped 𝛿 entirely.
     it "keeps the delta step in --sequence under --quiet" $
       withStdin "[[ D> 01- ]]" $
         testCLISucceeded

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -882,11 +882,34 @@ spec = do
               , "  \\leadsto [[ |x| -> [[ D> |01-|, |y| -> ? ]] ( |y| -> [[]] ) ]] . |x| \\leadsto_{\\nameref{r:copy}}"
               , "  \\leadsto [[ |x| -> [[ D> |01-|, |y| -> [[]] ]] ]] . |x| \\leadsto_{\\nameref{r:dot}}"
               , "  \\leadsto [[ D> |01-|, |y| -> [[]] ]] ( \\phiTerminal{\\rho} -> [[ |x| -> [[ D> |01-|, |y| -> [[]] ]] ]] ) \\leadsto_{\\nameref{r:copy}}"
-              , "  \\leadsto [[ D> |01-|, |y| -> [[]], \\phiTerminal{\\rho} -> [[ |x| -> [[ D> |01-|, |y| -> [[]] ]] ]] ]]{.}"
+              , "  \\leadsto [[ D> |01-|, |y| -> [[]], \\phiTerminal{\\rho} -> [[ |x| -> [[ D> |01-|, |y| -> [[]] ]] ]] ]] \\leadsto_{\\nameref{r:delta}}"
+              , "  \\leadsto |01-|{.}"
               , "\\end{phiquation}"
               , "01-"
               ]
           ]
+
+    -- The delta extraction is part of the derivation, so '--sequence' ends the
+    -- chain at the bare data 𝛿 even under '--quiet', which only governs the
+    -- separate bare-data console print (see #980, #480). Before the fix the
+    -- equation terminated at the data object and '--quiet' dropped 𝛿 entirely.
+    it "keeps the delta step in --sequence under --quiet" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded
+          ["dataize", "--sequence", "--quiet", "--output=latex", "--flat", "--sweet"]
+          [ intercalate
+              "\n"
+              [ "[[ D> |01-| ]] \\leadsto_{\\nameref{r:delta}}"
+              , "  \\leadsto |01-|{.}"
+              , "\\end{phiquation}"
+              ]
+          ]
+
+    it "ends the phi --sequence at the bare data" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded
+          ["dataize", "--sequence", "--quiet", "--flat", "--sweet"]
+          ["⟦ Δ ⤍ 01- ⟧\n01-"]
 
     it "focuses a compressed sequence whose meet replaces a step root" $
       withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -281,10 +281,11 @@ spec = do
                    , "contextualize"
                    , "dot"
                    , "copy"
+                   , "delta"
                    ]
     it "dataizes a located reference through the expected rules" $ do
       labels <- labelsOf "Q.foo.bar" "[[ foo -> [[ bar -> [[ @ -> Q.x ]] ]], x -> [[ D> 42- ]] ]]"
-      labels `shouldBe` ["contextualize", "md", "dot", "copy", "mf"]
+      labels `shouldBe` ["contextualize", "md", "dot", "copy", "mf", "delta"]
     -- The 'none' rule dataizes ⊥ (𝔻(⟦⟧) → 𝔻(⊥)), which matches no clause now
     -- that there is no 'end' rule, so an empty formation reduces through one
     -- labelled 'dataize' step and then fails: it has nothing to dataize (#955).


### PR DESCRIPTION
Closes #980.

## Problem

With `--sequence`, the dataization chain ended at the data *object*
`⟦ Δ ⤍ δ, ρ ↦ … ⟧` — the final `delta` rule (which extracts the bare data δ)
never appeared as a step. The extracted bytes were returned on the side and
printed separately by `putStrLn (P.printBytes bytes)` in `runDataize`. So:

- with `--output=latex` the bare byte line landed *after* `\end{phiquation*}`, producing malformed `.tex`;
- with `--quiet` it was dropped entirely, so the equation visibly terminated at the object rather than the data.

Root cause: in `dataize'` (`src/Dataize.hs`), the `delta` rule — whose
`d-result` has no producing premise — took the `Nothing ->` branch of `reduce`
and returned the bytes **without** calling `leadsTo`, unlike the
`box`/`fire`/`none` branches that splice their step into the chain.

## Fix

- Added a rendering-only `ExBytes Bytes` node to `Expression` to represent bare data δ in the chain (the chain stores `Expression`, which previously had no constructor for bare bytes). It never flows into the matcher, builder, or the dataization relation — only the render path (`CST` → `Render`/`LaTeX`) handles it.
- Recorded the delta transition in the `Nothing ->` branch via `leadsTo`, so the chain terminates at δ, labelled with the rule.

The chain now ends with `… \leadsto_{\nameref{r:delta}} <bytes>` for every
output format (phi, flat, latex), independent of `--quiet`. `--quiet` keeps
governing only the separate bare-data console print (#480).

For a non-root `--locator`, the final node is the whole expression with δ
substituted at the locator; for the default `Q` locator it is the bare bytes.

## Verification

- `cabal test` (`-Werror`): 1089 examples, 0 failures.
- `fourmolu --mode check` and `hlint`: clean.
- Exercised the built binary across phi/flat/latex, with and without `--quiet`, and with a non-root locator — the derivation ends at δ in every case.

Updated the affected label-sequence assertions in `DataizeSpec` (each now ends
with `delta`) and the `--sequence` LaTeX expectation in `CLISpec`, and added
regression tests that the delta step survives `--quiet` and that the phi
`--sequence` ends at the bare data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqLLhievR9wNy4wJ54xE7v

---
_Generated by [Claude Code](https://claude.ai/code/session_01WqLLhievR9wNy4wJ54xE7v)_