### PR TITLE
Keep Δ data when reading named bindings from XMIR

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -393,13 +393,12 @@ xmirToFormationBinding cur fqn
   | not (hasAttr "name" cur) = throwIO (InvalidXMIRFormat "Formation children must have @name attribute" cur)
   | not (hasAttr "base" cur) = do
       name <- getAttr "name" cur
-      bds <- mapM (`xmirToFormationBinding` (name : fqn)) (cur C.$/ C.element (toName "o")) >>= uniqueBindings'
       case name of
         "λ" -> BiLambda . Function <$> lambdaFunction
         ('α' : _) -> throwIO (InvalidXMIRFormat "Formation child @name can't start with α" cur)
-        "φ" -> pure (BiTau AtPhi (ExFormation (withVoidRho bds)))
-        "ρ" -> pure (BiTau AtRho (ExFormation (withVoidRho bds)))
-        _ -> pure (BiTau (AtLabel (T.pack name)) (ExFormation (withVoidRho bds)))
+        "φ" -> BiTau AtPhi <$> formation name
+        "ρ" -> BiTau AtRho <$> formation name
+        _ -> BiTau (AtLabel (T.pack name)) <$> formation name
   | otherwise = do
       name <- getAttr "name" cur
       base <- getAttr "base" cur
@@ -419,8 +418,18 @@ xmirToFormationBinding cur fqn
     -- tree, which is the only hint left
     lambdaFunction :: IO T.Text
     lambdaFunction
-      | hasText cur = T.strip . T.pack <$> getText cur
+      | hasText cur = T.pack <$> content
       | otherwise = pure (T.pack (intercalate "_" ("L" : reverse fqn)))
+    -- A formation keeps its Δ data in the text content of the element, the way
+    -- the printer emits a Δ binding, while the rest of the bindings are nested
+    -- as child elements
+    formation :: String -> IO Expression
+    formation name = do
+      nested <- mapM (`xmirToFormationBinding` (name : fqn)) (cur C.$/ C.element (toName "o"))
+      bds <- if hasText cur then (\bytes -> BiDelta (bytesToBts bytes) : nested) <$> content else pure nested
+      ExFormation . withVoidRho <$> uniqueBindings' bds
+    content :: IO String
+    content = T.unpack . T.strip . T.pack <$> getText cur
 
 xmirToExpression :: C.Cursor -> [String] -> IO Expression
 xmirToExpression cur fqn

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -396,9 +396,9 @@ xmirToFormationBinding cur fqn
       case name of
         "λ" -> BiLambda . Function <$> lambdaFunction
         ('α' : _) -> throwIO (InvalidXMIRFormat "Formation child @name can't start with α" cur)
-        "φ" -> BiTau AtPhi <$> formation name
-        "ρ" -> BiTau AtRho <$> formation name
-        _ -> BiTau (AtLabel (T.pack name)) <$> formation name
+        "φ" -> BiTau AtPhi <$> xmirToFormation cur (name : fqn)
+        "ρ" -> BiTau AtRho <$> xmirToFormation cur (name : fqn)
+        _ -> BiTau (AtLabel (T.pack name)) <$> xmirToFormation cur (name : fqn)
   | otherwise = do
       name <- getAttr "name" cur
       base <- getAttr "base" cur
@@ -418,18 +418,20 @@ xmirToFormationBinding cur fqn
     -- tree, which is the only hint left
     lambdaFunction :: IO T.Text
     lambdaFunction
-      | hasText cur = T.pack <$> content
+      | hasText cur = T.strip . T.pack <$> getText cur
       | otherwise = pure (T.pack (intercalate "_" ("L" : reverse fqn)))
-    -- A formation keeps its Δ data in the text content of the element, the way
-    -- the printer emits a Δ binding, while the rest of the bindings are nested
-    -- as child elements
-    formation :: String -> IO Expression
-    formation name = do
-      nested <- mapM (`xmirToFormationBinding` (name : fqn)) (cur C.$/ C.element (toName "o"))
-      bds <- if hasText cur then (\bytes -> BiDelta (bytesToBts bytes) : nested) <$> content else pure nested
-      ExFormation . withVoidRho <$> uniqueBindings' bds
-    content :: IO String
-    content = T.unpack . T.strip . T.pack <$> getText cur
+
+-- A formation keeps its Δ data in the text content of its own element, the way
+-- the printer emits a Δ binding, while the rest of the bindings live in the
+-- nested <o> elements
+xmirToFormation :: C.Cursor -> [String] -> IO Expression
+xmirToFormation cur fqn = do
+  nested <- mapM (`xmirToFormationBinding` fqn) (cur C.$/ C.element (toName "o"))
+  bds <- if hasText cur then (: nested) <$> delta else pure nested
+  ExFormation . withVoidRho <$> uniqueBindings' bds
+  where
+    delta :: IO Binding
+    delta = BiDelta . bytesToBts . T.unpack . T.strip . T.pack <$> getText cur
 
 xmirToExpression :: C.Cursor -> [String] -> IO Expression
 xmirToExpression cur fqn
