### PR TITLE
Add `--seed` flag for reproducible rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ to normalize expressions:
 phino rewrite --normalize hello.phi
 ```
 
+Some rules mint fresh synthetic names via the `random-string` built-in. To
+keep the output reproducible across runs, `phino` seeds the random generator
+deterministically with `0` by default. Use `--seed` to pick a different seed:
+
+```bash
+phino rewrite --seed=42 --rule=my-rule.yml hello.phi
+```
+
 If no input file is provided, the 𝜑-expression is taken from `stdin`:
 
 ```bash

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -192,6 +192,17 @@ optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "D
 optShuffle :: Parser Bool
 optShuffle = switch (long "shuffle" <> help "Shuffle rules before applying")
 
+optSeed :: Parser Int
+optSeed =
+  option
+    auto
+    ( long "seed"
+        <> metavar "SEED"
+        <> help "Seed for the random generator that mints fresh synthetic names, making output reproducible across runs"
+        <> value 0
+        <> showDefault
+    )
+
 optSugar :: Parser SugarType
 optSugar = flag SALTY SWEET (long "sweet" <> help (printf "Print result and intermediate (see %s option(s)) 𝜑-expressions using syntax sugar" _intermediateOptions))
 
@@ -259,6 +270,7 @@ dataizeParser =
             <*> optCanonize
             <*> optDepthSensitive
             <*> optShuffle
+            <*> optSeed
             <*> switch (long "quiet" <> help "Don't print the result of dataization")
             <*> optCompress
             <*> optMaxDepth
@@ -290,6 +302,7 @@ rewriteParser =
             <*> optMust
             <*> optNormalize
             <*> optShuffle
+            <*> optSeed
             <*> optOmitListing
             <*> optOmitComments
             <*> optDepthSensitive
@@ -343,6 +356,7 @@ matchParser =
             <*> optLogLines
             <*> optSugar
             <*> optLineFormat
+            <*> optSeed
             <*> optional (strOption (long "pattern" <> metavar "EXPRESSION" <> help "Pattern expression to match against"))
             <*> optional (strOption (long "when" <> metavar "CONDITION" <> help "Predicate for matched substitutions"))
             <*> argInputFile

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -31,6 +31,7 @@ import Rewriter
 import Rule (RuleContext (..), matchExpressionWithRule)
 import System.Directory (doesFileExist, getModificationTime)
 import System.Exit (exitSuccess)
+import System.Random (mkStdGen, setStdGen)
 import Tau (seedTaus)
 import Text.Printf (printf)
 import XMIR
@@ -48,6 +49,7 @@ runRewrite OptsRewrite{..} = do
   validateBreakpoint _breakpoint rules
   input <- readInput _inputFile
   expr <- parseInput input _inputFormat
+  setStdGen (mkStdGen _seed)
   seedTaus expr
   logDebug (printf "Amount of rewriting cycles across all the rules: %d, per rule: %d" _maxCycles _maxDepth)
   let listing = case (rules, _inputFormat, _outputFormat) of
@@ -141,6 +143,7 @@ runDataize OptsDataize{..} = do
   [foc] <- validatedDispatches "focus" [_focus]
   input <- readInput _inputFile
   expr <- parseInput input _inputFormat
+  setStdGen (mkStdGen _seed)
   seedTaus expr
   let printCtx = toPrintCtx foc
       exclude = (`F.exclude` excluded)
@@ -235,6 +238,7 @@ runMatch :: OptsMatch -> IO ()
 runMatch OptsMatch{..} = do
   input <- readInput _inputFile
   expr <- parseInput input PHI
+  setStdGen (mkStdGen _seed)
   seedTaus expr
   if isNothing _pattern
     then logDebug "The --pattern is not provided, no substitutions are built"

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -85,6 +85,7 @@ data OptsDataize = OptsDataize
   , _canonize :: Bool
   , _depthSensitive :: Bool
   , _shuffle :: Bool
+  , _seed :: Int
   , _quiet :: Bool
   , _compress :: Bool
   , _maxDepth :: Int
@@ -125,6 +126,7 @@ data OptsRewrite = OptsRewrite
   , _must :: Must
   , _normalize :: Bool
   , _shuffle :: Bool
