### PR TITLE
Implement the missing EO primitive atoms in dataize

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -228,15 +228,12 @@ pattern DataObject :: T.Text -> Bytes -> Expression
 pattern DataObject label bts <- (matchDataObject -> Just (label, bts))
   where
     DataObject label bts =
-      ExApplication
-        (BaseObject label)
-        ( ArTau
-            (AtLabel "as-bytes")
-            ( ExApplication
-                (BaseObject "bytes")
-                ( ArTau
-                    (AtLabel "data")
-                    (ExFormation [BiDelta bts, BiVoid AtRho])
-                )
-            )
-        )
+      ExApplication (BaseObject label) (ArTau (AtLabel "as-bytes") (dataBytes bts))
+
+-- The bytes object Φ.bytes(data ↦ ⟦ Δ ⤍ …, ρ ↦ ∅ ⟧) — what a 'bytes' atom
+-- yields and what a 'DataObject' carries under its 'as-bytes' argument
+dataBytes :: Bytes -> Expression
+dataBytes bts =
+  ExApplication
+    (BaseObject "bytes")
+    (ArTau (AtLabel "data") (ExFormation [BiDelta bts, BiVoid AtRho]))

--- a/src/Bytes.hs
+++ b/src/Bytes.hs
@@ -4,7 +4,9 @@
 -- SPDX-License-Identifier: MIT
 
 -- This module is a codec between 'Bytes' and the values they encode:
--- IEEE-754 doubles, UTF-8 strings and raw hex.
+-- IEEE-754 doubles, UTF-8 strings and raw hex. It also owns the byte-array
+-- operations that EO's 'bytes' atoms are built on, since only this module knows
+-- how a 'Bytes' maps onto the octets underneath it.
 module Bytes
   ( numToBts
   , strToBts
@@ -12,12 +14,20 @@ module Bytes
   , btsToStr
   , btsToNum
   , btsToUnescapedStr
+  , btsAnd
+  , btsOr
+  , btsNot
+  , btsConcat
+  , btsEqual
+  , btsSize
+  , btsSlice
+  , btsShift
   )
 where
 
 import AST
 import Data.Binary.IEEE754
-import Data.Bits (Bits (shiftL, shiftR), (.&.), (.|.))
+import Data.Bits (Bits (complement, shiftL, shiftR), (.&.), (.|.))
 import qualified Data.ByteString as B
 import Data.ByteString.Builder (toLazyByteString, word64BE)
 import Data.ByteString.Lazy (unpack)
@@ -198,3 +208,116 @@ btsToStr bytes = escapeStr (btsToUnescapedStr bytes)
 -- "5"
 btsToUnescapedStr :: Bytes -> String
 btsToUnescapedStr bytes = T.unpack (T.decodeUtf8 (B.pack (btsToWord8 bytes)))
