### PR TITLE
fix(#985): label mphi rule with \varphi to match the φ decorator glyph

### DIFF
--- a/resources/morphing.yaml
+++ b/resources/morphing.yaml
@@ -67,7 +67,7 @@
       morph: 𝑛1
 
 - name: mphi
-  label: \phi
+  label: \varphi
   match: ⟦𝐵⟧.𝜏
   e-match: 𝑒
   n-result: 𝑛1

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1070,7 +1070,7 @@ spec = do
             , "\\end{phinoMorphingInference}"
             , "\\begin{phinoMorphingInference}"
             , "  \\phinoName{mphi}"
-            , "  \\phinoLabel{\\phi}"
+            , "  \\phinoLabel{\\varphi}"
             , "  \\phinoCondition{ @ \\in B \\;\\text{and}\\; \\tau \\notin B \\;\\text{and}\\; L \\notin B }"
             , "  \\phinoPremise{ \\phinoNormalize{ [[ B ]] . @ . \\tau }{ n } }"
             , "  \\phinoPremise{ \\phinoMorph{ n }{ e }{ s_1 }{ n_1 }{ s_2 } }"


### PR DESCRIPTION
Fixes #985.

## Problem

`phino explain --morph` labeled the `mphi` rule — the one that dispatches through the `@` decorator — with `\phi`, which typesets U+03D5 (ϕ, straight-stroke phi). But phino renders the decorator attribute `PHI` as U+03C6 (φ) everywhere else (`src/Render.hs:64`, `AST.hs:73`), and U+03C6 is exactly LaTeX's `\varphi`. So the rule label used a different glyph from the very attribute it names, while every other rule label matches its attribute's glyph (`\lambda` for λ, `\Delta` for Δ, `\Phi` for Φ).

## Change

- `resources/morphing.yaml:70`: `label: \phi` → `label: \varphi`, so the label matches the decorator glyph phino already emits.
- `test/CLISpec.hs:1073`: updated the corresponding `\phinoLabel{\phi}` expectation to `\phinoLabel{\varphi}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TK4Wudo4AF4F55uyfAwZ6H)_