### PR TITLE
Report PR benchmark deltas instead of gating on them

### DIFF
--- a/.github/scripts/bench-compare.sh
+++ b/.github/scripts/bench-compare.sh
@@ -5,17 +5,21 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Compare two benchmark runs and gate on regressions.
+Compare two benchmark runs and report the deltas.
 
 Usage: bench-compare.sh BASE.txt HEAD.txt THRESHOLD
 
-BASE/HEAD: stdout captures of `cabal bench` (the bench prints `=== name ===`
-blocks with an `avg: X.YYY us` line per case).
+BASE/HEAD: stdout captures of the bench binary (it prints `=== name ===`
+blocks with an `avg: X.YYY us` line per case). Either file may hold several
+rounds appended one after another; every round counts as one sample, and the
+median of the samples is what gets reported.
 
-THRESHOLD: max allowed positive delta as a fraction, e.g. 0.20 for +20%.
+THRESHOLD: how far a case has to move to be called out, as a fraction, e.g.
+0.20 for 20%. A case is called out only when it also moves further than the
+noise measured across its own rounds.
 
-Prints a markdown comparison table to stdout, exits 1 if any case present in
-both runs regressed by more than THRESHOLD.
+Prints a markdown comparison table to stdout. A delta never fails the run:
+shared CI runners are too noisy to gate on, so the report is informational.
 EOF
 }
 
@@ -28,7 +32,7 @@ base=$1
 head=$2
 threshold=$3
 
