### PR TITLE
fix(sugar): strip ρ application arguments under --hide-rho (#1007)

### DIFF
--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -43,9 +43,10 @@ data SugarType = SWEET | SALTY
 -- Drop every ρ binding (ρ ↦ ∅, ρ ↦ e and ρ(…) ↦ e) from a rendered CST, the
 -- effect of the '--hide-rho' switch. It runs after 'withSugarType', so it also
 -- removes the ρ ↦ ∅ that 'bdWithVoidRho' re-inserts into every formation on the
--- SALTY path. Only formation bindings are stripped: dispatches such as ξ.ρ and
--- application arguments are left untouched, and a formation left empty by the
--- strip collapses to the compact '⟦⟧' layout.
+-- SALTY path. Both formation bindings and application arguments are stripped;
+-- dispatches such as ξ.ρ are left untouched. A formation left empty by the
+-- strip collapses to the compact '⟦⟧' layout, and an application left with no
+-- argument collapses to its bare callee (no leftover 'e()').
 withoutRho :: EXPRESSION -> EXPRESSION
 withoutRho = goExpr
   where
@@ -54,7 +55,9 @@ withoutRho = goExpr
       empty@BI_EMPTY{} -> EX_FORMATION lsb NO_EOL NO_TAB empty NO_EOL NO_TAB rsb
       binding' -> EX_FORMATION lsb eol tab binding' eol' tab' rsb
     goExpr EX_DISPATCH{..} = EX_DISPATCH (goExpr expr) space attr
-    goExpr EX_APPLICATION{..} = EX_APPLICATION (goExpr expr) space eol tab (goArgument argument) eol' tab' indent
+    goExpr EX_APPLICATION{..} = case goArgument argument of
+      Nothing -> goExpr expr
+      Just argument' -> EX_APPLICATION (goExpr expr) space eol tab argument' eol' tab' indent
     goExpr EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (goExpr expr)
     goExpr EX_PHI_AGAIN{..} = EX_PHI_AGAIN prefix idx (goExpr expr)
     goExpr expr = expr
@@ -77,22 +80,30 @@ withoutRho = goExpr
     promote tab (BDS_EMPTY _) = BI_EMPTY tab
     promote tab (BDS_PAIR _ _ pair bindings) = BI_PAIR pair bindings tab
     promote tab (BDS_META _ _ meta bindings) = BI_META meta bindings tab
-    -- Application arguments keep their ρ (bdWithVoidRho never adds one there);
-    -- only recurse into the expressions they carry.
-    goArgument :: APP_ARGUMENT -> APP_ARGUMENT
-    goArgument (AA_TAU binding) = AA_TAU (goAppBinding binding)
-    goArgument (AA_TAUS binding) = AA_TAUS (goArgBinding binding)
-    goArgument (AA_EXPRS args) = AA_EXPRS (goAppArg args)
-    goAppBinding :: APP_BINDING -> APP_BINDING
-    goAppBinding APP_BINDING{..} = APP_BINDING (goPair pair)
+    -- Application arguments: drop the ρ pairs too, the way 'goBinding' does for
+    -- formations. 'Nothing' means nothing survived the strip, so 'goExpr'
+    -- collapses the whole application to its bare callee instead of leaving an
+    -- empty 'e()'. Positional arguments ('AA_EXPRS') carry no ρ, so they stay.
+    goArgument :: APP_ARGUMENT -> Maybe APP_ARGUMENT
+    goArgument (AA_TAU (APP_BINDING pair))
+      | isRho pair = Nothing
+      | otherwise = Just (AA_TAU (APP_BINDING (goPair pair)))
+    goArgument (AA_TAUS binding) = case goArgBinding binding of
+      BI_EMPTY{} -> Nothing
+      binding' -> Just (AA_TAUS binding')
+    goArgument (AA_EXPRS args) = Just (AA_EXPRS (goAppArg args))
     goArgBinding :: BINDING -> BINDING
     goArgBinding empty@BI_EMPTY{} = empty
     goArgBinding BI_META{..} = BI_META meta (goArgBindings bindings) tab
