### PR TITLE
fix(#988): canonize functions as Fn1, Fn2 to avoid LaTeX metavariable clash

### DIFF
--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -122,7 +122,7 @@ optSequence :: Parser Bool
 optSequence = switch (long "sequence" <> help "Result output contains all intermediate 𝜑-expressions concatenated with EOL")
 
 optCanonize :: Parser Bool
-optCanonize = switch (long "canonize" <> help "Rename all functions attached to λ binding with F1, F2, etc.")
+optCanonize = switch (long "canonize" <> help "Rename all functions attached to λ binding with Fn1, Fn2, etc.")
 
 optExpression :: Parser (Maybe String)
 optExpression = optional (strOption (long "expression" <> metavar "NAME" <> help "Name for 'phiExpression' element when rendering to LaTeX (see --output option)"))

--- a/src/Canonizer.hs
+++ b/src/Canonizer.hs
@@ -2,8 +2,8 @@
 -- SPDX-License-Identifier: MIT
 
 -- Canonization is the process of replacing function names attrached to
--- lambda bindings with numbered identifiers started from 'F'
--- like 'F1', 'F2', etc.
+-- lambda bindings with numbered identifiers prefixed with 'Fn'
+-- like 'Fn1', 'Fn2', etc.
 module Canonizer (canonize, canonizeExpr) where
 
 import AST
@@ -14,7 +14,7 @@ canonizeBindings :: [Binding] -> Int -> ([Binding], Int)
 canonizeBindings [] idx = ([], idx)
 canonizeBindings ((BiLambda (Function _)) : rest) idx =
   let (bds', idx') = canonizeBindings rest (idx + 1)
-   in (BiLambda (Function (T.pack ('F' : show idx))) : bds', idx')
+   in (BiLambda (Function (T.pack ("Fn" <> show idx))) : bds', idx')
 canonizeBindings (BiTau attr expr : rest) idx =
   let (expr', idx') = canonizeExpression expr idx
       (bds', idx'') = canonizeBindings rest idx'
@@ -50,7 +50,7 @@ canonizeArgument (ArAlpha alpha expr) idx =
   let (expr', idx') = canonizeExpression expr idx
    in (ArAlpha alpha expr', idx')
 
--- Canonize a single expression, restarting the 'F' counter from 1 so the
+-- Canonize a single expression, restarting the 'Fn' counter from 1 so the
 -- numbering is local to that expression.
 canonizeExpr :: Expression -> Expression
 canonizeExpr expr = fst (canonizeExpression expr 1)

--- a/src/Canonizer.hs
+++ b/src/Canonizer.hs
@@ -1,7 +1,7 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
--- Canonization is the process of replacing function names attrached to
+-- Canonization is the process of replacing function names attached to
 -- lambda bindings with numbered identifiers prefixed with 'Fn'
 -- like 'Fn1', 'Fn2', etc.
 module Canonizer (canonize, canonizeExpr) where

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -842,7 +842,7 @@ spec = do
       withStdin "[[ x -> [[ y -> [[ L> Func ]].q, z -> Q.x(a -> [[ w -> [[ L> Atom ]], L> Hello ]]) ]], L> Package ]]" $
         testCLISucceeded
           ["rewrite", "--canonize", "--sweet", "--flat"]
-          ["⟦ x ↦ ⟦ y ↦ ⟦ λ ⤍ F1 ⟧.q, z ↦ Φ.x( a ↦ ⟦ w ↦ ⟦ λ ⤍ F2 ⟧, λ ⤍ F3 ⟧ ) ⟧, λ ⤍ F4 ⟧"]
+          ["⟦ x ↦ ⟦ y ↦ ⟦ λ ⤍ Fn1 ⟧.q, z ↦ Φ.x( a ↦ ⟦ w ↦ ⟦ λ ⤍ Fn2 ⟧, λ ⤍ Fn3 ⟧ ) ⟧, λ ⤍ Fn4 ⟧"]
 
     it "rewrites by locator" $
       withStdin "[[ ex -> [[ x -> [[ y -> 5 ]].y ]], abc -> [[ x -> ? ]](x -> 5) ]]" $


### PR DESCRIPTION
Closes #988.

## Problem

`phino --canonize` renamed every λ-asset function to `F1, F2, F3, …`. In LaTeX output the abstract L-function metavariable renders as a bare uppercase `F` (`src/Render.hs:133`), and the `ml`/`mphi` rules from `explain --morph` print `L> F`. So a canonized `L> F1` lands in the same document as rules writing `L> F`, and `F1` reads as an indexed instance of the metavariable `F` rather than the name of a distinct concrete function. (In Unicode mode the metavariable is `𝑓`, so the clash is specific to LaTeX.)

## Fix

Give the canonical family a two-letter prefix that cannot be read as the metavariable: emit `Fn1, Fn2, …` instead of `F1, F2, …`. `Fn1` is grammar-valid per `src/Parser.hs:86` (uppercase head, then lowercase/digit tail).

## Changes

- `src/Canonizer.hs` — `'F' : show idx` → `"Fn" <> show idx`, plus the two docstrings mentioning the `F` counter.
- `src/CLI/Parsers.hs` — `--canonize` help text now says `Fn1, Fn2`.
- `test/CLISpec.hs` — expected canonize output updated to `Fn1`…`Fn4`.

> Note: the Haskell toolchain is not available in this environment, so the test suite could not be run here. The change is a mechanical rename; the CLI spec expectation was updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awv4gzA1Bie5a4H1wnuSdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Awv4gzA1Bie5a4H1wnuSdA)_