@@ -459,9 +461,7 @@ xmirToExpression cur fqn
         'Φ' : '.' : rest -> xmirToExpression' ExRoot "Φ" rest cur fqn
         'ξ' : '.' : rest -> xmirToExpression' ExXi "ξ" rest cur fqn
         _ -> throwIO (InvalidXMIRFormat "The @base attribute must be either ['∅'|'Φ'] or start with ['Φ.'|'ξ.'|'.']" cur)
-  | otherwise = do
-      bds <- mapM (`xmirToFormationBinding` fqn) (cur C.$/ C.element (toName "o")) >>= uniqueBindings'
-      pure (ExFormation (withVoidRho bds))
+  | otherwise = xmirToFormation cur fqn
   where
     xmirToExpression' :: Expression -> String -> String -> C.Cursor -> [String] -> IO Expression
     xmirToExpression' start symbol rst c names =

--- a/test-resources/xmir-parsing-packs/data-in-dispatched-formation.yaml
+++ b/test-resources/xmir-parsing-packs/data-in-dispatched-formation.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="x" base=".plus">
+        <o>01-02</o>
+      </o>
+    </o>
+  </object>
+phi: '[[ app -> [[ x -> [[ D> 01-02 ]].plus ]] ]]'

--- a/test-resources/xmir-parsing-packs/data-in-named-binding.yaml
+++ b/test-resources/xmir-parsing-packs/data-in-named-binding.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="k">
+        <o name="a">01-02</o>
+        <o name="ρ">03-04</o>
+      </o>
+    </o>
+  </object>
+phi: '[[ app -> [[ k -> [[ a -> [[ D> 01-02 ]], ^ -> [[ D> 03-04 ]] ]] ]] ]]'

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -250,3 +250,9 @@ spec = do
       xmir' <- expressionToXMIR expr defaultXmirContext
       back <- xmirToPhi xmir'
       back `shouldBe` expr
+
+    it "keeps Δ data in a dispatched formation" $ do
+      expr <- parseExpressionThrows "[[ k -> [[ D> 01-02 ]].plus ]]"
+      xmir' <- expressionToXMIR expr defaultXmirContext
+      back <- xmirToPhi xmir'
+      back `shouldBe` expr

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -238,9 +238,15 @@ spec = do
               (expectationFailure ("Failed xpaths:\n - " ++ intercalate "\n - " failed ++ "\nXMIR is:\n" ++ printXMIR xmir'))
       )
 
-  describe "XMIR round-trip" $
+  describe "XMIR round-trip" $ do
     it "keeps λ function name and bound ρ" $ do
       expr <- parseExpressionThrows "[[ k -> [[ x -> ?, L> Lorg_eolang_number_plus, ^ -> [[ y -> ? ]] ]] ]]"
+      xmir' <- expressionToXMIR expr defaultXmirContext
+      back <- xmirToPhi xmir'
+      back `shouldBe` expr
+
+    it "keeps Δ data bound to a named attribute" $ do
+      expr <- parseExpressionThrows "[[ k -> [[ a -> [[ D> 01-02 ]], ^ -> [[ D> 03-04 ]] ]] ]]"
       xmir' <- expressionToXMIR expr defaultXmirContext
       back <- xmirToPhi xmir'
       back `shouldBe` expr


### PR DESCRIPTION
The reader now picks up the text content of an `<o>` element that has no
`@base` and turns it into a Δ binding, so `<o name="a">01-02</o>` comes back as
`a ↦ ⟦ Δ ⤍ 01-02, ρ ↦ ∅ ⟧` instead of an empty formation.

Our own printer writes Δ that way, so the round-trip was losing bytes: the
example from the issue, `⟦ k ↦ ⟦ a ↦ ⟦ Δ ⤍ 01-02 ⟧, ρ ↦ ∅ ⟧ ⟧`, printed to XMIR
and read back came out without the `01-02`. Same for a bound `ρ` carrying data.
The `lambda-and-rho.yaml` pack only checked printing, so nothing caught it.

There were two places building a formation out of an element — one for named
bindings, one for a formation reached through a dispatch such as
`⟦ Δ ⤍ 01-02 ⟧.plus` — and both dropped the text. They now share a single
`xmirToFormation`.

Covered by two new parsing packs and by print-then-parse assertions next to the
existing round-trip test.

Closes #1045