-    goArgBinding BI_PAIR{..} = BI_PAIR (goPair pair) (goArgBindings bindings) tab
+    goArgBinding BI_PAIR{..}
+      | isRho pair = promote tab (goArgBindings bindings)
+      | otherwise = BI_PAIR (goPair pair) (goArgBindings bindings) tab
     goArgBindings :: BINDINGS -> BINDINGS
     goArgBindings empty@BDS_EMPTY{} = empty
     goArgBindings BDS_META{..} = BDS_META eol tab meta (goArgBindings bindings)
-    goArgBindings BDS_PAIR{..} = BDS_PAIR eol tab (goPair pair) (goArgBindings bindings)
+    goArgBindings BDS_PAIR{..}
+      | isRho pair = goArgBindings bindings
+      | otherwise = BDS_PAIR eol tab (goPair pair) (goArgBindings bindings)
     goAppArg :: APP_ARG -> APP_ARG
     goAppArg APP_ARG{..} = APP_ARG (goExpr expr) (goAppArgs args)
     goAppArgs :: APP_ARGS -> APP_ARGS

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -151,6 +151,24 @@ spec = do
         , ExFormation [BiTau (AtLabel "a") (ExDispatch ExXi AtRho)]
         , "⟦ a ↦ ξ.ρ ⟧"
         )
+      ,
+        ( "an application whose only argument is rho collapses to its callee"
+        , SWEET
+        , ExApplication (ExDispatch ExRoot (AtLabel "x")) (ArTau AtRho (ExFormation [BiVoid AtRho]))
+        , "Φ.x"
+        )
+      ,
+        ( "the same collapse happens on the salty path, without leftover parens"
+        , SALTY
+        , ExApplication (ExDispatch ExRoot (AtLabel "x")) (ArTau AtRho (ExFormation [BiVoid AtRho]))
+        , "Φ.x"
+        )
+      ,
+        ( "an application keeps its other arguments and drops only rho"
+        , SWEET
+        , ExApplication (ExApplication (ExDispatch ExRoot (AtLabel "e")) (ArTau (AtLabel "a") ExRoot)) (ArTau AtRho ExXi)
+        , "Φ.e( a ↦ Φ )"
+        )
       ]
       ( \(desc, sugar, expr, expected) ->
           it desc (printExpressionHidingRho' expr (sugar, UNICODE, SINGLELINE, defaultMargin) `shouldBe` expected)


### PR DESCRIPTION
Fixes #1007.

## Problem

The `--hide-rho` switch (added in #1001) stripped ρ from **formation bindings only**. `goArgument` inside `withoutRho` deliberately left application arguments alone, so an application such as `e(ρ ↦ ⟦ … ⟧)` — exactly what the DOT rule emits on every step (`resources/normalize/dot.yaml:15`) — still printed its `(ρ ↦ …)` argument with the flag on. The noise the flag exists to remove was still there.

## Fix

`src/Sugar.hs` — `goArgument`, `goArgBinding` and `goArgBindings` now skip ρ pairs through the existing `isRho` predicate, the same way `goBinding`/`goBindings` already do for formations:

- `goArgument` returns `Maybe APP_ARGUMENT`. When the strip leaves nothing (`AA_TAU` whose sole pair was ρ, or `AA_TAUS` reduced to `BI_EMPTY`), it returns `Nothing`.
- The `EX_APPLICATION` case of `goExpr` returns `goExpr expr` (the bare callee) when the argument is `Nothing`, so an application whose only argument was ρ collapses to plain `e` with **no leftover `e()`**.
- An application carrying other arguments keeps them and loses only ρ: `e(α0 ↦ x, ρ ↦ y)` now prints as `e(α0 ↦ x)`.
- Positional arguments (`AA_EXPRS`) are untouched, since ρ cannot appear there.

The module-level doc comment on `withoutRho` is updated to reflect that application arguments are now stripped too.

## Tests

Added three cases to the `printExpressionHidingRho strips every rho binding for --hide-rho` group in `test/PrinterSpec.hs`:

- an application whose only argument is ρ collapses to its callee (SWEET)
- the same collapse on the SALTY path, with no leftover parens
- an application keeps its other arguments and drops only ρ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkXA4SQyLzU9HwfpmJxRUB)_