+
+-- Bitwise conjunction of two byte arrays, byte by byte. EO's 'BytesRaw.and'
+-- refuses operands of different lengths, so there is nothing to yield for them
+-- >>> btsAnd (BtMany ["02", "EF"]) (BtMany ["12", "33"])
+-- Just (BtMany ["02","23"])
+-- >>> btsAnd (BtOne "20") (BtMany ["CA", "FE"])
+-- Nothing
+btsAnd :: Bytes -> Bytes -> Maybe Bytes
+btsAnd = zipBytes (.&.)
+
+-- Bitwise disjunction of two byte arrays, under the same length rule as 'btsAnd'
+-- >>> btsOr (BtMany ["02", "EF"]) (BtMany ["12", "33"])
+-- Just (BtMany ["12","FF"])
+btsOr :: Bytes -> Bytes -> Maybe Bytes
+btsOr = zipBytes (.|.)
+
+zipBytes :: (Word8 -> Word8 -> Word8) -> Bytes -> Bytes -> Maybe Bytes
+zipBytes op left right
+  | length lefts /= length rights = Nothing
+  | otherwise = Just (word8ToBytes (zipWith op lefts rights))
+  where
+    lefts :: [Word8]
+    lefts = btsToWord8 left
+    rights :: [Word8]
+    rights = btsToWord8 right
+
+-- Bitwise negation of every byte
+-- >>> btsNot (BtMany ["CA", "FE", "BE", "BE"])
+-- BtMany ["35","01","41","41"]
+btsNot :: Bytes -> Bytes
+btsNot = word8ToBytes . map complement . btsToWord8
+
+-- >>> btsConcat (BtMany ["05", "5E"]) BtEmpty
+-- BtMany ["05","5E"]
+-- >>> btsConcat BtEmpty BtEmpty
+-- BtEmpty
+btsConcat :: Bytes -> Bytes -> Bytes
+btsConcat left right = word8ToBytes (btsToWord8 left ++ btsToWord8 right)
+
+-- EO's 'bytes.eq' compares the two arrays octet by octet, so two spellings of
+-- the same single byte are equal even though their constructors differ
+-- >>> btsEqual (BtOne "01") (BtMany ["01"])
+-- True
+btsEqual :: Bytes -> Bytes -> Bool
+btsEqual left right = btsToWord8 left == btsToWord8 right
+
+-- >>> btsSize (BtMany ["F1", "20", "5F"])
+-- 3
+btsSize :: Bytes -> Int
+btsSize = length . btsToWord8
+
+-- Take 'len' bytes starting at 'start'. A window reaching past the end of the
+-- array has no answer, which is the case EO's 'cant-slice' fallback exists for
+-- >>> btsSlice 1 3 (BtMany ["20", "1F", "EE", "B5", "90"])
+-- Just (BtMany ["1F","EE","B5"])
+-- >>> btsSlice 3 10 (BtMany ["20", "1F", "EE", "B5", "90"])
+-- Nothing
+btsSlice :: Int -> Int -> Bytes -> Maybe Bytes
+btsSlice start len bts
+  | start < 0 || len < 0 || start + len > length octets = Nothing
+  | otherwise = Just (word8ToBytes (take len (drop start octets)))
+  where
+    octets :: [Word8]
+    octets = btsToWord8 bts
+
+-- Shift a byte array right by 'bits' bit positions, or left when 'bits' is
+-- negative, the way EO's 'BytesRaw.shift' does it. The array keeps its length:
+-- bits pushed past either end are dropped and the vacated positions read zero
+-- >>> btsShift 1 (BtMany ["C0", "43", "00"])
+-- BtMany ["60","21","80"]
+-- >>> btsShift (-2147483648) (BtMany ["BF", "F0"])
+-- BtMany ["00","00"]
+btsShift :: Int -> Bytes -> Bytes
+btsShift bits bts
+  | bits < 0 = word8ToBytes (map leftwards indices)
+  | otherwise = word8ToBytes (map rightwards indices)
+  where
+    octets :: [Word8]
+    octets = btsToWord8 bts
+    size :: Int
+    size = length octets
+    indices :: [Int]
+    indices = [0 .. size - 1]
+    modulo :: Int
+    modulo = abs bits `mod` 8
+    offset :: Int
+    offset = abs bits `div` 8
+    octet :: Int -> Word8
+    octet index = octets !! index
+    rightwards :: Int -> Word8
+    rightwards index
+      | source < 0 = 0
+      | source > 0 = shifted .|. ((octet (source - 1) `shiftL` (8 - modulo)) .&. carry)
+      | otherwise = shifted
+      where
+        source :: Int
+        source = index - offset
+        shifted :: Word8
+        shifted = octet source `shiftR` modulo
+        carry :: Word8
+        carry = 0xFF `shiftL` (8 - modulo)
+    leftwards :: Int -> Word8
+    leftwards index
+      | source >= size = 0
+      | source + 1 < size = shifted .|. ((octet (source + 1) `shiftR` (8 - modulo)) .&. carry)
+      | otherwise = shifted
+      where
+        source :: Int
+        source = index + offset
+        shifted :: Word8
+        shifted = octet source `shiftL` modulo
+        carry :: Word8
+        carry = (0x01 `shiftL` modulo) - 1

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -13,9 +13,10 @@ module Dataize (morph, dataize, dataize', DataizeContext (..), State, emptyState
 
 import AST
 import Builder (buildBytesThrows, buildExpressionThrows)
-import Bytes (btsToNum, numToBts)
+import Bytes (btsAnd, btsConcat, btsEqual, btsNot, btsOr, btsShift, btsSize, btsSlice, btsToNum, numToBts, strToBts)
 import Control.Exception (throwIO)
 import Control.Monad (foldM)
+import Data.Int (Int32)
 import Data.List (find, partition)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -367,6 +368,29 @@ asNumber :: Bytes -> Maybe Double
 asNumber BtEmpty = Nothing
 asNumber bts = Just (either toDouble id (btsToNum bts))
 
+-- An operand that EO reads as a Java 'int' — a shift distance or a slice bound.
+-- 'Expect.at(…).that(Integer)' turns down anything but a whole number inside the
+-- 32-bit range, and so does this, leaving the atom with ⊥
+asInt :: Bytes -> Maybe Int
+asInt bts
+  | btsSize bts /= 8 = Nothing
+  | otherwise = case btsToNum bts of
+      Left num | num >= fromIntegral (minBound :: Int32) && num <= fromIntegral (maxBound :: Int32) -> Just num
+      _ -> Nothing
+
+-- An atom whose EO signature ends in '/Q.bool' hands back one of the two bool
+-- objects of the universe, exactly what 'Data.ToPhi(boolean)' does in the runtime
+boolean :: Bool -> Expression
+boolean True = BaseObject "true"
+boolean False = BaseObject "false"
+
+-- Both bitwise atoms take ρ and 'b' and reject operands of different lengths
+bitwise :: (Bytes -> Bytes -> Maybe Bytes) -> Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
+bitwise op self univ state ctx = do
+  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
+  pure (maybe ExTermination dataBytes (op rho b), rstate)
+
 atom :: T.Text -> Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
 atom "L_number_plus" self univ state ctx = do
   (left, lstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
@@ -389,6 +413,58 @@ atom "L_number_eq" self univ state ctx = do
         then pure (DataNumber (numToBts first), rstate)
         else pure (ExDispatch self (AtLabel "y"), rstate)
     _ -> pure (ExTermination, rstate)
+atom "L_number_div" self univ state ctx = do
+  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
+  case (asNumber x, asNumber rho) of
+    (Just divisor, Just dividend) -> pure (DataNumber (numToBts (dividend / divisor)), rstate)
+    _ -> pure (ExTermination, rstate)
+atom "L_number_gt" self univ state ctx = do
+  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
+  case (asNumber x, asNumber rho) of
+    (Just threshold, Just value) -> pure (boolean (value > threshold), rstate)
+    _ -> pure (ExTermination, rstate)
+atom "L_bytes_and" self univ state ctx = bitwise btsAnd self univ state ctx
+atom "L_bytes_or" self univ state ctx = bitwise btsOr self univ state ctx
+atom "L_bytes_not" self univ state ctx = do
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ state ctx
+  pure (dataBytes (btsNot rho), rstate)
+atom "L_bytes_concat" self univ state ctx = do
+  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
+  pure (dataBytes (btsConcat rho b), rstate)
+atom "L_bytes_eq" self univ state ctx = do
+  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
+  pure (boolean (btsEqual rho b), rstate)
+atom "L_bytes_size" self univ state ctx = do
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ state ctx
+  pure (DataNumber (numToBts (fromIntegral (btsSize rho))), rstate)
+atom "L_bytes_right" self univ state ctx = do
+  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
+  case asInt x of
+    Just bits -> pure (dataBytes (btsShift bits rho), rstate)
+    Nothing -> pure (ExTermination, rstate)
+atom "L_bytes_slice" self univ state ctx = do
+  (start, sstate) <- _dataize (ExDispatch self (AtLabel "start")) univ state ctx
+  (len, lstate) <- _dataize (ExDispatch self (AtLabel "len")) univ sstate ctx
+  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
+  case (asInt start, asInt len) of
+    (Just from, Just count)
+      | from >= 0 && count >= 0 ->
+          pure (maybe (cantSlice from count (btsSize rho)) dataBytes (btsSlice from count rho), rstate)
+    _ -> pure (ExTermination, rstate)
+  where
+    -- A window past the end of the array does not stop EO: it copies the
+    -- 'cant-slice' fallback, applies the complaint to it and lets the caller
+    -- decide. A caller that left 'cant-slice' unbound gets ⊥ out of the dispatch
+    cantSlice :: Int -> Int -> Int -> Expression
+    cantSlice from count size =
+      ExApplication
+        (ExDispatch self (AtLabel "cant-slice"))
+        (ArAlpha (Alpha 0) (DataString (strToBts (printf "cannot slice '%d' bytes from offset '%d' of bytes of size %d" count from size))))
 atom func _ _ _ _ = throwIO (userError (printf "Atom '%s' does not exist" (T.unpack func)))
 
 -- Augment the injected, context-free term builder with the dataization and

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -51,6 +51,66 @@ testDataize useCases =
       (value, _) <- dataize expr (defaultDataizeContext loc')
       value `shouldBe` res
 
+-- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
+-- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
+-- expression under φ. Alongside them stand the objects the atoms hand results
+-- to: 'string' carries the 'cant-slice' complaint, while 'true' and 'false' fill
+-- in for the real bool objects, since the single byte an EO bool dataizes to is
+-- all these cases assert.
+primitives :: String -> String
+primitives src =
+  unlines
+    [ "[["
+    , "  bytes -> [["
+    , "    data -> ?,"
+    , "    @ -> $.data,"
+    , "    and -> [[ b -> ?, L> L_bytes_and ]],"
+    , "    or -> [[ b -> ?, L> L_bytes_or ]],"
+    , "    not -> [[ L> L_bytes_not ]],"
+    , "    concat -> [[ b -> ?, L> L_bytes_concat ]],"
+    , "    eq -> [[ b -> ?, L> L_bytes_eq ]],"
+    , "    size -> [[ L> L_bytes_size ]],"
+    , "    right -> [[ x -> ?, L> L_bytes_right ]],"
+    , "    slice -> [[ start -> ?, len -> ?, cant-slice -> ?, L> L_bytes_slice ]]"
+    , "  ]],"
+    , "  number -> [["
+    , "    as-bytes -> ?,"
+    , "    @ -> $.as-bytes,"
+    , "    plus -> [[ x -> ?, L> L_number_plus ]],"
+    , "    times -> [[ x -> ?, L> L_number_times ]],"
+    , "    div -> [[ x -> ?, L> L_number_div ]],"
+    , "    gt -> [[ x -> ?, L> L_number_gt ]]"
+    , "  ]],"
+    , "  string -> [[ as-bytes -> ?, @ -> $.as-bytes ]],"
+    , "  true -> [[ @ -> [[ D> 01- ]] ]],"
+    , "  false -> [[ @ -> [[ D> 00- ]] ]],"
+    , "  @ -> " ++ src
+    , "]]"
+    ]
+
+-- Wrap a hex literal into the bytes object that EO source spells as a bare '20-1F'
+raw :: String -> String
+raw bts = "Q.bytes( data -> [[ D> " ++ bts ++ " ]] )"
+
+testAtom :: [(String, String, Bytes)] -> Spec
+testAtom useCases =
+  forM_ useCases $ \(name, src, res) ->
+    it name $ do
+      expr <- parseExpressionThrows (primitives src)
+      loc <- parseExpressionThrows "Q"
+      (value, _) <- dataize expr (defaultDataizeContext loc)
+      value `shouldBe` res
+
+-- An atom with no answer yields ⊥, which stops the whole dataization
+testStuckAtom :: [(String, String)] -> Spec
+testStuckAtom useCases =
+  forM_ useCases $ \(name, src) ->
+    it name $ do
+      expr <- parseExpressionThrows (primitives src)
+      loc <- parseExpressionThrows "Q"
+      dataize expr (defaultDataizeContext loc)
+        `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
+
 spec :: Spec
 spec = do
   describe "morph" $
@@ -402,3 +462,68 @@ spec = do
       , BtOne "2A"
       )
     ]
+
+  describe "atoms" $ do
+    testAtom
+      [ ("divides a positive dividend", "256.div( 16 )", BtMany ["40", "30", "00", "00", "00", "00", "00", "00"])
+      , ("divides by zero into infinity", "2.div( 0 )", BtMany ["7F", "F0", "00", "00", "00", "00", "00", "00"])
+      , ("tells 1000 is greater than 200", "1000.gt( 200 )", BtOne "01")
+      , ("tells 42 is not greater than 42.5", "42.gt( 42.5 )", BtOne "00")
+      , ("tells zero is greater than a negative", "0.gt( -5 )", BtOne "01")
+      ,
+        ( "conjoins two long bytes"
+        , raw "02-EF-D4-05-5E-78-3A" ++ ".and( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
+        , BtMany ["02", "23", "C0", "05", "5E", "70", "10"]
+        )
+      ,
+        ( "disjoins negative bytes with one"
+        , raw "FF-FF-FF-FF-00-00-00-00" ++ ".or( " ++ raw "00-00-00-00-00-00-00-01" ++ " )"
+        , BtMany ["FF", "FF", "FF", "FF", "00", "00", "00", "01"]
+        )
+      , ("inverts bytes", raw "CA-FE-BE-BE" ++ ".not", BtMany ["35", "01", "41", "41"])
+      ,
+        ( "concats two long bytes"
+        , raw "02-EF-D4-05-5E-78-3A" ++ ".concat( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
+        , BtMany ["02", "EF", "D4", "05", "5E", "78", "3A", "12", "33", "C1", "B5", "5E", "71", "55"]
+        )
+      ,
+        ( "concats bytes with empty ones"
+        , raw "05-5E-78" ++ ".concat( " ++ raw "--" ++ " )"
+        , BtMany ["05", "5E", "78"]
+        )
+      , ("counts the size of bytes", raw "F1-20-5F-EC-B5-90-32" ++ ".size", BtMany ["40", "1C", "00", "00", "00", "00", "00", "00"])
+      , ("tells equal bytes are equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FE" ++ " )", BtOne "01")
+      , ("tells different bytes are not equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FF" ++ " )", BtOne "00")
+      , ("takes a part of bytes", raw "20-1F-EE-B5-90" ++ ".slice( 1, 3 )", BtMany ["1F", "EE", "B5"])
+      ,
+        ( "shifts right an even negative"
+        , raw "C0-43-00-00-00-00-00-00" ++ ".right( 1 )"
+        , BtMany ["60", "21", "80", "00", "00", "00", "00", "00"]
+        )
+      ,
+        ( "shifts right minus one"
+        , raw "BF-F0-00-00-00-00-00-00" ++ ".right( 4 )"
+        , BtMany ["0B", "FF", "00", "00", "00", "00", "00", "00"]
+        )
+      ,
+        ( "shifts right by the integer minimum"
+        , raw "BF-F0-00-00-00-00-00-00" ++ ".right( -2147483648 )"
+        , BtMany ["00", "00", "00", "00", "00", "00", "00", "00"]
+        )
+      ,
+        ( "recovers from an out-of-bounds slice"
+        , raw "20-1F-EE-B5-90" ++ ".slice( 3, 10, [[ message -> ?, @ -> \"recovered\" ]] )"
+        , BtMany ["72", "65", "63", "6F", "76", "65", "72", "65", "64"]
+        )
+      ,
+        ( "recovers from a slice whose start plus length overflows"
+        , raw "20-1F-EE-B5-90" ++ ".slice( 2000000000, 2000000000, [[ message -> ?, @ -> \"recovered\" ]] )"
+        , BtMany ["72", "65", "63", "6F", "76", "65", "72", "65", "64"]
+        )
+      ]
+    testStuckAtom
+      [ ("cannot conjoin bytes of different lengths", raw "20-1F" ++ ".and( " ++ raw "CA-FE-BE" ++ " )")
+      , ("cannot disjoin bytes of different lengths", raw "20-1F" ++ ".or( " ++ raw "CA-FE-BE" ++ " )")
+      , ("cannot slice from an offset beyond the int range", raw "20-1F-EE-B5-90" ++ ".slice( 3000000000, 1 )")
+      , ("cannot slice a negative length", raw "20-1F-EE-B5-90" ++ ".slice( 1, -1 )")
+      ]


### PR DESCRIPTION
The atom table in `src/Dataize.hs` knew only `plus`, `times` and `eq`, so any
division, comparison or bytes manipulation stopped a run with "Atom does not
exist". It now covers all 12 primitives EO's data operations reduce to:
`number.div`/`gt` and `bytes.and`/`concat`/`eq`/`not`/`or`/`right`/`size`/`slice`
join the three that were already there. The pure byte-array arithmetic went into
`src/Bytes.hs`, next to the mapping from `Bytes` onto the octets underneath, and
`AST.dataBytes` is the new constructor for the `Φ.bytes(data ↦ ⟦ Δ ⤍ … ⟧)`
object the bytes atoms yield — the `DataObject` pattern reuses it now too.

The semantics follow the Java runtime. Division is plain IEEE double division.
`gt` and `bytes.eq` yield `Φ.true` or `Φ.false`, the same thing
`Data.ToPhi(boolean)` hands back, so the answer can still be dispatched with
`.if`. `and` and `or` refuse operands of different lengths, as
`BytesRaw.ofSameLength` does. `right` reproduces `BytesRaw.shift`, including the
left shift a negative distance asks for. `slice` turns down bounds below zero or
outside the int range, and an out-of-bounds window goes to the `cant-slice`
fallback carrying EO's own complaint text instead of terminating. The 23 new
cases in `test/DataizeSpec.hs` take their vectors straight from `bytes.eo` and
`number.eo`.

Two things worth deciding separately. phino spells these `L_number_div`,
`L_bytes_and` and so on, matching the existing `L_number_plus`, so the
`Lorg_eolang_number_div` in the issue's snippet still needs the phino spelling —
someone should say whether the runtime spelling ought to be accepted as an alias.
And that snippet also needs `bytes` and `number` declared in its universe:
without them phino spins forever on the unresolved `Φ.number` dispatch. That is
not new, the existing `L_number_plus` hangs the same way in the same bare
universe, but it deserves its own issue.

Closes #1038