### PR TITLE
Apply --rule together with --normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ to normalize expressions:
 phino rewrite --normalize hello.phi
 ```
 
+Both flags may be combined, so that your own rules are applied
+alongside the built-in ones, in a single rewriting session:
+
+```bash
+phino rewrite --normalize --rule=my-rule.yaml hello.phi
+```
+
 Some rules mint fresh synthetic names via the `random-string` built-in. To
 keep the output reproducible across runs, `phino` seeds the random generator
 deterministically with `0` by default. Use `--seed` to pick a different seed:

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -112,29 +112,32 @@ printCtxToLatexCtx :: PrintContext -> LatexContext
 printCtxToLatexCtx PrintCtx{..} =
   LatexContext _sugar _line _margin _nonumber _compress _canonize _meetPopularity _meetLength _focus _expression _label _meetPrefix _headers
 
--- Get rules for rewriting depending on provided flags
+-- Get rules for rewriting depending on provided flags. Both flags may be given
+-- together, in which case the user rules follow the built-in ones
 getRules :: Bool -> Bool -> [FilePath] -> IO [Y.Rule]
 getRules normalize shuffle rules = do
-  ordered <-
-    if normalize
-      then do
-        let rules' = normalizationRules
-        logDebug (printf "The --normalize option is provided, %d built-it normalization rules are used" (length rules'))
-        pure rules'
-      else
-        if null rules
-          then do
-            logDebug "No --rule and no --normalize options are provided, no rules are used"
-            pure []
-          else do
-            logDebug (printf "Using rules from files: [%s]" (intercalate ", " rules))
-            yamls <- mapM ensuredFile rules
-            mapM (Y.yamlRule >=> validateRewriteRule) yamls
+  ordered <- (++) <$> builtin <*> custom
   if shuffle
     then do
       logDebug "The --shuffle option is provided, rules are used in random order"
       R.shuffle ordered
     else pure ordered
+  where
+    builtin :: IO [Y.Rule]
+    builtin
+      | normalize = do
+          logDebug (printf "The --normalize option is provided, %d built-it normalization rules are used" (length normalizationRules))
+          pure normalizationRules
+      | otherwise = pure []
+    custom :: IO [Y.Rule]
+    custom
+      | null rules = do
+          logDebug "No --rule option is provided, no user rules are used"
+          pure []
+      | otherwise = do
+          logDebug (printf "Using rules from files: [%s]" (intercalate ", " rules))
+          yamls <- mapM ensuredFile rules
+          mapM (Y.yamlRule >=> validateRewriteRule) yamls
 
 -- Pass a user-supplied rewriting rule through unchanged, or fail fast if it
 -- references a build-term function which needs the dataization context: those

--- a/test-resources/cli/marker.yaml
+++ b/test-resources/cli/marker.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# This rule turns a λ-marked formation into data. It is used to check that
+# --rule is honoured together with --normalize, since none of the built-in
+# normalization rules touches a λ binding.
+name: marker
+pattern: ⟦ λ ⤍ Marker ⟧
+result: ⟦ Δ ⤍ FF- ⟧

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -428,6 +428,12 @@ spec = do
             ]
         ]
 
+    it "normalizes and applies --rule at the same time" $
+      withStdin "⟦ k ↦ ⟦ m ↦ ⟦ Δ ⤍ 01- ⟧ ⟧.m, j ↦ ⟦ λ ⤍ Marker ⟧ ⟧" $
+        testCLISucceeded
+          ["rewrite", "--normalize", rule "marker.yaml", "--sweet"]
+          ["⟦ k ↦ ⟦ Δ ⤍ 01-, ρ ↦ ⟦ m ↦ ⟦ Δ ⤍ 01- ⟧ ⟧ ⟧, j ↦ ⟦ Δ ⤍ FF- ⟧ ⟧"]
+
     it "normalizes from stdin" $
       withStdin "⟦ a ↦ ⟦ b ↦ ∅ ⟧ (b ↦ [[ ]]) ⟧" $
         testCLISucceeded


### PR DESCRIPTION
Closes #1037.

`getRules` used to return the built-in normalization set whenever
`--normalize` was on, without ever looking at the `--rule` file list. So
`phino rewrite --normalize --rule my.yaml` quietly behaved as if the second
flag had not been typed. Now the two sets are concatenated, with the user
rules running after the built-in ones, and `--shuffle` covers the whole list.

The reason this matters: anyone who wanted normalization plus a couple of
their own domain rules had to copy all fourteen built-in normalize YAMLs into
their own tree and keep them in sync by hand on every phino upgrade. There was
no way to say "normalize, and also do this".

Two things for the reviewer. First, `--rule` is validated now even under
`--normalize`, so a typo in a path or a dataization-only function in a rule
stops the run instead of slipping past — that is a behaviour change, though I
think it is the right one. Second, `explain` still turns down the same flag
combination in its own `validateOpts` guard, and I left that alone since the
issue is about `rewrite`; whether `explain --normalize --rule x.yaml` should
print both sets is worth deciding on its own.

`make test` gives 1133 examples and no failures, `make hlint` finds no hints,
`make fourmolu` and markdownlint are clean.