### PR TITLE
Fix #984: render morph/dataize premise universe from the rule's e-match

### DIFF
--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -465,7 +465,7 @@ premiseToLatex universe index premise = case premise.operation of
   Y.OpMorph arg -> (phinoMorph (renderExpr arg) universe (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
   Y.OpDataize arg -> (phinoDataize (renderExpr arg) universe (stateName index) (stateName (index + 1)) (renderBytes (BtMeta premise.result)), index + 1)
   Y.OpNormalize arg -> (phinoNormalize (renderExpr arg) (renderExpr (ExMeta premise.result)), index)
-  Y.OpEvaluate arg universe -> (phinoEvaluate (renderExpr arg) (renderExpr universe) (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
+  Y.OpEvaluate arg evalUniverse -> (phinoEvaluate (renderExpr arg) (renderExpr evalUniverse) (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
   Y.OpContextualize arg context -> (phinoContextualize (renderExpr arg) (renderExpr context) (renderExpr (ExMeta premise.result)), index)
 
 -- Assemble an inference block from a name, optional label, optional side

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -392,7 +392,7 @@ explainMorphRule rule =
     premises
     (phinoMorph (renderExpr rule.match) (renderExpr rule.ematch) (conclusionStateName final 1) (conclusionStateName final final) (renderExpr rule.nresult))
   where
-    (premises, final) = premisesToLatex rule.premises
+    (premises, final) = premisesToLatex (renderExpr rule.ematch) rule.premises
 
 -- Render a dataization rule as a LaTeX inference rule, with 𝔻(match, e, s_1) ⟿
 -- ⟨d-result, s_k⟩ as the conclusion below the line, s_k being the final threaded
@@ -407,7 +407,7 @@ explainDataizeRule rule =
     premises
     (phinoDataize (renderExpr rule.match) (renderExpr rule.ematch) (conclusionStateName final 1) (conclusionStateName final final) (renderBytes rule.dresult))
   where
-    (premises, final) = premisesToLatex rule.premises
+    (premises, final) = premisesToLatex (renderExpr rule.ematch) rule.premises
 
 -- Render a contextualization rule as a LaTeX inference rule, with 𝒞(match, c) ⟿
 -- c-result as the conclusion below the line. 𝒞 carries no state, so its premises
@@ -419,7 +419,7 @@ explainContextualizeRule rule =
     rule.name
     rule.label
     Nothing
-    (fst (premisesToLatex rule.premises))
+    (fst (premisesToLatex "e" rule.premises))
     (phinoContextualize (renderExpr rule.match) (renderExpr rule.cmatch) (renderExpr rule.cresult))
 
 -- The state metavariable for index 'n', rendered as s_1, s_2, … to mirror the
@@ -440,25 +440,30 @@ conclusionStateName final index
 -- Render a rule's premises in order, threading the state through them. The rule
 -- starts in state s_1; each state-changing premise (𝕄, 𝔻, 𝔼) consumes the
 -- current state and yields the next (s_2, s_3, …), matching how the engine folds
--- the state through the premises ('sidePremise' in 'Dataize.hs'). Returns the
--- rendered judgments and the final state index, which the conclusion returns.
-premisesToLatex :: [Y.Premise] -> ([String], Int)
-premisesToLatex = go 1
+-- the state through the premises ('sidePremise' in 'Dataize.hs'). The 'universe'
+-- is the rule's own e-match, threaded into 𝕄/𝔻 premises (bound by the conclusion)
+-- rather than a free 'e'. Returns the rendered judgments and the final state
+-- index, which the conclusion returns.
+premisesToLatex :: String -> [Y.Premise] -> ([String], Int)
+premisesToLatex universe = go 1
   where
+    go :: Int -> [Y.Premise] -> ([String], Int)
     go index [] = ([], index)
     go index (premise : rest) = (rendered : more, final)
       where
-        (rendered, next) = premiseToLatex index premise
+        (rendered, next) = premiseToLatex universe index premise
         (more, final) = go next rest
 
 -- One premise judgment in state s_index, rendered per its operation. The
--- state-changing operations 𝕄 ('morph'), 𝔻 ('dataize') and 𝔼 ('evaluate') carry
--- the universe 'e' they were given, consume s_index and yield s_index+1 (so they
--- return the bumped index); the rest are stateless and leave the index as is.
-premiseToLatex :: Int -> Y.Premise -> (String, Int)
-premiseToLatex index premise = case premise.operation of
-  Y.OpMorph arg -> (phinoMorph (renderExpr arg) "e" (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
-  Y.OpDataize arg -> (phinoDataize (renderExpr arg) "e" (stateName index) (stateName (index + 1)) (renderBytes (BtMeta premise.result)), index + 1)
+-- state-changing operations 𝕄 ('morph'), 𝔻 ('dataize') and 𝔼 ('evaluate') consume
+-- s_index and yield s_index+1 (so they return the bumped index); the rest are
+-- stateless and leave the index as is. 𝕄 and 𝔻 carry the rule's own 'universe'
+-- (its e-match) so the premise stays bound by the conclusion instead of naming a
+-- free 'e'; 𝔼 carries the explicit universe from its own operation.
+premiseToLatex :: String -> Int -> Y.Premise -> (String, Int)
+premiseToLatex universe index premise = case premise.operation of
+  Y.OpMorph arg -> (phinoMorph (renderExpr arg) universe (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
+  Y.OpDataize arg -> (phinoDataize (renderExpr arg) universe (stateName index) (stateName (index + 1)) (renderBytes (BtMeta premise.result)), index + 1)
   Y.OpNormalize arg -> (phinoNormalize (renderExpr arg) (renderExpr (ExMeta premise.result)), index)
   Y.OpEvaluate arg universe -> (phinoEvaluate (renderExpr arg) (renderExpr universe) (stateName index) (stateName (index + 1)) (renderExpr (ExMeta premise.result)), index + 1)
   Y.OpContextualize arg context -> (phinoContextualize (renderExpr arg) (renderExpr context) (renderExpr (ExMeta premise.result)), index)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1129,7 +1129,7 @@ spec = do
             , "\\end{phinoMorphingInference}"
             , "\\begin{phinoMorphingInference}"
             , "  \\phinoName{mg}"
-            , "  \\phinoPremise{ \\phinoMorph{ T }{ e }{ s_1 }{ n }{ s_2 } }"
+            , "  \\phinoPremise{ \\phinoMorph{ T }{ Q }{ s_1 }{ n }{ s_2 } }"
             , "  \\phinoConclusion{ \\phinoMorph{ Q }{ Q }{ s_1 }{ n }{ s_2 } }"
             , "\\end{phinoMorphingInference}"
             ]


### PR DESCRIPTION
Closes #984.

## Problem

`phino explain --morph` printed the `mg` rule with a free metavariable: the premise `𝕄(⊥, e, s₁) → ⟨n, s₂⟩` over the conclusion `𝕄(Φ, Φ, s₁) → ⟨n, s₂⟩`. The premise universe `e` is bound by nothing in the conclusion (which pins the universe to `Φ`), so the printed schema is not well-formed.

The cause was `premiseToLatex` in `src/LaTeX.hs`: its `OpMorph`/`OpDataize` branches hardcoded the premise universe to the literal `"e"`. For every rule whose `e-match` is the `𝑒` meta the hardcoded `e` and the conclusion's `e` coincide, hiding the defect — but `mg` pins `e-match: Φ`, so the premise's literal `e` disagreed with the conclusion's `Φ`.

## Fix

Thread the rule's own e-match into `premisesToLatex`/`premiseToLatex` so `𝕄` and `𝔻` premises render the same universe as the conclusion instead of a free `e`. `mg` now prints `𝕄(⊥, Φ, s₁)`. Rules with `e-match: 𝑒` are unchanged, since `renderExpr` of that meta is already `e`. Contextualization rules (no e-match, universe-free) keep `"e"`, and the `𝔼` (evaluate) branch continues to use its own explicit universe.

## Testing

Updated the `mg` snapshot in the `explains morphing rules` test (`test/CLISpec.hs`) so its premise reads `\phinoMorph{ T }{ Q }{ s_1 }{ n }{ s_2 }` (`Q` = `Φ`), matching the conclusion. It is the only rule with a non-`𝑒` e-match, so no other expectations change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M27jFRW6qWp23GRhCSLRjG)_