### PR TITLE
feat(cli): add --headers to annotate --sequence steps

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -25,7 +25,7 @@ import Logger
 import Parser (parseExpressionThrows)
 import qualified Printer as P
 import qualified Random as R
-import Rewriter (Rewritten, Rewrittens')
+import Rewriter (Rewritten, Rewrittens', stepHeaders)
 import System.IO (getContents')
 import Text.Printf (printf)
 import XMIR (expressionToXMIR, parseXMIRThrows, printXMIR, xmirToPhi)
@@ -69,11 +69,26 @@ parseInput _ LATEX = invalidCLIArguments "LaTeX cannot be used as input format"
 printRewrittens :: PrintContext -> Rewrittens' -> IO String
 printRewrittens ctx@PrintCtx{..} rewrittens@(chain, _)
   | _outputFormat == LATEX && _sequence = rewrittensToLatex rewrittens (printCtxToLatexCtx ctx)
-  | _focus == ExRoot = mapM (printInFormat ctx . fst) (canonized chain) <&> intercalate "\n"
-  | otherwise = mapM (\(expr, _) -> locatedExpression _focus expr >>= printExpression ctx) (canonized chain) <&> intercalate "\n"
+  | otherwise = withHeaders <$> mapM render (canonized chain)
   where
+    render :: Rewritten -> IO String
+    render (expr, _)
+      | _focus == ExRoot = printInFormat ctx expr
+      | otherwise = locatedExpression _focus expr >>= printExpression ctx
     canonized :: [Rewritten] -> [Rewritten]
     canonized = if _canonize then canonize else id
+    -- Prefix every step with an empty line and its header (see 'stepHeaders')
+    -- when '--headers' is on. Headers, like the other intermediate-output
+    -- flags, are meaningful only together with '--sequence'. Node counts come
+    -- from the original 'chain', not the canonized one, since canonization
+    -- only renames functions and never changes the AST size.
+    withHeaders :: [String] -> String
+    withHeaders rendered
+      | _headers && _sequence = intercalate "\n" (zipWith prefixed (stepHeaders chain) rendered)
+      | otherwise = intercalate "\n" rendered
+      where
+        prefixed :: String -> String -> String
+        prefixed = printf "\n%s\n%s"
 
 printExpression :: PrintContext -> Expression -> IO String
 printExpression ctx@PrintCtx{..} ex = case _outputFormat of
@@ -90,7 +105,7 @@ printInFormat ctx@PrintCtx{..} expr = case _outputFormat of
 
 printCtxToLatexCtx :: PrintContext -> LatexContext
 printCtxToLatexCtx PrintCtx{..} =
-  LatexContext _sugar _line _margin _nonumber _compress _canonize _meetPopularity _meetLength _focus _expression _label _meetPrefix
+  LatexContext _sugar _line _margin _nonumber _compress _canonize _meetPopularity _meetLength _focus _expression _label _meetPrefix _headers
 
 -- Get rules for rewriting depending on provided flags
 getRules :: Bool -> Bool -> [FilePath] -> IO [Y.Rule]

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -121,6 +121,13 @@ optNonumber = switch (long "nonumber" <> help "Turn off equation auto numbering 
 optSequence :: Parser Bool
 optSequence = switch (long "sequence" <> help "Result output contains all intermediate 𝜑-expressions concatenated with EOL")
 
+optHeaders :: Parser Bool
+optHeaders =
+  switch
+    ( long "headers"
+        <> help "Prefix every intermediate step (see --sequence) with a header line: step number, the rule that produced it, and AST node count before and after that rule"
+    )
+
 optCanonize :: Parser Bool
 optCanonize = switch (long "canonize" <> help "Rename all functions attached to λ binding with Fn1, Fn2, etc.")
 
@@ -267,6 +274,7 @@ dataizeParser =
             <*> optOmitComments
             <*> optNonumber
             <*> optSequence
+            <*> optHeaders
             <*> optCanonize
             <*> optDepthSensitive
             <*> optShuffle
@@ -310,6 +318,7 @@ rewriteParser =
             <*> switch (long "in-place" <> help "Edit file in-place instead of printing to output")
             <*> switch (long "update" <> help "Skip rewriting if --target file is newer than the input file")
             <*> optSequence
+            <*> optHeaders
             <*> optCanonize
             <*> optCompress
             <*> optMaxDepth

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -126,6 +126,7 @@ runRewrite OptsRewrite{..} = do
         _compress
         _canonize
         _sequence
+        _headers
         (justMeetPopularity _meetPopularity)
         (justMeetLength _meetLength)
         focus
@@ -174,6 +175,7 @@ runDataize OptsDataize{..} = do
         _compress
         _canonize
         _sequence
+        _headers
         (justMeetPopularity _meetPopularity)
         (justMeetLength _meetLength)
         focus
@@ -222,6 +224,7 @@ runMerge OptsMerge{..} = do
         _flat
         _margin
         xmirCtx
+        False
         False
         False
         False

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -24,6 +24,7 @@ data PrintContext = PrintCtx
   , _compress :: Bool
   , _canonize :: Bool
   , _sequence :: Bool
+  , _headers :: Bool
   , _meetPopularity :: Int
   , _meetLength :: Int
   , _focus :: Expression
@@ -82,6 +83,7 @@ data OptsDataize = OptsDataize
   , _omitComments :: Bool
   , _nonumber :: Bool
   , _sequence :: Bool
+  , _headers :: Bool
   , _canonize :: Bool
   , _depthSensitive :: Bool
   , _shuffle :: Bool
@@ -134,6 +136,7 @@ data OptsRewrite = OptsRewrite
   , _inPlace :: Bool
   , _update :: Bool
   , _sequence :: Bool
+  , _headers :: Bool
   , _canonize :: Bool
   , _compress :: Bool
   , _maxDepth :: Int

--- a/src/LaTeX.hs
+++ b/src/LaTeX.hs
@@ -38,7 +38,7 @@ import Matcher
 import Misc
 import Render (Render (render))
 import Replacer (replaceExpression)
-import Rewriter (Rewritten, Rewrittens')
+import Rewriter (Rewritten, Rewrittens', stepHeaders)
 import Sugar (SugarType (SWEET), ToSalty, withSugarType)
 import Text.Printf (printf)
 import Text.Read (readMaybe)
@@ -57,10 +57,11 @@ data LatexContext = LatexContext
   , _expression :: Maybe String
   , _label :: Maybe String
   , _meetPrefix :: Maybe String
+  , _headers :: Bool
   }
 
 defaultLatexContext :: LatexContext
-defaultLatexContext = LatexContext SWEET SINGLELINE defaultMargin False False False defaultMeetPopularity defaultMeetLength ExRoot Nothing Nothing Nothing
+defaultLatexContext = LatexContext SWEET SINGLELINE defaultMargin False False False defaultMeetPopularity defaultMeetLength ExRoot Nothing Nothing Nothing False
 
 defaultMeetPopularity :: Int
 defaultMeetPopularity = 50
@@ -158,22 +159,38 @@ preamble ctx@LatexContext{..} =
 -- than 0 (via 'baseTab'); this keeps a wrapped multi-line step's members nested
 -- one level below its '\leadsto [[' line and its closing bracket aligned with
 -- that line. The first step has no '\leadsto' prefix and stays at base tab 0.
-body :: [(a, Maybe String)] -> (Int -> a -> String) -> String
-body printed toLatex =
+-- Each step is prefixed with the matching entry from 'comments', which is
+-- either empty or a '% ...'-commented header line ending in a newline (see
+-- 'stepComments'), so headers stay on their own line above the equation.
+body :: [String] -> [(a, Maybe String)] -> (Int -> a -> String) -> String
+body comments printed toLatex =
   intercalate
-    "\n  \\leadsto "
-    ( zipWith
-        ( \idx (item, maybeName) ->
+    "\n"
+    ( zipWith3
+        ( \idx comment (item, maybeName) ->
             let item' = toLatex (baseTab idx) item
-             in maybe item' (printf "%s \\leadsto_{\\nameref{r:%s}}" item') maybeName
+                leadsto = if idx == 0 then item' else "  \\leadsto " ++ item'
+             in comment ++ maybe leadsto (printf "%s \\leadsto_{\\nameref{r:%s}}" leadsto) maybeName
         )
         [0 ..]
+        comments
         printed
     )
   where
     baseTab :: Int -> Int
     baseTab 0 = 0
     baseTab _ = 1
+
+-- LaTeX comment header lines for each step (see 'stepHeaders' in "Rewriter"),
+-- or empty strings when '--headers' is off. A '%' starts a LaTeX comment, so
+-- the header documents the '--sequence' chain without affecting the rendered
+-- equation. Each comment ends in a newline so the following step starts on a
+-- fresh line.
+stepComments :: [Rewritten] -> LatexContext -> [String]
+stepComments rewrittens LatexContext{_headers = enabled} =
+  if enabled
+    then map (printf "%% %s\n") (stepHeaders rewrittens)
+    else map (const "") rewrittens
 
 ending :: Bool -> LatexContext -> String
 ending True ctx = printf " \\leadsto\n  \\leadsto \\dots\n\\end{%s}" (phiquation ctx)
@@ -212,7 +229,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{_focus = ExRoot} =
   pure
     ( concat
         [ preamble ctx
-        , body (canonizedRewrittens (compressedRewrittens rewrittens ctx) ctx) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
+        , body (stepComments rewrittens ctx) (canonizedRewrittens (compressedRewrittens rewrittens ctx) ctx) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
         , ending exceeded ctx
         ]
     )
@@ -222,7 +239,7 @@ rewrittensToLatex (rewrittens, exceeded) ctx@LatexContext{..} = do
   pure
     ( concat
         [ preamble ctx
-        , body (zip (canonizedExpressions (compressedExpressions focused ctx) ctx) rules) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
+        , body (stepComments rewrittens ctx) (zip (canonizedExpressions (compressedExpressions focused ctx) ctx) rules) (\tabs expr -> renderToLatex (expressionToCSTFrom tabs expr) ctx)
         , ending exceeded ctx
         ]
     )

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -9,7 +9,7 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Rewriter (rewrite, RewriteContext (..), Rewritten, Rewrittens, Rewrittens') where
+module Rewriter (rewrite, RewriteContext (..), Rewritten, Rewrittens, Rewrittens', stepHeaders) where
 
 import AST
 import Builder
@@ -17,6 +17,7 @@ import Control.Exception (Exception, throwIO)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe)
 import Deps
 import Locator (locatedExpression, withLocatedExpression)
 import Logger (logDebug)
@@ -53,6 +54,27 @@ type Rewritten = (Expression, Maybe String)
 type Rewrittens = (NonEmpty Rewritten, Bool)
 
 type Rewrittens' = ([Rewritten], Bool)
+
+-- Build a header line for every step of a rewriting chain. The chain is
+-- '[(e0, Just r0), ..., (en, Nothing)]', where 'ri' is the rule applied to 'ei'
+-- to produce 'e(i+1)' (see 'leadsTo'). A step's header names the rule that
+-- produced its expression, together with the AST node counts before and after
+-- that rule, e.g. "=== Step #4, Rule 'STOP', 32t -> 43t". The very first step is
+-- the input, which no rule produced, so it carries only its number:
+-- "=== Step #1". The 'N nodes -> M nodes' pair matches the debug log emitted
+-- while rewriting.
+stepHeaders :: [Rewritten] -> [String]
+stepHeaders chain = zipWith3 header [1 ..] chain (Nothing : map Just chain)
+  where
+    header :: Int -> Rewritten -> Maybe Rewritten -> String
+    header step _ Nothing = printf "=== Step #%d" step
+    header step (current, _) (Just (before, rule)) =
+      printf
+        "=== Step #%d, Rule '%s', %dt -> %dt"
+        step
+        (fromMaybe "?" rule)
+        (countNodes before)
+        (countNodes current)
 
 type ToReplace = (Expression, Expression, Expression, [Subst])
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -545,6 +545,65 @@ spec = do
               ]
           ]
 
+    it "prefixes every step with a header when --headers is on" $
+      withStdin "[[ x -> \"foo\" ]]" $
+        testCLISucceeded
+          [ "rewrite"
+          , rule "first.yaml"
+          , rule "second.yaml"
+          , "--max-depth=1"
+          , "--max-cycles=2"
+          , "--sequence"
+          , "--headers"
+          , "--sweet"
+          , "--flat"
+          ]
+          [ intercalate
+              "\n"
+              [ ""
+              , "=== Step #1"
+              , "⟦ x ↦ \"foo\" ⟧"
+              , ""
+              , "=== Step #2, Rule 'first', 31t -> 30t"
+              , "Φ.x( y ↦ \"foo\" )"
+              , ""
+              , "=== Step #3, Rule 'second', 30t -> 31t"
+              , "⟦ x ↦ \"foo\" ⟧"
+              ]
+          ]
+
+    it "ignores --headers without --sequence" $
+      withStdin "[[ x -> \"foo\" ]]" $
+        testCLISucceeded
+          ["rewrite", rule "simple.yaml", "--headers", "--sweet", "--flat"]
+          ["⟦ x ↦ \"bar\" ⟧"]
+
+    it "emits step headers as LaTeX comments with --headers" $
+      withStdin "[[ x -> \"foo\" ]]" $
+        testCLISucceeded
+          [ "rewrite"
+          , rule "first.yaml"
+          , rule "second.yaml"
+          , "--max-depth=1"
+          , "--max-cycles=2"
+          , "--sequence"
+          , "--headers"
+          , "--sweet"
+          , "--flat"
+          , "--output=latex"
+          ]
+          [ unlines
+              [ "\\begin{phiquation}"
+              , "% === Step #1"
+              , "[[ |x| -> \"foo\" ]] \\leadsto_{\\nameref{r:first}}"
+              , "% === Step #2, Rule 'first', 31t -> 30t"
+              , "  \\leadsto Q . |x| ( |y| -> \"foo\" ) \\leadsto_{\\nameref{r:second}}"
+              , "% === Step #3, Rule 'second', 30t -> 31t"
+              , "  \\leadsto [[ |x| -> \"foo\" ]]{.}"
+              , "\\end{phiquation}"
+              ]
+          ]
+
     it "prints only one latex preamble with --sequence" $
       withStdin "[[ x -> \"foo\" ]]" $
         testCLISucceeded


### PR DESCRIPTION
Closes #999.

## Problem

When `phino rewrite --normalize --sequence` (or `dataize --sequence`) prints the chain, the intermediate expressions arrive back-to-back, joined by a single newline in `printRewrittens`. Nothing in the output says which step is which, which rule produced it, or how much the expression grew.

## Change

A new `--headers` switch (added next to `--sequence` in both `rewrite` and `dataize`) prefixes every step with an empty line and a header line:

```

=== Step #4, Rule 'STOP', 32t -> 43t
```

- The header names the rule that **produced** the step and the AST node count **before → after** that rule. The `Nt -> Mt` pair matches the existing rewriter debug log (`Applied '<rule>' (N nodes -> M nodes)`).
- The first step is the input — which no rule produced — so it carries only its number: `=== Step #1`.
- In LaTeX output (`--output=latex --sequence`) the same header is emitted as a `%`-prefixed comment, so it stays out of the rendered equation.
- Like the other intermediate-output flags, `--headers` is meaningful only together with `--sequence`; on its own it is a no-op.

Everything the header needs was already at hand: `type Rewritten = (Expression, Maybe String)` carries the name of the rule applied to each expression (tagged in `leadsTo`), and `countNodes` computes the size. So no new plumbing runs through the rewriter — the new `Rewriter.stepHeaders` derives the header lines from the existing chain, and only the rendering layer changed.

## Example

```
$ echo '[[ x -> [[ y -> ? ]](y -> 5) ]]' | phino rewrite --normalize --sequence --headers --sweet --flat

=== Step #1
⟦ x ↦ ⟦ y ↦ ∅ ⟧( y ↦ 5 ) ⟧

=== Step #2, Rule 'copy', 44t -> 39t
⟦ x ↦ ⟦ y ↦ 5 ⟧ ⟧
```

## Tests

Added three `CLISpec` cases: PHI headers output, the LaTeX `%`-comment variant, and the no-op-without-`--sequence` behavior.

Verified locally with GHC 9.8.4:
- `cabal test --ghc-options=-Werror` → 1098 examples, 0 failures
- `fourmolu --mode check src app test` → clean
- `hlint src app test` → No hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FZW4BLjdpQ5cZcduVLMBK9)_