### PR TITLE
Declare the required author attribute in XMIR output

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -191,7 +191,8 @@ expressionToXMIR expr@(ExFormation [BiTau (AtLabel _) arg, BiVoid AtRho]) ctx@Xm
             (Prologue [] Nothing [])
             ( element
                 "object"
-                [ ("dob", formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" now)
+                [ ("author", "phino")
+                , ("dob", formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" now)
                 , ("ms", "0")
                 , ("revision", "1234567")
                 , ("time", time now)

--- a/test-resources/xmir-printing-packs/document-author.yaml
+++ b/test-resources/xmir-printing-packs/document-author.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+# yamllint disable rule:line-length
+---
+phi: |
+  [[
+    x -> 5
+  ]]
+xpaths:
+  - '/object[@author="phino"]'


### PR DESCRIPTION
The root `<object>` element now carries `author="phino"`. That is the one
attribute the `object` complexType in `XMIR.xsd` marks `use="required"`, and the
value fits its `[a-z]+(-[a-z]+)*` pattern.

phino points at that schema itself, through the `xsi:noNamespaceSchemaLocation`
it writes on the same element, so until now every document out of
`phino rewrite --output xmir` was turned away by anything that validates before
parsing — which rather defeats the point of emitting the schema location. I
checked it by hand with `xmllint` against a local copy of the schema: the old
output says `Element 'object': The attribute 'author' is required but missing`
and fails, the new output validates.

The new printing pack `test-resources/xmir-printing-packs/document-author.yaml`
pins it with the xpath `/object[@author="phino"]`. The suite cannot fetch the
schema itself, since the tests assume no network, so that xpath is the guard.

Worth noting that #1018 is still open on this same element, about `ms="0"` and
`revision="1234567"` being placeholders rather than real values. I left those
alone — different defect.

Closes #1039