### PR TITLE
Keep bound ρ and λ function name in XMIR output

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -143,22 +143,25 @@ expression (ExApplication expr arg) ctx = do
 expression expr _ = throwIO (UnsupportedExpression expr)
 
 formationBinding :: Binding -> XmirContext -> IO (Maybe Node)
-formationBinding (BiTau (AtLabel label) (ExFormation bds)) ctx = do
-  inners <- nestedBindings bds ctx
-  pure (Just (object [("name", T.unpack label)] inners))
-formationBinding (BiTau (AtLabel label) expr) ctx = do
-  (base, children) <- expression expr ctx
-  pure (Just (object [("name", T.unpack label), ("base", base)] children))
+formationBinding (BiTau (AtLabel label) expr) ctx = Just <$> namedBinding (T.unpack label) expr ctx
+formationBinding (BiTau AtRho expr) ctx = Just <$> namedBinding (show AtRho) expr ctx
 formationBinding (BiTau AtPhi expr) ctx = do
   (base, children) <- expression expr ctx
   pure (Just (object [("name", show AtPhi), ("base", base)] children))
-formationBinding (BiTau AtRho _) _ = pure Nothing
 formationBinding (BiDelta bytes) _ = pure (Just (NodeContent (T.pack (printBytes bytes))))
-formationBinding (BiLambda _) _ = pure (Just (object [("name", show AtLambda)] []))
+formationBinding (BiLambda (Function name)) _ = pure (Just (object [("name", show AtLambda)] [NodeContent name]))
 formationBinding (BiVoid AtRho) _ = pure Nothing
 formationBinding (BiVoid AtPhi) _ = pure (Just (object [("name", show AtPhi), ("base", "∅")] []))
 formationBinding (BiVoid (AtLabel label)) _ = pure (Just (object [("name", T.unpack label), ("base", "∅")] []))
 formationBinding binding _ = throwIO (UnsupportedBinding binding)
+
+-- Render a bound attribute as a named element: a formation nests its bindings
+-- right inside it, while any other expression is carried by the @base attribute
+namedBinding :: String -> Expression -> XmirContext -> IO Node
+namedBinding name (ExFormation bds) ctx = object [("name", name)] <$> nestedBindings bds ctx
+namedBinding name expr ctx = do
+  (base, children) <- expression expr ctx
+  pure (object [("name", name), ("base", base)] children)
 
 nestedBindings :: [Binding] -> XmirContext -> IO [Node]
 nestedBindings bds ctx = catMaybes <$> mapM (`formationBinding` ctx) bds
@@ -391,15 +394,17 @@ xmirToFormationBinding cur fqn
       name <- getAttr "name" cur
       bds <- mapM (`xmirToFormationBinding` (name : fqn)) (cur C.$/ C.element (toName "o")) >>= uniqueBindings'
       case name of
-        "λ" -> pure (BiLambda (Function (T.pack (intercalate "_" ("L" : reverse fqn)))))
+        "λ" -> BiLambda . Function <$> lambdaFunction
         ('α' : _) -> throwIO (InvalidXMIRFormat "Formation child @name can't start with α" cur)
         "φ" -> pure (BiTau AtPhi (ExFormation (withVoidRho bds)))
+        "ρ" -> pure (BiTau AtRho (ExFormation (withVoidRho bds)))
         _ -> pure (BiTau (AtLabel (T.pack name)) (ExFormation (withVoidRho bds)))
   | otherwise = do
       name <- getAttr "name" cur
       base <- getAttr "base" cur
       attr <- case name of
         "φ" -> pure AtPhi
+        "ρ" -> pure AtRho
         ('α' : _) -> throwIO (InvalidXMIRFormat "Formation child @name can't start with α" cur)
         _ -> pure (AtLabel (T.pack name))
       case base of
@@ -407,6 +412,14 @@ xmirToFormationBinding cur fqn
         _ -> do
           expr <- xmirToExpression cur fqn
           pure (BiTau attr expr)
