### PR TITLE
fix(xmir): emit real revision and ms attributes, matching the schema (#1018)

### DIFF
--- a/phino.cabal
+++ b/phino.cabal
@@ -91,6 +91,7 @@ library
     directory >=1.3.7 && <1.4,
     file-embed >=0.0.15 && <0.0.17,
     filepath >=1.4.200 && <1.6,
+    gitrev >=1.3.1 && <1.4,
     megaparsec >=9.5 && <9.9,
     optparse-applicative >=0.18 && <0.20,
     random >=1.2 && <1.4,

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
@@ -30,10 +31,11 @@ import Data.Maybe (catMaybes)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TB
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Version (showVersion)
+import Development.GitRev (gitHash)
 import Misc
 import Paths_phino (version)
 import Printer
@@ -47,6 +49,12 @@ data XmirContext = XmirContext
   , _omitComments :: Bool
   , _listing :: Expression -> String
   }
+
+-- The 7-character Git SHA of the phino build that produced the document,
+-- matching the XMIR schema pattern [0-9a-f]{7}. When built outside a git
+-- checkout gitrev yields "UNKNOWN", which the schema allows us to omit.
+gitRevision :: String
+gitRevision = take 7 $(gitHash)
 
 defaultXmirContext :: XmirContext
 defaultXmirContext = XmirContext True True (const "")
@@ -176,6 +184,7 @@ expressionToXMIR expr@(ExFormation [BiTau (AtLabel _) arg, BiVoid AtRho]) ctx@Xm
   where
     expressionToXMIR' :: IO Document
     expressionToXMIR' = do
+      started <- getCurrentTime
       (pckg, expr') <- getPackage expr
       root <- rootExpression expr' ctx
       now <- getCurrentTime
@@ -186,20 +195,25 @@ expressionToXMIR expr@(ExFormation [BiTau (AtLabel _) arg, BiVoid AtRho]) ctx@Xm
               else text
           listing' = NodeElement (element "listing" [] [NodeContent (T.pack listing)])
           metas = metasWithPackage (intercalate "." pckg)
+          ms :: Int
+          ms = round (diffUTCTime now started * 1000)
+          revisionAttr = [("revision", gitRevision) | gitRevision /= "UNKNOWN"]
+          attrs =
+            [ ("author", "phino")
+            , ("dob", formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" now)
+            , ("ms", show ms)
+            , ("time", time now)
+            , ("version", showVersion version)
+            , ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
+            , ("xsi:noNamespaceSchemaLocation", "https://raw.githubusercontent.com/objectionary/eo/refs/heads/gh-pages/XMIR.xsd")
+            ]
+              <> revisionAttr
       pure
         ( Document
             (Prologue [] Nothing [])
             ( element
                 "object"
-                [ ("author", "phino")
-                , ("dob", formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S" now)
-                , ("ms", "0")
-                , ("revision", "1234567")
-                , ("time", time now)
-                , ("version", showVersion version)
-                , ("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
-                , ("xsi:noNamespaceSchemaLocation", "https://raw.githubusercontent.com/objectionary/eo/refs/heads/gh-pages/XMIR.xsd")
-                ]
+                attrs
                 ( if null pckg
                     then [listing', root]
                     else [listing', metas, root]

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -9,7 +9,7 @@ module CLISpec (spec) where
 import CLI (runCLI)
 import CLI.Types (CmdException (..), IOFormat (..))
 import Control.Exception
-import Control.Monad (forM_, unless, when)
+import Control.Monad (forM_, unless)
 import Data.Char (isDigit)
 import Data.List (intercalate, isInfixOf, isPrefixOf, sort)
 import Data.Time.Clock (addUTCTime, getCurrentTime)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -9,8 +9,9 @@ module CLISpec (spec) where
 import CLI (runCLI)
 import CLI.Types (CmdException (..), IOFormat (..))
 import Control.Exception
-import Control.Monad (forM_, unless)
-import Data.List (intercalate, isInfixOf, sort)
+import Control.Monad (forM_, unless, when)
+import Data.Char (isDigit)
+import Data.List (intercalate, isInfixOf, isPrefixOf, sort)
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
@@ -476,6 +477,25 @@ spec = do
         testCLISucceeded
           ["rewrite", "--output=xmir"]
           ["<?xml version=\"1.0\" encoding=\"UTF-8\"?>", "<object", "  <o base=\"Φ.y\" name=\"x\"/>"]
+
+    it "emits a real revision and ms in XMIR" $ do
+      (output, _) <- withStdin "[[ x -> Q.y ]]" $ withStdout (runCLI ["rewrite", "--output=xmir"])
+      let attrValue :: String -> String -> String
+          attrValue name text =
+            let needle = name ++ "=\""
+                breakOn :: String -> Maybe String
+                breakOn haystack
+                  | needle `isPrefixOf` haystack = Just (drop (length needle) haystack)
+                  | null haystack = Nothing
+                  | otherwise = breakOn (drop 1 haystack)
+             in case breakOn text of
+                  Just afterNeedle -> takeWhile (/= '"') afterNeedle
+                  Nothing -> ""
+          revision = attrValue "revision" output
+          ms = attrValue "ms" output
+      revision `shouldSatisfy` (\sha -> length sha == 7 && all (`elem` "0123456789abcdef") sha)
+      revision `shouldNotBe` "1234567"
+      ms `shouldSatisfy` (all isDigit)
 
     it "rewrites as LaTeX" $
       withStdin "[[ x_o -> Q.z(y -> 5), q$ -> T, w -> $, ^ -> Q, @ -> 1, y -> \"H$@^M\", L> Fu_nc ]]" $


### PR DESCRIPTION
Fixes #1018.

## Problem

`expressionToXMIR` emitted fabricated XML attributes on the `<object>` element: `revision="1234567"` (a fake Git SHA) and `ms="0"` (a constant). Per the XMIR schema (the `xsi:noNamespaceSchemaLocation` the output itself points at), `revision` is documented as *"The Git SHA of the release of the parser that created the document"* and `ms` as *"The amount of milliseconds that were spent on creating this document"*. `"1234567"` only happens to satisfy the `[0-9a-f]{7}` pattern; it asserts a commit that does not exist.

## Solution

- **`revision`** — the 7-character Git SHA of the build that produced the document, spliced at compile time via `Development.GitRev` (`gitrev`) Template Haskell (`take 7 $(gitHash)`, src/XMIR.hs). When built outside a git checkout `gitHash` yields `"UNKNOWN"`, and per the schema (the attribute is optional) it is then **omitted** rather than replaced with a placeholder.
- **`ms`** — the wall-clock milliseconds actually spent producing the document: a `getCurrentTime` at the start of `expressionToXMIR'`, subtracted and rounded at the end.

The `author` attribute required by the schema (`author="phino"`) was added separately in upstream #1044; this PR keeps it and only replaces the two placeholder values.

## Test

Added `test/CLISpec.hs` case "emits a real revision and ms in XMIR": asserts `revision` is 7 hex chars and not `1234567`, and `ms` is numeric. `make test` passes (1159 examples).

## Checklist

- [x] `make test` passes (1159 examples)
- [x] `make hlint` — no hints
- [x] `make fourmolu` — clean