-# Extract "<name> <avg-us>" lines from a bench output file.
+# Extract one "<name> <avg-us>" line per case per round from a bench output file.
 extract() {
   awk '
     /^=== .* ===$/ { name = $2; next }
@@ -36,53 +40,75 @@ extract() {
   ' "$1"
 }
 
-# Build the table body as "<name>\t<row>" lines, one row per case, plus a final
-# trailing "REGRESSIONS=N" line for the gate decision.
+# Build the table body as "<name>\t<row>" lines, one row per case, plus trailing
+# "CALLED=N" and "ROUNDS=N" lines for the summary.
 body=$(
   {
     extract "$base" | awk '{ print "base", $1, $2 }'
     extract "$head" | awk '{ print "head", $1, $2 }'
   } | awk -v threshold="$threshold" '
-    { vals[$1, $2] = $3; names[$2] = 1 }
-    END {
-      regressions = 0
-      for (k in names) {
-        b = (("base", k) in vals) ? vals["base", k] : ""
-        h = (("head", k) in vals) ? vals["head", k] : ""
-        if (b == "") {
-          printf "%s\t| `%s` | - | %.2f | new |\n", k, k, h
-        } else if (h == "") {
-          printf "%s\t| `%s` | %.2f | - | removed |\n", k, k, b
-        } else {
-          d = (h - b) / b
-          pct = d * 100
-          note = ""
-          if (d > threshold) {
-            note = " **REGRESSION**"
-            regressions++
-          } else if (d < -0.05) {
-            note = " (improved)"
-          }
-          printf "%s\t| `%s` | %.2f | %.2f | %+.1f%%%s |\n", k, k, b, h, pct, note
-        }
+    function sorted(side, name, out,   total, idx, pos, held) {
+      total = count[side, name]
+      for (idx = 1; idx <= total; idx++) { out[idx] = sample[side, name, idx] + 0 }
+      for (idx = 2; idx <= total; idx++) {
+        held = out[idx]
+        for (pos = idx - 1; pos >= 1 && out[pos] > held; pos--) { out[pos + 1] = out[pos] }
+        out[pos + 1] = held
       }
-      print "REGRESSIONS=" regressions
+      return total
+    }
+    function median(values, total) { return values[int((total + 1) / 2)] }
+    function spread(values, total) { return total > 1 ? (values[total] - values[1]) / median(values, total) : 0 }
+    function noiseText(value, total) { return total > 1 ? sprintf("±%.1f%%", value * 100) : "n/a" }
+    { count[$1, $2]++; sample[$1, $2, count[$1, $2]] = $3; names[$2] = 1 }
+    END {
+      called = 0
+      rounds = 0
+      for (name in names) {
+        bases = sorted("base", name, low)
+        heads = sorted("head", name, high)
+        if (bases > rounds) { rounds = bases }
+        if (heads > rounds) { rounds = heads }
+        if (bases == 0) {
+          printf "%s\t| `%s` | - | %.2f | new | %s |\n", name, name, median(high, heads), noiseText(spread(high, heads), heads)
+          continue
+        }
+        if (heads == 0) {
+          printf "%s\t| `%s` | %.2f | - | removed | %s |\n", name, name, median(low, bases), noiseText(spread(low, bases), bases)
+          continue
+        }
+        delta = (median(high, heads) - median(low, bases)) / median(low, bases)
+        noise = spread(low, bases) > spread(high, heads) ? spread(low, bases) : spread(high, heads)
+        samples = bases > heads ? bases : heads
+        note = ""
+        if (delta > threshold && delta > noise) {
+          note = " **slower**"
+          called++
+        } else if (-delta > threshold && -delta > noise) {
+          note = " **faster**"
+        }
+        printf "%s\t| `%s` | %.2f | %.2f | %+.1f%%%s | %s |\n", name, name, median(low, bases), median(high, heads), delta * 100, note, noiseText(noise, samples)
+      }
+      print "CALLED=" called
+      print "ROUNDS=" rounds
     }
   '
 )
 
-regressions=$(awk -F= '/^REGRESSIONS=/ { print $2 }' <<<"$body")
-rows=$(awk '!/^REGRESSIONS=/' <<<"$body" | sort | cut -f2-)
+called=$(awk -F= '/^CALLED=/ { print $2 }' <<<"$body")
+rounds=$(awk -F= '/^ROUNDS=/ { print $2 }' <<<"$body")
+rows=$(awk '!/^(CALLED|ROUNDS)=/' <<<"$body" | sort | cut -f2-)
 pct=$(awk -v t="$threshold" 'BEGIN { printf "%d", t * 100 }')
 
 printf '## Benchmark comparison\n\n'
-printf 'Regression threshold: +%s%%. Same-runner A/B against the PR merge-base; the bench fixture is frozen across both runs.\n\n' "$pct"
-printf '| Bench | base (us) | head (us) | delta |\n'
-printf '|---|---:|---:|---:|\n'
+printf 'Median of %s round(s) per side, interleaved on the same runner against the PR merge-base, with the bench fixture frozen across both builds. Noise is the spread between the fastest and the slowest round, taken from the noisier side.\n\n' "$rounds"
+printf '| Bench | base (μs) | head (μs) | delta | noise |\n'
+printf '|---|---:|---:|---:|---:|\n'
 printf '%s\n\n' "$rows"
 
-if [ "$regressions" -gt 0 ]; then
-  printf '**Failing**: %s case(s) regressed above the +%s%% threshold.\n' "$regressions" "$pct"
-  exit 1
+if [ "$called" -gt 0 ]; then
+  printf 'Worth a look: %s case(s) moved by more than %s%% and by more than their own noise.\n' "$called" "$pct"
+else
+  printf 'No case moved by more than %s%% beyond its own noise.\n' "$pct"
 fi
-printf 'OK: no case regressed above the +%s%% threshold.\n' "$pct"
+printf 'This report is informational, a delta never fails the build.\n'

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -13,6 +13,8 @@ concurrency:
 env:
   GHC_VERSION: '9.8.4'
   CABAL_VERSION: '3.12.1.0'
+  BENCH_ROUNDS: '5'
+  BENCH_THRESHOLD: '0.20'
 jobs:
   regression-check:
     timeout-minutes: 90
@@ -45,41 +47,48 @@ jobs:
           key: ubuntu-m2-${{ hashFiles('benchmark/.mvn/wrapper/maven-wrapper.properties') }}
           restore-keys: ubuntu-m2-
       - run: cabal update
-      - name: Generate frozen fixture from merge-base
+      - name: Build bench and frozen fixture at merge-base
         run: |
           set -e
           git checkout ${{ github.event.pull_request.base.sha }}
-          cabal build all
+          cabal build all --enable-benchmarks
           phino_dir=$(dirname "$(cabal list-bin phino)")
           PATH="$phino_dir:$PATH" make benchmark/tmp/native.phi
           cp benchmark/tmp/native.phi /tmp/native.phi
           cp benchmark/tmp/Native.xmir /tmp/Native.xmir
-      - name: Bench at merge-base
-        run: |
-          set -e
-          cabal bench --enable-benchmarks 2>&1 | tee /tmp/base.out
-      - name: Restore fixture at PR head
+          cp "$(cabal list-bin bench --enable-benchmarks)" /tmp/bench-base
+      - name: Build bench at PR head
         run: |
           set -e
           git checkout ${{ github.event.pull_request.head.sha }}
+          cabal build all --enable-benchmarks
+          cp "$(cabal list-bin bench --enable-benchmarks)" /tmp/bench-head
           mkdir -p benchmark/tmp
           cp /tmp/native.phi benchmark/tmp/native.phi
           cp /tmp/Native.xmir benchmark/tmp/Native.xmir
-      - name: Bench at PR head
+      - name: Bench both builds interleaved
         run: |
           set -e
-          cabal bench --enable-benchmarks 2>&1 | tee /tmp/head.out
+          : > /tmp/base.out
+          : > /tmp/head.out
+          for round in $(seq 1 "$BENCH_ROUNDS"); do
+            echo "round $round of $BENCH_ROUNDS"
+            if [ $((round % 2)) -eq 0 ]; then
+              /tmp/bench-head >> /tmp/head.out
+              /tmp/bench-base >> /tmp/base.out
+            else
+              /tmp/bench-base >> /tmp/base.out
+              /tmp/bench-head >> /tmp/head.out
+            fi
+          done
       - name: Save PR number
         run: echo "${{ github.event.number }}" > /tmp/pr-number
-      - name: Compare and gate
-        id: compare
+      - name: Compare
         run: |
-          set +e
-          .github/scripts/bench-compare.sh /tmp/base.out /tmp/head.out 0.20 > /tmp/benchmark-comment.md
-          status=$?
+          set -e
+          .github/scripts/bench-compare.sh /tmp/base.out /tmp/head.out "$BENCH_THRESHOLD" > /tmp/benchmark-comment.md
           cat /tmp/benchmark-comment.md
           cat /tmp/benchmark-comment.md >> "$GITHUB_STEP_SUMMARY"
-          exit "$status"
       - name: Upload PR number
         if: always()
         uses: actions/upload-artifact@v7

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -264,6 +264,9 @@ instance Render CONDITION where
   render CO_ABSOLUTE{..} = "\\phinoAbsolute{ " <> render expr <> " }"
   render CO_NOT{condition = CO_FORMATION{..}} = "\\phinoNotFormation{ " <> render expr <> " }"
   render CO_NOT{..} = renderFunc "not" condition
+    where
+      renderFunc :: Render a => Text -> a -> Text
+      renderFunc func renderable = func <> "\\lparen " <> render renderable <> " \\rparen"
   render CO_COMPARE{..} = render left <> " " <> render equal <> " " <> render right
   render CO_MATCHES{..} = "matches\\lparen " <> T.pack regex <> ", " <> render expr <> " \\rparen"
   render CO_PART_OF{..} = "part-of\\lparen " <> render expr <> ", " <> render binding <> " \\rparen"
@@ -279,9 +282,6 @@ instance Render CONDITION where
       renderGroups [group] = render group
       renderGroups gs = "\\lparen " <> T.intercalate " \\cup " (map render gs) <> " \\rparen"
   render CO_EMPTY = ""
-
-renderFunc :: Render a => Text -> a -> Text
-renderFunc func renderable = func <> "\\lparen " <> render renderable <> " \\rparen"
 
 instance Render EXTRA_ARG where
   render ARG_ATTR{..} = render attr

--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -352,12 +352,6 @@ metaNamesWithPrefix prefix = nub . go
     goArgument (ArTau _ expr) = go expr
     goArgument (ArAlpha _ expr) = go expr
 
-nfMetaNames :: Expression -> [T.Text]
-nfMetaNames = metaNamesWithPrefix "n"
-
-kMetaNames :: Expression -> [T.Text]
-kMetaNames = metaNamesWithPrefix "k"
-
 matchExpressionWithRule :: Expression -> Y.Rule -> RuleContext -> IO [Subst]
 matchExpressionWithRule = matchExpressionBy matchExpression [substEmpty]
 
@@ -410,3 +404,9 @@ matchExpressionBy matcher seed expr rule ctx =
                       met <- meetMaybeCondition rule.having extended ctx
                       when (null met) (logDebug "The 'having' condition wasn't met")
                       pure met
+  where
+    nfMetaNames :: Expression -> [T.Text]
+    nfMetaNames = metaNamesWithPrefix "n"
+
+    kMetaNames :: Expression -> [T.Text]
+    kMetaNames = metaNamesWithPrefix "k"


### PR DESCRIPTION
The benchmark gate measured one sample per side and compared it against a flat
+20% threshold. That threshold is below the noise floor of a shared runner. On
master alone, `rewrite/normalize` reported anywhere from 50k to 106k μs and
`parse/phi` from 126k to 179k μs across recent runs, so PRs failed on jitter:
#1010 was flagged at +39% and #1000 at +22.5%, and a renovate PR bumping an
action version got a red build too.

So the check keeps measuring, but it stops gating. Both bench binaries are
built up front and then run interleaved, alternating which side goes first so
that load drifting during the job cannot systematically favour one side:

```bash
for round in $(seq 1 "$BENCH_ROUNDS"); do
  if [ $((round % 2)) -eq 0 ]; then
    /tmp/bench-head >> /tmp/head.out
    /tmp/bench-base >> /tmp/base.out
  else
    /tmp/bench-base >> /tmp/base.out
    /tmp/bench-head >> /tmp/head.out
  fi
done
```

`bench-compare.sh` takes the median of the five rounds per case instead of a
lone sample, and prints the spread between the fastest and slowest round as a
noise column beside every delta. A case is called out only when it moves past
both the threshold and its own noise. Replaying the #1010 numbers through it,
the +39% "REGRESSION" becomes +0.7% against ±92.2% noise; a synthetic 2x
slowdown with tight rounds still reads +100.2% against ±2.1% and gets called
out.

Verified against real bench output too: three interleaved A/A rounds of the
same binary, where every delta is by definition noise, produce no callouts.

The job name is still `regression-check` even though nothing regressed can fail
it any more. Renaming it touches `post-comment.yml` and the check name people
see on PRs, so I left it alone; say the word and it becomes `benchmark-report`.

The second commit is unrelated and small: `renderFunc`, `nfMetaNames` and
`kMetaNames` each had a single call site, so they move into the `where` scope of
the equation that uses them.

Closes #1005
