### PR TITLE
Add `--hide-rho` flag to strip ρ bindings from printed expressions

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -77,16 +77,21 @@ printRewrittens ctx@PrintCtx{..} rewrittens@(chain, _)
 
 printExpression :: PrintContext -> Expression -> IO String
 printExpression ctx@PrintCtx{..} ex = case _outputFormat of
-  PHI -> pure (P.printExpression' ex (_sugar, UNICODE, _line, _margin))
+  PHI -> pure (printPhi ctx ex)
   XMIR -> throwIO CouldNotPrintExpressionInXMIR
   LATEX -> pure (expressionToLaTeX ex (printCtxToLatexCtx ctx))
 
 -- Convert an expression to its corresponding String format
 printInFormat :: PrintContext -> Expression -> IO String
 printInFormat ctx@PrintCtx{..} expr = case _outputFormat of
-  PHI -> pure (P.printExpression' expr (_sugar, UNICODE, _line, _margin))
+  PHI -> pure (printPhi ctx expr)
   XMIR -> expressionToXMIR expr _xmirCtx <&> printXMIR
   LATEX -> pure (expressionToLaTeX expr (printCtxToLatexCtx ctx))
+
+-- Render an expression as PHI, dropping every ρ binding when '--hide-rho' is set.
+printPhi :: PrintContext -> Expression -> String
+printPhi PrintCtx{..} expr =
+  (if _hideRho then P.printExpressionHidingRho' else P.printExpression') expr (_sugar, UNICODE, _line, _margin)
 
 printCtxToLatexCtx :: PrintContext -> LatexContext
 printCtxToLatexCtx PrintCtx{..} =

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -206,6 +206,9 @@ optSeed =
 optSugar :: Parser SugarType
 optSugar = flag SALTY SWEET (long "sweet" <> help (printf "Print result and intermediate (see %s option(s)) 𝜑-expressions using syntax sugar" _intermediateOptions))
 
+optHideRho :: Parser Bool
+optHideRho = switch (long "hide-rho" <> help "Remove every ρ binding from result and intermediate 𝜑-expressions for cleaner output")
+
 optSugar' :: Parser SugarType
 optSugar' = flag SALTY SWEET (long "sweet" <> help "Print result 𝜑-expression using syntax sugar")
 
@@ -262,6 +265,7 @@ dataizeParser =
             <*> optInputFormat
             <*> optOutputFormat
             <*> optSugar
+            <*> optHideRho
             <*> optLineFormat
             <*> optOmitListing
             <*> optOmitComments
@@ -298,6 +302,7 @@ rewriteParser =
             <*> optInputFormat
             <*> optOutputFormat
             <*> optSugar
+            <*> optHideRho
             <*> optLineFormat
             <*> optMust
             <*> optNormalize

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -119,6 +119,7 @@ runRewrite OptsRewrite{..} = do
     toPrintCtx xmirCtx focus =
       PrintCtx
         _sugarType
+        _hideRho
         _flat
         _margin
         xmirCtx
@@ -167,6 +168,7 @@ runDataize OptsDataize{..} = do
     toPrintCtx focus =
       PrintCtx
         _sugarType
+        _hideRho
         _flat
         _margin
         defaultXmirContext
@@ -219,6 +221,7 @@ runMerge OptsMerge{..} = do
     toPrintCtx xmirCtx =
       PrintCtx
         _sugarType
+        False
         _flat
         _margin
         xmirCtx

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -17,6 +17,7 @@ import XMIR (XmirContext)
 
 data PrintContext = PrintCtx
   { _sugar :: SugarType
+  , _hideRho :: Bool
   , _line :: LineFormat
   , _margin :: Int
   , _xmirCtx :: XmirContext
@@ -77,6 +78,7 @@ data OptsDataize = OptsDataize
   , _inputFormat :: IOFormat
   , _outputFormat :: IOFormat
   , _sugarType :: SugarType
+  , _hideRho :: Bool
   , _flat :: LineFormat
   , _omitListing :: Bool
   , _omitComments :: Bool
@@ -122,6 +124,7 @@ data OptsRewrite = OptsRewrite
   , _inputFormat :: IOFormat
   , _outputFormat :: IOFormat
   , _sugarType :: SugarType
+  , _hideRho :: Bool
   , _flat :: LineFormat
   , _must :: Must
   , _normalize :: Bool

--- a/src/Printer.hs
+++ b/src/Printer.hs
@@ -7,6 +7,7 @@
 module Printer
   ( printExpression
   , printExpression'
+  , printExpressionHidingRho'
   , printAttribute
   , printAlpha
   , printBinding
@@ -42,7 +43,18 @@ logPrintConfig :: (SugarType, Encoding, LineFormat, Int)
 logPrintConfig = (SWEET, UNICODE, SINGLELINE, defaultMargin)
 
 printExpression' :: Expression -> PrintConfig -> String
-printExpression' ex (sugar, encoding, line, margin) = T.unpack $ render (withLineFormat line $ withMargin margin $ withEncoding encoding $ withSugarType sugar $ expressionToCST ex)
+printExpression' = printExpressionWith id
+
+-- Like 'printExpression'', but drops every ρ binding from the rendered
+-- expression (the '--hide-rho' switch). See 'withoutRho'.
+printExpressionHidingRho' :: Expression -> PrintConfig -> String
+printExpressionHidingRho' = printExpressionWith withoutRho
+
+-- Shared rendering pipeline with a hook applied to the sugared CST, right
+-- before encoding and margin wrapping.
+printExpressionWith :: (EXPRESSION -> EXPRESSION) -> Expression -> PrintConfig -> String
+printExpressionWith hide ex (sugar, encoding, line, margin) =
+  T.unpack $ render (withLineFormat line $ withMargin margin $ withEncoding encoding $ hide $ withSugarType sugar $ expressionToCST ex)
 
 printExpression :: Expression -> String
 printExpression ex = printExpression' ex defaultPrintConfig

--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -7,7 +7,7 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Sugar (toSalty, withSugarType, SugarType (..), ToSalty) where
+module Sugar (toSalty, withSugarType, withoutRho, SugarType (..), ToSalty) where
 
 import AST
 import Bytes (numToBts, strToBts)
@@ -39,6 +39,75 @@ bdWithVoidRho bd@BI_META{} = bd
 
 data SugarType = SWEET | SALTY
   deriving (Eq, Show)
+
+-- Drop every ρ binding (ρ ↦ ∅, ρ ↦ e and ρ(…) ↦ e) from a rendered CST, the
+-- effect of the '--hide-rho' switch. It runs after 'withSugarType', so it also
+-- removes the ρ ↦ ∅ that 'bdWithVoidRho' re-inserts into every formation on the
+-- SALTY path. Only formation bindings are stripped: dispatches such as ξ.ρ and
+-- application arguments are left untouched, and a formation left empty by the
+-- strip collapses to the compact '⟦⟧' layout.
+withoutRho :: EXPRESSION -> EXPRESSION
+withoutRho = goExpr
+  where
+    goExpr :: EXPRESSION -> EXPRESSION
+    goExpr EX_FORMATION{..} = case goBinding binding of
+      empty@BI_EMPTY{} -> EX_FORMATION lsb NO_EOL NO_TAB empty NO_EOL NO_TAB rsb
+      binding' -> EX_FORMATION lsb eol tab binding' eol' tab' rsb
+    goExpr EX_DISPATCH{..} = EX_DISPATCH (goExpr expr) space attr
+    goExpr EX_APPLICATION{..} = EX_APPLICATION (goExpr expr) space eol tab (goArgument argument) eol' tab' indent
+    goExpr EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (goExpr expr)
+    goExpr EX_PHI_AGAIN{..} = EX_PHI_AGAIN prefix idx (goExpr expr)
+    goExpr expr = expr
+    -- Formation bindings: drop the ρ pairs, recurse into whatever remains.
+    goBinding :: BINDING -> BINDING
+    goBinding empty@BI_EMPTY{} = empty
+    goBinding BI_META{..} = BI_META meta (goBindings bindings) tab
+    goBinding BI_PAIR{..}
+      | isRho pair = promote tab (goBindings bindings)
+      | otherwise = BI_PAIR (goPair pair) (goBindings bindings) tab
+    goBindings :: BINDINGS -> BINDINGS
+    goBindings empty@BDS_EMPTY{} = empty
+    goBindings BDS_META{..} = BDS_META eol tab meta (goBindings bindings)
+    goBindings BDS_PAIR{..}
+      | isRho pair = goBindings bindings
+      | otherwise = BDS_PAIR eol tab (goPair pair) (goBindings bindings)
+    -- Turn the tail chain back into a head binding once its leading pair was
+    -- dropped; the promoted pair is already stripped and recursed by 'goBindings'.
+    promote :: TAB -> BINDINGS -> BINDING
+    promote tab (BDS_EMPTY _) = BI_EMPTY tab
+    promote tab (BDS_PAIR _ _ pair bindings) = BI_PAIR pair bindings tab
+    promote tab (BDS_META _ _ meta bindings) = BI_META meta bindings tab
+    -- Application arguments keep their ρ (bdWithVoidRho never adds one there);
+    -- only recurse into the expressions they carry.
+    goArgument :: APP_ARGUMENT -> APP_ARGUMENT
+    goArgument (AA_TAU binding) = AA_TAU (goAppBinding binding)
+    goArgument (AA_TAUS binding) = AA_TAUS (goArgBinding binding)
+    goArgument (AA_EXPRS args) = AA_EXPRS (goAppArg args)
+    goAppBinding :: APP_BINDING -> APP_BINDING
+    goAppBinding APP_BINDING{..} = APP_BINDING (goPair pair)
+    goArgBinding :: BINDING -> BINDING
+    goArgBinding empty@BI_EMPTY{} = empty
+    goArgBinding BI_META{..} = BI_META meta (goArgBindings bindings) tab
+    goArgBinding BI_PAIR{..} = BI_PAIR (goPair pair) (goArgBindings bindings) tab
+    goArgBindings :: BINDINGS -> BINDINGS
+    goArgBindings empty@BDS_EMPTY{} = empty
+    goArgBindings BDS_META{..} = BDS_META eol tab meta (goArgBindings bindings)
+    goArgBindings BDS_PAIR{..} = BDS_PAIR eol tab (goPair pair) (goArgBindings bindings)
+    goAppArg :: APP_ARG -> APP_ARG
+    goAppArg APP_ARG{..} = APP_ARG (goExpr expr) (goAppArgs args)
+    goAppArgs :: APP_ARGS -> APP_ARGS
+    goAppArgs AAS_EMPTY = AAS_EMPTY
+    goAppArgs AAS_EXPR{..} = AAS_EXPR eol tab (goExpr expr) (goAppArgs args)
+    goPair :: PAIR -> PAIR
+    goPair PA_TAU{..} = PA_TAU attr arrow (goExpr expr)
+    goPair PA_ALPHA{..} = PA_ALPHA alpha arrow (goExpr expr)
+    goPair PA_FORMATION{..} = PA_FORMATION attr voids arrow (goExpr expr)
+    goPair pair = pair
+    isRho :: PAIR -> Bool
+    isRho PA_VOID{attr = AT_RHO _} = True
+    isRho PA_TAU{attr = AT_RHO _} = True
+    isRho PA_FORMATION{attr = AT_RHO _} = True
+    isRho _ = False
 
 -- By default CST is generated with all possible syntax sugar
 -- The main purpose of this class is to get rid of syntax sugar

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -137,6 +137,25 @@ spec = do
           ["--pin=", "rewrite"]
           ["Version mismatch: --pin requires ''"]
 
+  describe "--hide-rho" $ do
+    it "drops every rho binding from the default salty output" $
+      withStdin "[[ foo -> [[ x -> [[ ]], ^ -> $.y ]], y -> [[ ]] ]]" $
+        testCLISucceeded
+          ["rewrite", "--flat", "--hide-rho"]
+          ["⟦ foo ↦ ⟦ x ↦ ⟦⟧ ⟧, y ↦ ⟦⟧ ⟧"]
+
+    it "also drops the rho that --sweet leaves behind" $
+      withStdin "[[ foo -> [[ x -> [[ ]], ^ -> $.y ]], y -> [[ ]] ]]" $
+        testCLISucceeded
+          ["rewrite", "--flat", "--sweet", "--hide-rho"]
+          ["⟦ foo ↦ ⟦ x ↦ ⟦⟧ ⟧, y ↦ ⟦⟧ ⟧"]
+
+    it "keeps sweet numeric literals intact" $
+      withStdin "[[ a -> 42 ]]" $
+        testCLISucceeded
+          ["rewrite", "--flat", "--sweet", "--hide-rho"]
+          ["⟦ a ↦ 42 ⟧"]
+
   it "prints debug info with --log-level=DEBUG" $
     withStdin "[[]]" $
       testCLISucceeded ["rewrite", "--log-level=DEBUG"] ["[DEBUG]:"]

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -122,6 +122,46 @@ spec = do
           it desc (printExpression' expr (SALTY, UNICODE, SINGLELINE, defaultMargin) `shouldBe` expected)
       )
 
+  describe "printExpressionHidingRho strips every rho binding for --hide-rho" $ do
+    let issueExpr =
+          ExFormation
+            [ BiTau
+                (AtLabel "foo")
+                ( ExFormation
+                    [ BiTau (AtLabel "x") (ExFormation [BiVoid AtRho])
+                    , BiTau AtRho (ExDispatch ExXi (AtLabel "y"))
+                    ]
+                )
+            , BiTau (AtLabel "y") (ExFormation [BiVoid AtRho])
+            , BiVoid AtRho
+            ]
+    forM_
+      [ ("salty clears both void and dispatch-valued rho", SALTY, issueExpr, "⟦ foo ↦ ⟦ x ↦ ⟦⟧ ⟧, y ↦ ⟦⟧ ⟧")
+      , ("sweet also drops the rho that --sweet keeps", SWEET, issueExpr, "⟦ foo ↦ ⟦ x ↦ ⟦⟧ ⟧, y ↦ ⟦⟧ ⟧")
+      ,
+        ( "a rho bound to an expression is removed"
+        , SWEET
+        , ExFormation [BiTau (AtLabel "a") ExRoot, BiTau AtRho (ExDispatch ExXi (AtLabel "y"))]
+        , "⟦ a ↦ Φ ⟧"
+        )
+      , ("a formation holding only rho collapses to empty", SALTY, ExFormation [BiVoid AtRho], "⟦⟧")
+      ,
+        ( "a ξ.ρ dispatch value is left untouched"
+        , SALTY
+        , ExFormation [BiTau (AtLabel "a") (ExDispatch ExXi AtRho)]
+        , "⟦ a ↦ ξ.ρ ⟧"
+        )
+      ]
+      ( \(desc, sugar, expr, expected) ->
+          it desc (printExpressionHidingRho' expr (sugar, UNICODE, SINGLELINE, defaultMargin) `shouldBe` expected)
+      )
+
+  describe "printExpressionHidingRho keeps primitives that carry no visible rho" $
+    it "renders a sweet numeric literal exactly as printExpression' does" $ do
+      let number = DataNumber (BtMany ["40", "45", "00", "00", "00", "00", "00", "00"])
+          config = (SWEET, UNICODE, SINGLELINE, defaultMargin)
+      printExpressionHidingRho' number config `shouldBe` printExpression' number config
+
   describe "printAttribute with default encoding" $
     forM_
       [ ("label", AtLabel "attr", "attr")


### PR DESCRIPTION
Closes #1001.

## What

Adds a `--hide-rho` switch to `phino rewrite` and `phino dataize` that removes **every** ρ binding from printed 𝜑-expressions, so a long `--sequence` chain stays readable.

For the issue's input:

```
[[ foo -> [[ x -> [[ ]], ^ -> $.y ]], y -> [[ ]] ]]
```

`phino rewrite` (default, SALTY) previously printed:

```
⟦ foo ↦ ⟦ x ↦ ⟦ ρ ↦ ∅ ⟧, ρ ↦ ξ.y ⟧, y ↦ ⟦ ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧
```

With `--hide-rho`:

```
⟦ foo ↦ ⟦ x ↦ ⟦⟧ ⟧, y ↦ ⟦⟧ ⟧
```

`--sweet` alone only drops the trailing void ρ (`ρ ↦ ξ.y` survived); `--hide-rho` removes all of them and works for both the sweet and salty forms.

## How

The strip is **print-only** and lives on the printing path, so ρ stays in the AST while rewriting and matching (the `withVoidRho` invariant is untouched):

- `withoutRho` (`src/Sugar.hs`) is a CST→CST pass that drops every ρ formation binding (`ρ ↦ ∅`, `ρ ↦ e`, `ρ(…) ↦ e`).
- `Printer.printExpressionHidingRho'` runs it **after** `withSugarType`, so it also removes the `ρ ↦ ∅` that `bdWithVoidRho` re-inserts into every formation on the SALTY path — otherwise the strip would be silently undone.
- `--hide-rho` is parsed next to `--sweet` (`optHideRho`), threaded through `PrintContext._hideRho`, and used by the PHI branches of `printExpression`/`printInFormat`, so it also applies to `--sequence` and `--steps-dir` output.

Running the pass on the sugared CST (rather than the AST) keeps things safe: sweet numeric/string literals have already collapsed to `EX_NUMBER`/`EX_STRING` and are left intact, dispatches like `ξ.ρ` and application arguments are preserved, and a formation emptied by the strip renders as the compact `⟦⟧`.

## Testing

- `test/PrinterSpec.hs`: unit tests for `printExpressionHidingRho'` covering salty/sweet stripping, `ρ ↦ e`, empty-formation collapse, `ξ.ρ` preservation, and literal preservation.
- `test/CLISpec.hs`: end-to-end `--hide-rho` cases for `rewrite`.
- Full suite green (1104 examples, 0 failures) under `-Werror`; `fourmolu 0.17.0.0` and `hlint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144hxUUqVbPJsDvWwKxx1tK

---
_Generated by [Claude Code](https://claude.ai/code/session_0144hxUUqVbPJsDvWwKxx1tK)_