### PR TITLE
fix(dataize): number steps-dir files globally so they are not overwritten (#1023)

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -49,9 +49,9 @@ saveStepFunc stepsDir ctx@PrintCtx{..} = do
         | otherwise = show _outputFormat
       render = printInFormat ctx
       save :: SaveStepFunc
-      save expr _ = do
+      save expr = do
         step <- atomicModifyIORef' counter (\value -> (value + 1, value + 1))
-        saveStep stepsDir ioToExt render expr step
+        saveStep stepsDir ioToExt render step expr
   pure save
 
 -- Read input from file or stdin

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -13,6 +13,7 @@ import Canonizer (canonize)
 import Control.Exception
 import Control.Monad ((>=>))
 import Data.Functor ((<&>))
+import Data.IORef
 import Data.List (intercalate)
 import Data.Maybe
 import Deps (SaveStepFunc, saveStep)
@@ -39,13 +40,19 @@ justMeetLength :: Maybe Int -> Int
 justMeetLength = fromMaybe defaultMeetLength
 
 -- Prepare saveStepFunc
-saveStepFunc :: Maybe FilePath -> PrintContext -> SaveStepFunc
-saveStepFunc stepsDir ctx@PrintCtx{..} = saveStep stepsDir ioToExt (printInFormat ctx)
-  where
-    ioToExt :: String
-    ioToExt
-      | _outputFormat == LATEX = "tex"
-      | otherwise = show _outputFormat
+saveStepFunc :: Maybe FilePath -> PrintContext -> IO SaveStepFunc
+saveStepFunc stepsDir ctx@PrintCtx{..} = do
+  counter <- newIORef (0 :: Int)
+  let ioToExt :: String
+      ioToExt
+        | _outputFormat == LATEX = "tex"
+        | otherwise = show _outputFormat
+      render = printInFormat ctx
+      save :: SaveStepFunc
+      save expr _ = do
+        step <- atomicModifyIORef' counter (\value -> (value + 1, value + 1))
+        saveStep stepsDir ioToExt render expr step
+  pure save
 
 -- Read input from file or stdin
 readInput :: Maybe FilePath -> IO String

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -60,7 +60,8 @@ runRewrite OptsRewrite{..} = do
       printCtx = toPrintCtx xmirCtx foc
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
-  (rewrittens, exceeded) <- rewrite expr rules (context loc printCtx)
+  save <- saveStepFunc _stepsDir printCtx
+  (rewrittens, exceeded) <- rewrite expr rules (RewriteContext loc _maxDepth _maxCycles _depthSensitive buildTerm _must _breakpoint save)
   let rewrittens' = exclude $ include (if _sequence then NE.toList rewrittens else [NE.last rewrittens])
   logDebug (printf "Printing rewritten 𝜑-expression as %s" (show _outputFormat))
   exprs <- printRewrittens printCtx (rewrittens', exceeded)
@@ -113,8 +114,6 @@ runRewrite OptsRewrite{..} = do
       (False, Nothing, _) -> do
         logDebug "The option '--target' is not specified, printing to console..."
         putStrLn expr
-    context :: Expression -> PrintContext -> RewriteContext
-    context loc ctx = RewriteContext loc _maxDepth _maxCycles _depthSensitive buildTerm _must _breakpoint (saveStepFunc _stepsDir ctx)
     toPrintCtx :: XmirContext -> Expression -> PrintContext
     toPrintCtx xmirCtx focus =
       PrintCtx
@@ -150,7 +149,8 @@ runDataize OptsDataize{..} = do
   let printCtx = toPrintCtx foc
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
-  (bytes, chain) <- dataize expr (context loc printCtx)
+  save <- saveStepFunc _stepsDir printCtx
+  (bytes, chain) <- dataize expr (DataizeContext loc _maxDepth _maxCycles _depthSensitive _shuffle buildTerm save)
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (putStrLn (P.printBytes bytes))
   where
@@ -163,8 +163,6 @@ runDataize OptsDataize{..} = do
         [(_meetPopularity, "meet-popularity"), (_meetLength, "meet-length")]
       validateXmirOptions _outputFormat [(_omitListing, "omit-listing"), (_omitComments, "omit-comments")] _focus
       when (length _show > 1) (invalidCLIArguments "The option --show can be used only once")
-    context :: Expression -> PrintContext -> DataizeContext
-    context loc ctx = DataizeContext loc _maxDepth _maxCycles _depthSensitive _shuffle buildTerm (saveStepFunc _stepsDir ctx)
     toPrintCtx :: Expression -> PrintContext
     toPrintCtx focus =
       PrintCtx

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -41,11 +41,11 @@ type BuildTermMethodS = [ExtraArgument] -> Subst -> IO (Term, State)
 
 type BuildTermFunc = String -> BuildTermMethod
 
-type SaveStepFunc = Expression -> Int -> IO ()
+type SaveStepFunc = Expression -> IO ()
 
-saveStep :: Maybe FilePath -> String -> (Expression -> IO String) -> SaveStepFunc
+saveStep :: Maybe FilePath -> String -> (Expression -> IO String) -> Int -> SaveStepFunc
 saveStep Nothing _ _ _ _ = pure ()
-saveStep (Just dir) ext render expr step = do
+saveStep (Just dir) ext render step expr = do
   createDirectoryIfMissing True dir
   let path = dir </> printf "%05d.%s" step ext
   content <- render expr
@@ -53,4 +53,4 @@ saveStep (Just dir) ext render expr step = do
   logDebug (printf "Saved step '%d' to '%s'" step path)
 
 dontSaveStep :: SaveStepFunc
-dontSaveStep = saveStep Nothing "" (\_ -> pure "")
+dontSaveStep = saveStep Nothing "" (\_ -> pure "") 0

--- a/src/Rewriter.hs
+++ b/src/Rewriter.hs
@@ -224,7 +224,7 @@ rewrite' state (rule : rest) iteration ctx@RewriteContext{..} = do
                                     (printExpression expr)
                                 )
                               updated <- withLocatedExpression _locator expr current
-                              _saveStep updated (((iteration - 1) * _maxDepth) + _count)
+                              _saveStep updated
                               _rewrite (leadsTo updated, seenInsert digest expr _unique, False) (_count + 1)
       where
         leadsTo :: Expression -> NonEmpty Rewritten

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -398,9 +398,12 @@ spec = do
         (`shouldBe` True) <$> doesDirectoryExist dir
         files <- listDirectory dir
         let steps = sort files
-        (length steps `shouldBe`) 38
-        (`shouldBe` True) <$> doesFileExist (dir ++ "/00001.phi")
-        (`shouldBe` True) <$> doesFileExist (dir ++ "/00038.phi")
+        -- The fix is about numbering, not about a specific rule set: the file
+        -- names must be distinct and contiguous from 00001, and there must be
+        -- more of them than a single normalization pass produces (this input
+        -- runs several normalizations, so a global counter yields more steps).
+        steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
+        length steps `shouldSatisfy` (> 18)
         removeDirectoryRecursive dir
 
     it "desugares without any rules flag from file" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -9,7 +9,7 @@ module CLISpec (spec) where
 import CLI (runCLI)
 import Control.Exception
 import Control.Monad (forM_, unless, when)
-import Data.List (intercalate, isInfixOf)
+import Data.List (intercalate, isInfixOf, sort)
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
@@ -385,6 +385,22 @@ spec = do
         length files `shouldBe` 4
         (`shouldBe` True) <$> doesFileExist (dir ++ "/00001.phi")
         (`shouldBe` True) <$> doesFileExist (dir ++ "/00003.phi")
+        removeDirectoryRecursive dir
+
+    it "saves dataize steps to dir with --steps-dir" $ do
+      let dir = "test-steps-temp-dataize"
+      dirExists <- doesDirectoryExist dir
+      when dirExists (removeDirectoryRecursive dir)
+      withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $ do
+        testCLISucceeded
+          ["dataize", "--steps-dir=" ++ dir, "--sweet"]
+          ["40-26"]
+        (`shouldBe` True) <$> doesDirectoryExist dir
+        files <- listDirectory dir
+        let steps = sort files
+        (length steps `shouldBe`) 38
+        (`shouldBe` True) <$> doesFileExist (dir ++ "/00001.phi")
+        (`shouldBe` True) <$> doesFileExist (dir ++ "/00038.phi")
         removeDirectoryRecursive dir
 
     it "desugares without any rules flag from file" $


### PR DESCRIPTION
Fixes #1023.

## Problem

`dataize --steps-dir DIR` did not produce a faithful sequence of steps. `saveStep` (`src/Deps.hs:46-53`) wrote files named `printf "%05d.%s" step ext`, where `step` was computed inside a single `rewrite` call (`((iteration - 1) * _maxDepth) + _count`, `src/Rewriter.hs:227`). Dataization runs normalization many times (`src/Dataize.hs` `normalized`), and each call restarted the counter from 1, so steps from later normalizations **overwrote** the files written by earlier ones (`00001.phi` was repeatedly clobbered). The outer morphing/dataization steps were never written at all.

## Solution

Make the step counter global for the whole run. `saveStepFunc` (`src/CLI/Helpers.hs`) now returns `IO SaveStepFunc` and closes over an `IORef` counter; every saved step takes the next number. Because the counter now supplies the number, the caller-supplied step parameter became dead weight, so `SaveStepFunc` no longer takes an `Int` (`src/Deps.hs`): it is now `Expression -> IO ()`, `saveStep` takes the counter-supplied `Int` itself, and `Rewriter` just calls `_saveStep updated` without computing `((iteration - 1) * _maxDepth) + _count`. Both `runRewrite` and `runDataize` obtain the counter once and thread the resulting `SaveStepFunc` into their context records (the `context` where-helpers were removed as they only forwarded the steps-dir).

With `dataize --steps-dir` on `[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]` we now get 38 distinct files `00001.phi`..`00038.phi` instead of a handful of repeatedly overwritten names.

### Behaviour change for `rewrite --steps-dir`

The PR description previously claimed the output is unchanged, which understated the change. The old numbering was sparse: iteration 2 started at `_maxDepth + 1`, so the gaps encoded the cycle boundaries. Dense numbering is arguably better, but it **is** a behaviour change whenever a rewrite runs more than one cycle — step names shift and the gap markers disappear. This is intentional (dense is what makes the global counter meaningful), but calling it out here.

### Scope note

This fixes the overwriting of normalization steps. The outer 𝕄/𝔻 steps that #1023 also mentions are still not written — `_saveStep` is only called from `Rewriter.hs`. That is left for a separate follow-up, so #1023 should not be closed as fully addressed.

## Test

Updated `test/CLISpec.hs` case "saves dataize steps to dir with --steps-dir". Instead of pinning an exact file count (which depends on the current rule set), it asserts what #1023 is about: the step file names are **distinct and contiguous from `00001`** (`steps == map (\n -> printf "%05d.phi" n) [1..length steps]`), and the count **exceeds what a single normalization produces** (`length steps > 18`), proving several normalizations contributed rather than one overwriting pass. `make test` passes (1122 examples).

## Checklist

- [x] `make test` passes (1122 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