+  , _seed :: Int
   , _omitListing :: Bool
   , _omitComments :: Bool
   , _depthSensitive :: Bool
@@ -172,6 +174,7 @@ data OptsMatch = OptsMatch
   , _logLines :: Int
   , _sugarType :: SugarType
   , _flat :: LineFormat
+  , _seed :: Int
   , _pattern :: Maybe String
   , _when :: Maybe String
   , _inputFile :: Maybe FilePath

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -334,7 +334,24 @@ spec = do
     it "prints help" $
       testCLISucceeded
         ["rewrite", "--help"]
-        ["Rewrite the 𝜑-expression"]
+        ["Rewrite the 𝜑-expression", "--seed SEED"]
+
+    it "accepts --seed flag" $
+      withStdin "[[ x -> 5 ]]" $
+        testCLISucceeded
+          ["rewrite", "--seed=42", "--sweet"]
+          ["⟦ x ↦ 5 ⟧"]
+
+    it "defaults --seed to 0 in help" $
+      testCLISucceeded
+        ["rewrite", "--help"]
+        ["default: 0"]
+
+    it "fails with a non-integer --seed" $
+      withStdin "[[ ]]" $
+        testCLIFailed
+          ["rewrite", "--seed=abc"]
+          ["[ERROR]"]
 
     it "saves steps to dir with --steps-dir" $ do
       let dir = "test-steps-temp"
@@ -867,6 +884,10 @@ spec = do
       withStdin "[[ D> 01- ]]" $
         testCLISucceeded ["dataize"] ["01-"]
 
+    it "accepts --seed flag" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded ["dataize", "--seed=7"] ["01-"]
+
     it "fails to dataize an empty object, which dataizes the terminator ⊥" $
       withStdin "[[ ]]" $
         testCLIFailed ["dataize"] ["terminator ⊥"]
@@ -1314,6 +1335,10 @@ spec = do
     it "prints one substitution" $
       withStdin "[[ x -> Q.x ]]" $
         testCLISucceeded ["match", "--pattern=Q.!t"] ["t >> x"]
+
+    it "accepts --seed flag" $
+      withStdin "[[ x -> Q.x ]]" $
+        testCLISucceeded ["match", "--seed=3", "--pattern=Q.!t"] ["t >> x"]
 
     it "prints many substitutions" $
       withStdin "[[ x -> Q.x, y -> Q.y ]]" $


### PR DESCRIPTION
Closes #994

## Problem

`phino rewrite` (and `dataize`/`match`) returned different output on every run for identical input and rules. Rules mint fresh synthetic names through the `random-string` built-in (`src/Functions.hs`), whose `%d`/`%x` directives expand via `randomRIO` on the global generator (`src/Random.hs`). That generator is seeded from process entropy and was never fixed, so a name template such as `"lambda$hone$%d"` gets a different number each process. Names stayed unique within a run but were disjoint across runs, breaking reproducible builds and turning synthetic-name faults into heisenbugs.

## Change

- Added a `--seed SEED` option (default `0`) to the `rewrite`, `dataize`, and `match` commands.
- Each runner now calls `setStdGen (mkStdGen _seed)` before rewriting, so the global generator is fixed deterministically. Identical inputs now yield byte-identical output across separate process runs; a different seed can be chosen when a distinct name base is needed.

The within-run uniqueness in `regenerate` (`src/Random.hs`) is unaffected — the `strings` dedup set still guarantees no collisions inside a single run.

## Files touched

- `src/CLI/Parsers.hs` — new `optSeed` parser, wired into all three command parsers.
- `src/CLI/Types.hs` — new `_seed :: Int` field on `OptsRewrite`, `OptsDataize`, `OptsMatch`.
- `src/CLI/Runners.hs` — seed the generator before each run.
- `test/CLISpec.hs` — flag-wiring tests (help output, default, acceptance, invalid value).
- `README.md` — documented the flag.

## Tests

Added CLI tests verifying the flag is accepted, appears in `--help` with its default of `0`, and rejects non-integer values, for `rewrite`, `dataize`, and `match`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6cuXpWJk3xWGgR2a1bSAA)_