### PR TITLE
Point parse errors at the typo, not at the first binding

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -82,15 +82,19 @@ label' = lexeme $ do
   return (T.pack (first : rest))
 
 function :: Parser String
-function = lexeme $ do
-  first <- oneOf ['A' .. 'Z']
-  rest <-
-    many
-      ( satisfy
-          (\ch -> isDigit ch || isAsciiLower ch || ch == '_' || ch == 'φ')
-          <?> "allowed character in function name"
-      )
-  return (first : rest)
+function =
+  lexeme
+    ( do
+        first <- oneOf ['A' .. 'Z']
+        rest <-
+          many
+            ( satisfy
+                (\ch -> isDigit ch || isAsciiLower ch || ch == '_' || ch == 'φ')
+                <?> "allowed character in function name"
+            )
+        return (first : rest)
+    )
+    <?> "function name"
 
 delta :: Parser String
 delta =
@@ -244,7 +248,7 @@ quotedStr = char '"' >> manyTill (choice [escapedChar, noneOf ['\\', '"']]) (cha
 tauValue :: Parser Expression
 tauValue =
   choice
-    [ try $ do
+    [ do
         _ <- arrow
         expression
     , do
@@ -265,41 +269,42 @@ tauValue =
     rb :: Parser String
     rb = symbol ")"
 
-tauBinding :: Parser Attribute -> Parser Binding
-tauBinding attr = BiTau <$> attr <*> tauValue
-
 metaBinding :: Parser Binding
 metaBinding = BiMeta <$> meta' 'B' "𝐵"
 
 -- binding
--- 1. tau
--- 2. void
--- 3. delta
--- 4. meta delta
--- 5. meta
--- 6. lambda
--- 7. meta lambda
+-- 1. delta
+-- 2. meta delta
+-- 3. meta
+-- 4. lambda
+-- 5. meta lambda
+-- 6. void
+-- 7. tau
+--
+-- Every alternative commits as soon as the token that tells it apart from its
+-- siblings is consumed, so a failure deeper in the binding keeps its own
+-- position instead of being rewound to the beginning of the binding.
 binding :: Parser Binding
 binding =
   choice
-    [ try (tauBinding attribute)
-    , try $ do
-        attr <- attribute
-        _ <- arrow
-        _ <- choice [symbol "?", symbol "∅"]
-        return (BiVoid attr)
-    , try $ do
-        _ <- delta
+    [ do
+        _ <- try delta
         BiDelta <$> bytes
     , try metaBinding
-    , try $ do
-        _ <- lambda
-        BiLambda . Function . T.pack <$> function
     , do
-        _ <- lambda
-        BiLambda . FnMeta <$> meta' 'F' "𝑓"
+        _ <- try lambda
+        BiLambda <$> choice [Function . T.pack <$> function, FnMeta <$> meta' 'F' "𝑓"]
+    , do
+        attr <- attribute
+        choice
+          [ try blank >> return (BiVoid attr)
+          , BiTau attr <$> tauValue
+          ]
     ]
     <?> "binding"
+  where
+    blank :: Parser String
+    blank = arrow >> choice [symbol "?", symbol "∅"]
 
 -- inlined void attribute
 -- 1. label
@@ -352,7 +357,7 @@ alpha = do
 argument :: Parser Argument
 argument =
   choice
-    [ try (ArAlpha <$> alpha <*> tauValue)
+    [ ArAlpha <$> try alpha <*> tauValue
     , ArTau <$> attribute <*> tauValue
     ]
     <?> "argument"

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -10,6 +10,7 @@ module ParserSpec where
 import AST
 import Control.Monad (forM_)
 import Data.Either (isLeft, isRight)
+import Data.List (isInfixOf)
 import Files (allPathsIn)
 import Parser
 import System.FilePath (takeBaseName)
@@ -25,6 +26,15 @@ test function useCases =
     it ipt $ case res of
       Just right -> function ipt `shouldBe` Right right
       _ -> function ipt `shouldSatisfy` isLeft
+
+fails ::
+  (Show a) =>
+  (String -> Either String a) ->
+  [(String, String)] ->
+  SpecWith (Arg Expectation)
+fails function useCases =
+  forM_ useCases $ \(ipt, fragment) ->
+    it ipt (function ipt `shouldSatisfy` either (isInfixOf fragment) (const False))
 
 spec :: Spec
 spec = do
@@ -245,6 +255,25 @@ spec = do
           , "⟦ k ↦ ⟦ Δ ⤍ 42-, Δ ⤍ 55- ⟧ ⟧"
           ]
       )
+
+  describe "points at the typo instead of the beginning of the binding" $
+    fails
+      parseExpression
+      [ ("[[ D> x ]]", "expression:1:7:")
+      , ("[[ L> 42 ]]", "expression:1:7:")
+      , ("⟦ a ↦ Φ.foo() ⟧", "expression:1:13:")
+      , ("[[ x -> ]]", "expression:1:9:")
+      , ("[[ x -> Q.y(] ]]", "expression:1:13:")
+      , ("[[ y -> 5, x -> Q.z(} ]]", "expression:1:21:")
+      ]
+
+  describe "tells what a binding prefix may be followed by" $
+    fails
+      parseExpression
+      [ ("[[ D> x ]]", "expecting bytes")
+      , ("[[ L> 42 ]]", "function name")
+      , ("[[ x -> ]]", "expecting '?', '∅', or expression head")
+      ]
 
   describe "parse packs" $ do
     packs <- runIO (allPathsIn "test-resources/parser-packs")


### PR DESCRIPTION
Every alternative of `binding` in `src/Parser.hs` used to be wrapped in `try`, so a syntax error anywhere inside a binding rewound the parser to the start of that binding. Megaparsec then blamed the formation's *first* binding, however valid it was, and the caret never landed near the actual typo. Each alternative now commits as soon as the token that tells it apart from its siblings is consumed, and the same narrowing is applied to `tauValue` and `argument`.

This matters most in big files, where `unexpected "a "` pointing at line 1 tells you nothing about a typo 3000 lines down. Two examples: `⟦ a ↦ Φ.foo() ⟧` now reports column 13 (the stray `()`) instead of column 3, and `[[ D> x ]]` now says `expecting bytes` at column 7 instead of `unexpected "D>"` — the delta branch was the only one that swallowed its own inner error, while the lambda branch had always reported correctly. `function` also got a label, so a bad lambda binding says `expecting function name`.

Six new cases in `ParserSpec` pin the reported positions and three more pin the expected-token sets; five of them fail on `master`. As a side effect the tau path no longer saves parser state for the whole value, so parsing a 535 KB formation is a hair faster rather than slower.

Closes #873