### PR TITLE
test(builder): pin contextualize behavior for xi and dispatch (#1021)

### DIFF
--- a/test/BuilderSpec.hs
+++ b/test/BuilderSpec.hs
@@ -100,6 +100,18 @@ spec = do
         [substSingle "e1" (MvExpression (ExDispatch ExRoot (AtLabel "x")))]
         `shouldThrow` anyException
 
+  describe "contextualize" $ do
+    it "replaces a xi expression with the context" $
+      contextualize ExXi (ExFormation [BiVoid AtRho]) `shouldBe` ExFormation [BiVoid AtRho]
+    it "keeps a root expression untouched" $
+      contextualize ExRoot (ExFormation [BiVoid AtRho]) `shouldBe` ExRoot
+    it "keeps an empty formation untouched" $
+      contextualize (ExFormation [BiVoid AtRho]) (ExFormation [BiVoid AtRho, BiVoid AtRho])
+        `shouldBe` ExFormation [BiVoid AtRho]
+    it "recurses into a dispatch application" $
+      contextualize (ExDispatch ExXi (AtLabel "z")) (ExFormation [BiVoid AtRho])
+        `shouldBe` ExDispatch (ExFormation [BiVoid AtRho]) (AtLabel "z")
+
   describe "build with duplicate attributes in bindings" $ do
     it "build binding with duplicates" $
       buildBinding (BiMeta "B") (substSingle "B" (MvBindings [BiVoid AtRho, BiVoid AtRho])) `shouldSatisfy` isLeft


### PR DESCRIPTION
Closes #1021 (as a test/documentation follow-up; the behavior itself is kept).

## Problem

`Builder.contextualize ExXi ex = ex` (src/Builder.hs:55) returns its second argument (the context) for a ξ-expression, while `ExRoot` and formations keep their own value. Whether this is the intended semantics was unclear, and no direct unit test pinned any of these cases.

## What this PR does

Adds a `contextualize` test block to `test/BuilderSpec.hs` that pins the current behavior:

- `contextualize ExXi ctx` returns `ctx` (the context replaces ξ)
- `contextualize ExRoot ctx` returns `ExRoot` (unchanged)
- a formation is returned as-is
- the recursion into a dispatch application substitutes the context at the head

This does not change the semantics of `contextualize`; it documents and locks in the existing behavior so a future change is a conscious decision. If maintainers consider the ξ case wrong, that becomes a separate behavioral change on top of these tests.

## Test

New cases in `test/BuilderSpec.hs`. `make test` passes (1125 examples).

## Checklist

- [x] `make test` passes (1125 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
