### PR TITLE
fix(must): make Show/Read round-trip for the empty range (#1022)

### DIFF
--- a/src/Must.hs
+++ b/src/Must.hs
@@ -34,7 +34,7 @@ instance Read Must where
               hiPart = if null hiStr then Nothing else readMaybe hiStr
            in case (loPart, hiPart, null loStr, null hiStr) of
                 (Nothing, Nothing, False, False) -> [] -- Invalid range: non-numeric values
-                (Nothing, Nothing, True, True) -> [] -- Invalid range: empty range '..'
+                (Nothing, Nothing, True, True) -> [(MtRange Nothing Nothing, "")] -- Empty range '..' round-trips
                 (Nothing, Just hi, True, False) ->
                   [(MtRange Nothing (Just hi), "") | hi >= 0]
                 (Just lo, Nothing, False, True) ->

--- a/test/MustSpec.hs
+++ b/test/MustSpec.hs
@@ -121,9 +121,9 @@ spec = do
           it desc $ (readMaybe input :: Maybe Must) `shouldBe` expected
       )
 
-  describe "Read instance rejects empty range" $
-    it "fails on dots only" $
-      (readMaybe ".." :: Maybe Must) `shouldBe` Nothing
+  describe "Read instance parses empty range" $
+    it "round-trips dots only" $
+      (readMaybe ".." :: Maybe Must) `shouldBe` Just (MtRange Nothing Nothing)
 
   describe "Read instance rejects invalid range with negative minimum" $
     it "fails on negative min" $


### PR DESCRIPTION
Fixes #1022.

## Problem

`Show`/`Read` round-trip for `Must` was broken for the empty range:

```haskell
show (MtRange Nothing Nothing) = ".."   -- src/Must.hs:19
```

but `readsPrec ".."` routed into `parseRange` whose both-empty branch returned `[]`:

```haskell
(Nothing, Nothing, True, True) -> []   -- Invalid range: empty range '..'
```

So `read (show m)` was not `Just m` for `MtRange Nothing Nothing`, even though every other `Must` value round-trips.

## Solution

Make `readsPrec ".."` produce `MtRange Nothing Nothing`, matching `show`:

```haskell
(Nothing, Nothing, True, True) -> [(MtRange Nothing Nothing, "")] -- Empty range '..' round-trips
```

`MtRange Nothing Nothing` is a valid value (an unbounded range, `inRange` returns `True` for any count), so parsing it back is safe.

## Test

Updated `test/MustSpec.hs`: the case previously asserting `readMaybe ".." == Nothing` now asserts the round-trip `Just (MtRange Nothing Nothing)`. `make test` passes (1124 examples).

## Checklist

- [x] `make test` passes (1124 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
