### PR TITLE
feat(random): pad %d to a fixed 4-digit width in random-string (#1019)

### DIFF
--- a/src/Random.hs
+++ b/src/Random.hs
@@ -13,6 +13,7 @@ import qualified Data.Vector.Mutable as M
 import GHC.IO (unsafePerformIO)
 import System.Random (newStdGen, randomRIO)
 import System.Random.Stateful (newIOGenM, uniformRM)
+import Text.Printf (printf)
 
 strings :: IORef (Set String)
 {-# NOINLINE strings #-}
@@ -25,7 +26,7 @@ generate ('%' : ch : rest) = do
     'x' -> replicateM 8 $ do
       v <- randomRIO (0, 15)
       pure (intToDigit v)
-    'd' -> show <$> randomRIO (0 :: Int, 9999)
+    'd' -> printf "%04d" <$> randomRIO (0 :: Int, 9999)
     _ -> pure ['%', ch]
   next <- generate rest
   pure (rep ++ next)

--- a/test/RandomSpec.hs
+++ b/test/RandomSpec.hs
@@ -44,10 +44,10 @@ spec = do
       result `shouldSatisfy` all isDigit
 
   describe "randomString with %d pattern length" $
-    it "generates 1-4 digit number" $ do
+    it "generates a fixed 4-digit number" $ do
       result <- randomString "%d"
       let len = length result
-      len `shouldSatisfy` (\l -> l >= 1 && l <= 4)
+      len `shouldBe` 4
 
   describe "randomString with %x pattern" $
     it "generates hex digits" $ do


### PR DESCRIPTION
Fixes #1019.

## Problem

`Random.generate` expanded `%d` as `show <$> randomRIO (0 :: Int, 9999)`, producing a **variable-length** number: `"3"`, `"42"`, `"567"`, `"8901"`. Meanwhile `%x` expands to a **fixed** 8-char hex string. So synthetic names like `L%d` had unstable lengths across values, and `%d`/`%x` behaved inconsistently with each other.

## Proposed fix

Make `%d` a fixed **4-digit** number, matching `%04d` (and mirroring `%x`'s fixed width):

```haskell
'd' -> printf "%04d" <$> randomRIO (0 :: Int, 9999)
```

`42` now becomes `0042`. The numeric range is unchanged (`0..9999`), only the rendering is padded to a constant width. If a different format is preferred (e.g. unpadded, or a different width), this PR can be rejected — it is a proposal to make the output deterministic in length.

## Test

Updated `test/RandomSpec.hs`: the "%d pattern length" case now asserts `length result == 4` instead of the previous `1..4` window. All other cases (`%d` digits, range `0..9999`, prefix/suffix, uniqueness) still hold. `make test` passes (1122 examples).

## Checklist

- [x] `make test` passes (1122 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
