### PR TITLE
fix(functions): correct join error message to say join() (#1017)

### DIFF
--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -208,7 +208,7 @@ _join args subst = do
       bds <- buildBindingThrows bd subst
       next <- buildBindings args'
       pure (bds ++ next)
-    buildBindings _ = throwIO (userError "Function 'go can work with bindings only")
+    buildBindings _ = throwIO (userError "Function join() can work with bindings only")
     go :: [Binding] -> Set.Set Attribute -> IO [Binding]
     go [] _ = pure []
     go (bd : bds) attrs =

--- a/test-resources/cli/join-broken.yaml
+++ b/test-resources/cli/join-broken.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# This rule passes a non-binding argument to the 'join' where-function.
+# It is used to test that the error message names the 'join' function
+# correctly (it used to say "'go" instead of "join()").
+name: uses-join-on-non-binding
+pattern: '!e'
+result: '!e1'
+where:
+  - meta: '!e1'
+    function: join
+    args:
+      - 'some-text'

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -406,6 +406,12 @@ spec = do
           ["rewrite", rule "evaluate-in-rewrite.yaml"]
           ["Function 'evaluate' in rule 'uses-evaluate' is available only for dataization and morphing, not for rewriting"]
 
+    it "names the join function in the error message" $
+      withStdin "⟦⟧" $
+        testCLIFailed
+          ["rewrite", rule "join-broken.yaml"]
+          ["Function join() can work with bindings only"]
+
     it "normalizes with --normalize flag" $
       testCLISucceeded
         ["rewrite", "--normalize", resource "normalize.phi", "--margin=25"]


### PR DESCRIPTION
Fixes #1017.

## Problem

In `src/Functions.hs` the `join` where-function reported a wrong error message when given a non-binding argument:

```haskell
buildBindings _ = throwIO (userError "Function 'go can work with bindings only")
```

The message said `'go` (an internal worker name) instead of `join`, and the `()` suffix that every other `Function <name>() ...` message in the file uses was missing.

## Solution

```haskell
buildBindings _ = throwIO (userError "Function join() can work with bindings only")
```

Now consistent with the rest of `Functions.hs` (e.g. `Function sed() requires...`, `Function number() requires...`).

## Test

Added `test-resources/cli/join-broken.yaml` (a rule passing a non-binding arg to `join`) and a `CLISpec` case asserting the message contains `Function join() can work with bindings only`.

## Checklist

- [x] `make test` passes (1124 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
