### PR TITLE
fix(rule): treat ⊥ as xi-free so copy accepts a ⊥ argument (#1009)

### DIFF
--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -176,11 +176,13 @@ _nf (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
 _nf expr subst ctx = pure [subst | isNF expr ctx]
 
 -- An expression is xi-free when it contains no ξ outside of a formation: it is
--- Φ, a formation, a dispatch with a xi-free subject, or an application with a
--- xi-free subject and argument. Together with a normal-form check this is what
--- makes an expression absolute (𝒦 ⊆ 𝒩); the '𝑘' meta-variable applies this
--- xi-free check first (cheap, structural, rules out the ξ-recursion the
--- normal-form check could loop on) and the normal-form check second.
+-- Φ, ⊥, a formation, a dispatch with a xi-free subject, or an application with
+-- a xi-free subject and argument. ⊥ holds no ξ to capture, so it is xi-free
+-- (and 'isNF ⊥ = True' already), which lets the copy rule accept a ⊥ argument.
+-- Together with a normal-form check this is what makes an expression absolute
+-- (𝒦 ⊆ 𝒩); the '𝑘' meta-variable applies this xi-free check first (cheap,
+-- structural, rules out the ξ-recursion the normal-form check could loop on)
+-- and the normal-form check second.
 _absolute :: Expression -> Subst -> RuleContext -> IO [Subst]
 _absolute (ExMeta meta) (Subst mp) ctx = case M.lookup meta mp of
   Just (MvExpression expr) -> _absolute expr (Subst mp) ctx
@@ -190,6 +192,7 @@ _absolute expr subst _ = pure [subst | xiFree expr]
     xiFree :: Expression -> Bool
     xiFree (ExFormation _) = True
     xiFree ExRoot = True
+    xiFree ExTermination = True
     xiFree (ExApplication e (ArTau _ te)) = xiFree e && xiFree te
     xiFree (ExApplication e (ArAlpha _ te)) = xiFree e && xiFree te
     xiFree (ExDispatch e _) = xiFree e

--- a/test-resources/condition-packs/absolute-termination.yaml
+++ b/test-resources/condition-packs/absolute-termination.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+expression: '[[ x -> T ]]'
+pattern: '[[ x -> !e ]]'
+condition:
+  absolute: '!e'

--- a/test-resources/rewriter-packs/normalize/e-cpy-bot.yaml
+++ b/test-resources/rewriter-packs/normalize/e-cpy-bot.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+normalize: true
+input: |
+  ⟦ r ↦ ∅ ⟧( r ↦ ⟦ x ↦ ∅ ⟧( x ↦ ⊥ ) )
+output: |-
+  ⟦ r ↦ ⟦ x ↦ ⊥, ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧


### PR DESCRIPTION
Fixes #1009.

## Problem

The `copy` rule (`resources/normalize/copy.yaml`) binds the applied argument to the absolute meta-variable `𝑘`. The `_absolute` check in `src/Rule.hs` gates `𝑘` on its local `xiFree` helper, whose catch-all returned `False` for `ExTermination`. As a result a void slot receiving `⊥` matched **no** normalization rule and became a stuck normal form:

```
echo '⟦ r ↦ ∅ ⟧( r ↦ ⟦ x ↦ ∅ ⟧( x ↦ ⊥ ) )' | phino rewrite --normalize
```

printed the input back (with `ρ ↦ ∅` added) instead of reducing. Because `⊥` also counted as non-absolute, morphing then took the `mad` branch (`resources/morphing.yaml`) and collapsed the whole object to `⊥`, so dataization discarded the object instead of filling its slot.

## Fix

`⊥` holds no `ξ` to capture, which is the only thing absoluteness guards against, and `isNF ExTermination = True` already treats `⊥` as a normal form. Added `xiFree ExTermination = True` beside `xiFree ExRoot = True` so `⊥` is recognized as absolute. With that line the example above reduces to `⟦ r ↦ ⟦ x ↦ ⊥, ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧`, as expected.

## Changes

- `src/Rule.hs` — `xiFree ExTermination = True` in `_absolute` (plus updated comment).
- `test-resources/rewriter-packs/normalize/e-cpy-bot.yaml` — normalization pack for the issue's example.
- `test-resources/condition-packs/absolute-termination.yaml` — condition pack asserting `⊥` is absolute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWiX1SCxXwhEJPxFFmEVwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWiX1SCxXwhEJPxFFmEVwB)_