+  where
+    -- The λ function name is carried by the text of the marker element. XMIR
+    -- coming from elsewhere holds no name, so fall back to the position in the
+    -- tree, which is the only hint left
+    lambdaFunction :: IO T.Text
+    lambdaFunction
+      | hasText cur = T.strip . T.pack <$> getText cur
+      | otherwise = pure (T.pack (intercalate "_" ("L" : reverse fqn)))
 
 xmirToExpression :: C.Cursor -> [String] -> IO Expression
 xmirToExpression cur fqn

--- a/test-resources/xmir-parsing-packs/bound-rho.yaml
+++ b/test-resources/xmir-parsing-packs/bound-rho.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="k">
+        <o name="ρ">
+          <o name="y" base="∅"/>
+        </o>
+      </o>
+    </o>
+  </object>
+phi: '[[ app -> [[ k -> [[ ^ -> [[ y -> ? ]] ]] ]] ]]'

--- a/test-resources/xmir-parsing-packs/lambda-with-name.yaml
+++ b/test-resources/xmir-parsing-packs/lambda-with-name.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="x">
+        <o name="void" base="∅"/>
+        <o name="λ">Lorg_eolang_number_plus</o>
+      </o>
+    </o>
+  </object>
+phi: '[[ app -> [[ x -> [[ void -> ?, L> Lorg_eolang_number_plus ]] ]] ]]'

--- a/test-resources/xmir-printing-packs/lambda-and-rho.yaml
+++ b/test-resources/xmir-printing-packs/lambda-and-rho.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
+---
+phi: |
+  [[
+    k -> [[
+      x -> ?,
+      L> Lorg_eolang_number_plus,
+      ^ -> [[
+        y -> ?
+      ]]
+    ]]
+  ]]
+xpaths:
+  - '/object/o[@name="k"]/o[@name="λ"]'
+  - '/object/o[@name="k"][o="Lorg_eolang_number_plus"]'
+  - '/object/o[@name="k"]/o[@name="ρ"]/o[@name="y" and @base="∅"]'

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -237,3 +237,10 @@ spec = do
               (null failed)
               (expectationFailure ("Failed xpaths:\n - " ++ intercalate "\n - " failed ++ "\nXMIR is:\n" ++ printXMIR xmir'))
       )
+
+  describe "XMIR round-trip" $
+    it "keeps λ function name and bound ρ" $ do
+      expr <- parseExpressionThrows "[[ k -> [[ x -> ?, L> Lorg_eolang_number_plus, ^ -> [[ y -> ? ]] ]] ]]"
+      xmir' <- expressionToXMIR expr defaultXmirContext
+      back <- xmirToPhi xmir'
+      back `shouldBe` expr


### PR DESCRIPTION
Closes #1036.

XMIR was throwing away two things on the way out. A bound `ρ` was dropped
outright, and the `λ` function name was erased down to a bare `<o name="λ"/>`.
The reader then guessed the name back from where the element sat in the tree,
as `L_<fqn>`, which is right only when the name happens to follow the position.
So `phino rewrite --input xmir --output xmir` could not reproduce its own
output, and any atom named something like `Lorg_eolang_number_plus` came back
as `L_k`.

The writer now emits a bound `ρ` the same way it emits any other named
attribute, and puts the `λ` name in the text of the marker element. Text rather
than an attribute, because the XMIR.xsd that phino itself points at leaves no
room: the `o` element has no `anyAttribute`, so its attribute list is closed,
and `atom` is typed as an atom return-type signature whose pattern rejects
anything starting with an uppercase letter. The same `o` element is declared
`mixed="true"`, so text is schema-valid. On the way back in, `name="ρ"` maps to
`AtRho` again, and the `λ` text wins over the positional guess when it is
there — when it is not, the old reconstruction still runs, so XMIR coming from
EO reads exactly as before.

One thing the reviewer should know: the example in #1036 still does not survive
a full round-trip, and this change is not why. A formation binding with `Δ`
loses its bytes on the way in — `⟦ k ↦ ⟦ Δ ⤍ 01-02 ⟧ ⟧` reads back as
`⟦ k ↦ ⟦⟧ ⟧` on master today, with or without this patch, because
`xmirToFormationBinding` never looks at the text content. Separate defect,
separate fix; I left it alone and it is worth its own issue.

`make test` gives 1132 examples and no failures, `make hlint` finds no hints,
`make fourmolu` is clean.