### PR TITLE
Record atom evaluations in a machine-readable protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ $ phino dataize hello.phi
 68-65-6C-6C-6F
 ```
 
+Every atom fired on the way to the bytes may be recorded in a machine-readable
+protocol, with the `--evaluations` option. One firing is one line of three
+tab-separated fields: the name of the λ function, the formation it was applied
+to, and the expression it returned:
+
+```bash
+$ cat sum.phi
+⟦
+  bytes(data) ↦ ⟦ φ ↦ data ⟧,
+  number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
+  φ ↦ 5.plus( 6 )
+⟧
+$ phino dataize --evaluations=atoms.tsv --quiet --sweet --hide-rho sum.phi
+$ cat -T atoms.tsv
+L_number_plus^I⟦ x ↦ 6 ⟧^I11
+```
+
+Records follow the syntax of the other options, such as `--sweet` and
+`--hide-rho`, but always stay on one line. The file is truncated at the
+beginning of every run, and `--output=phi` is the only output format it
+works with, since one record must fit into one line.
+
 ## Rewrite
 
 You can rewrite this expression with the help of [rules](#rule-structure)

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -16,17 +16,20 @@ import Data.Functor ((<&>))
 import Data.IORef
 import Data.List (intercalate)
 import Data.Maybe
-import Deps (SaveStepFunc, saveStep)
+import Deps (SaveEvalFunc, SaveStepFunc, dontSaveEval, saveEval, saveStep)
 import Encoding
 import Files (ensuredFile)
 import Functions (execFunctions)
-import LaTeX (LatexContext (..), defaultMeetLength, defaultMeetPopularity, expressionToLaTeX, rewrittensToLatex)
+import LaTeX (LatexContext (LatexContext), defaultMeetLength, defaultMeetPopularity, expressionToLaTeX, rewrittensToLatex)
+import Lining (LineFormat (SINGLELINE))
 import Locator (locatedExpression)
 import Logger
 import Parser (parseExpressionThrows)
 import qualified Printer as P
 import qualified Random as R
 import Rewriter (Rewritten, Rewrittens', stepHeaders)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
 import System.IO (getContents')
 import Text.Printf (printf)
 import XMIR (expressionToXMIR, parseXMIRThrows, printXMIR, xmirToPhi)
@@ -53,6 +56,19 @@ saveStepFunc stepsDir ctx@PrintCtx{..} = do
         step <- atomicModifyIORef' counter (\value -> (value + 1, value + 1))
         saveStep stepsDir ioToExt render step expr
   pure save
+
+-- Prepare saveEvalFunc. The file is truncated up front, so that it always holds
+-- the firings of exactly one run: a caller reading it back never picks up
+-- records left over from the previous run, even when this run fires no atom at
+-- all. Every record is flattened into a single line, whatever '--flat' says
+-- about the main output, since the file is a line-per-firing protocol.
+saveEvalFunc :: Maybe FilePath -> PrintContext -> IO SaveEvalFunc
+saveEvalFunc Nothing _ = pure dontSaveEval
+saveEvalFunc (Just file) ctx = do
+  createDirectoryIfMissing True (takeDirectory file)
+  writeFile file ""
+  logDebug (printf "The option '--evaluations' is specified, atom firings will be recorded in '%s'" file)
+  pure (saveEval file (printExpression ctx{_line = SINGLELINE}))
 
 -- Read input from file or stdin
 readInput :: Maybe FilePath -> IO String

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -30,7 +30,7 @@ import qualified Random as R
 import Rewriter (Rewritten, Rewrittens', stepHeaders)
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath (takeDirectory)
-import System.IO (getContents')
+import System.IO (Handle, IOMode (WriteMode), getContents', hClose, hSetEncoding, openFile, utf8)
 import Text.Printf (printf)
 import XMIR (expressionToXMIR, parseXMIRThrows, printXMIR, xmirToPhi)
 import Yaml (normalizationRules)
@@ -57,18 +57,32 @@ saveStepFunc stepsDir ctx@PrintCtx{..} = do
         saveStep stepsDir ioToExt render step expr
   pure save
 
--- Prepare saveEvalFunc. The file is truncated up front, so that it always holds
--- the firings of exactly one run: a caller reading it back never picks up
--- records left over from the previous run, even when this run fires no atom at
--- all. Every record is flattened into a single line, whatever '--flat' says
--- about the main output, since the file is a line-per-firing protocol.
-saveEvalFunc :: Maybe FilePath -> PrintContext -> IO SaveEvalFunc
-saveEvalFunc Nothing _ = pure dontSaveEval
-saveEvalFunc (Just file) ctx = do
+-- Run the action with a function recording atom firings, holding the protocol
+-- file open for the whole run. Opening it for writing truncates it, so that it
+-- always holds the firings of exactly one run: a caller reading it back never
+-- picks up records left over from the previous run, even when this run fires no
+-- atom at all. The handle is closed on the way out, failure included, so the
+-- last records reach the disk even when dataization gives up. Every record is
+-- flattened into a single line, whatever '--flat' says about the main output,
+-- since the file is a line-per-firing protocol. The encoding is pinned to UTF-8
+-- rather than taken from the locale, since the file is read back by other
+-- programs.
+withEvalFunc :: Maybe FilePath -> PrintContext -> (SaveEvalFunc -> IO a) -> IO a
+withEvalFunc Nothing _ action = action dontSaveEval
+withEvalFunc (Just file) ctx action = do
   createDirectoryIfMissing True (takeDirectory file)
-  writeFile file ""
   logDebug (printf "The option '--evaluations' is specified, atom firings will be recorded in '%s'" file)
-  pure (saveEval file (printExpression ctx{_line = SINGLELINE}))
+  bracket opened hClose $ \protocol ->
+    action (saveEval protocol (printExpression ctx{_line = SINGLELINE}))
+  where
+    -- 'withFile' would do the same, except that it annotates whatever the action
+    -- throws with the name of the file, and a dataization failure has to reach
+    -- the user as it is
+    opened :: IO Handle
+    opened = do
+      protocol <- openFile file WriteMode
+      hSetEncoding protocol utf8
+      pure protocol
 
 -- Read input from file or stdin
 readInput :: Maybe FilePath -> IO String

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -202,6 +202,9 @@ optTarget = optional (strOption (long "target" <> short 't' <> metavar "FILE" <>
 optStepsDir :: Parser (Maybe FilePath)
 optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "Directory to save intermediate steps during rewriting/dataizing"))
 
+optEvaluations :: Parser (Maybe FilePath)
+optEvaluations = optional (strOption (long "evaluations" <> metavar "FILE" <> help "File to record every atom fired during dataizing, as one tab-separated line per firing: the λ function name, its argument formation and its result (requires --output=phi)"))
+
 optShuffle :: Parser Bool
 optShuffle = switch (long "shuffle" <> help "Shuffle rules before applying")
 
@@ -305,6 +308,7 @@ dataizeParser =
             <*> optLabel
             <*> optMeetPrefix
             <*> optStepsDir
+            <*> optEvaluations
             <*> argInputFile
         )
 

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -150,7 +150,8 @@ runDataize OptsDataize{..} = do
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
-  (bytes, chain) <- dataize expr (DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle buildTerm save)
+  evals <- saveEvalFunc _evaluations printCtx
+  (bytes, chain) <- dataize expr (DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle buildTerm save evals)
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (putStrLn (P.printBytes bytes))
   where
@@ -163,6 +164,9 @@ runDataize OptsDataize{..} = do
         [(_meetPopularity, "meet-popularity"), (_meetLength, "meet-length")]
       validateXmirOptions _outputFormat [(_omitListing, "omit-listing"), (_omitComments, "omit-comments")] _focus
       when (length _show > 1) (invalidCLIArguments "The option --show can be used only once")
+      when
+        (isJust _evaluations && _outputFormat /= PHI)
+        (invalidCLIArguments "The --evaluations option can stay together with --output=phi only, since one record must fit into one line")
     toPrintCtx :: Expression -> PrintContext
     toPrintCtx focus =
       PrintCtx

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -150,8 +150,9 @@ runDataize OptsDataize{..} = do
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
-  evals <- saveEvalFunc _evaluations printCtx
-  (bytes, chain) <- dataize expr (DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle buildTerm save evals)
+  (bytes, chain) <-
+    withEvalFunc _evaluations printCtx $
+      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle buildTerm save
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (putStrLn (P.printBytes bytes))
   where

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -106,6 +106,7 @@ data OptsDataize = OptsDataize
   , _label :: Maybe String
   , _meetPrefix :: Maybe String
   , _stepsDir :: Maybe FilePath
+  , _evaluations :: Maybe FilePath
   , _inputFile :: Maybe FilePath
   }
 

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -23,7 +23,7 @@ import Data.List (find, partition)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Text as T
-import Deps (BuildTermFunc, BuildTermMethodS, SaveStepFunc, State, Term (..))
+import Deps (BuildTermFunc, BuildTermMethodS, Evaluation (..), SaveEvalFunc, SaveStepFunc, State, Term (..))
 import Locator (locatedExpression, withLocatedExpression)
 import Matcher (MetaValue (..), Subst (..), combine, matchExpression', substEmpty, substSingle)
 import Misc
@@ -78,6 +78,7 @@ data DataizeContext = DataizeContext
   , _shuffle :: Bool
   , _buildTerm :: BuildTermFunc
   , _saveStep :: SaveStepFunc
+  , _saveEval :: SaveEvalFunc
   }
 
 newtype DataizeException = OutOfSteps Int
@@ -100,13 +101,18 @@ deeper ctx@DataizeContext{_steps = Steps limit spent}
   | otherwise = pure ctx{_steps = Steps limit (spent + 1)}
 
 -- Resolve formation for LAMBDA Morphing rule.
--- If formation contains λ binding, the called atom result is returned. The
--- universe 'univ' is forwarded to the atom.
-formation :: [Binding] -> Expression -> State -> DataizeContext -> IO (Maybe (Expression, State))
+-- If formation contains λ binding, the called atom result is returned, together
+-- with the name of the fired function and the formation the atom fired against,
+-- so that 𝔼 can report the firing to the outside world. The '_result' of that
+-- report is the atom's raw answer, which 𝔼 normalizes before handing it back.
+-- The universe 'univ' is forwarded to the atom.
+formation :: [Binding] -> Expression -> State -> DataizeContext -> IO (Maybe (Evaluation, State))
 formation bds univ state ctx = do
   let (lambda, bds') = maybeLambda bds
   case lambda of
-    Just (BiLambda (Function func)) -> Just <$> atom func (ExFormation bds') univ state ctx
+    Just (BiLambda (Function func)) -> do
+      (obj, state') <- atom func (ExFormation bds') univ state ctx
+      pure (Just (Evaluation func (ExFormation bds') obj, state'))
     _ -> pure Nothing
   where
     maybeLambda :: [Binding] -> (Maybe Binding, [Binding])
@@ -528,6 +534,10 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- callers ('fire', 'ml') need no follow-up 'normalize' premise. The universe is
 -- passed explicitly as the second argument (rather than threaded behind the
 -- scenes), matching how the morphing 𝕄 and dataization 𝔻 functions carry it.
+-- Every firing is reported to '_saveEval', which the '--evaluations' option
+-- turns into one record per line. A nested firing — an atom that dataizes its
+-- own arguments — completes first, so it is reported before the firing that
+-- triggered it.
 _evaluate :: DataizeContext -> State -> BuildTermMethodS
 _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   form <- buildExpressionThrows expr subst
@@ -536,8 +546,9 @@ _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
     ExFormation bds -> do
       resolved <- formation bds univ state ctx
       case resolved of
-        Just (obj, state') -> do
-          (normal, _) <- normalized obj ((univ, Nothing) :| []) ctx
+        Just (fired, state') -> do
+          (normal, _) <- normalized fired._result ((univ, Nothing) :| []) ctx
+          ctx._saveEval (Evaluation fired._function fired._arguments normal)
           pure (TeExpression normal, state')
         Nothing -> throwIO (userError "Function evaluate() expects a formation with a λ binding")
     _ -> throwIO (userError "Function evaluate() expects a formation")

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -103,8 +103,9 @@ deeper ctx@DataizeContext{_steps = Steps limit spent}
 -- Resolve formation for LAMBDA Morphing rule.
 -- If formation contains λ binding, the called atom result is returned, together
 -- with the name of the fired function and the formation the atom fired against,
--- so that 𝔼 can report the firing to the outside world. The '_result' of that
--- report is the atom's raw answer, which 𝔼 normalizes before handing it back.
+-- since 𝔼 has to report all three. This is not the report itself: its '_result'
+-- is the atom's raw answer, while the one 𝔼 reports carries the normal form of
+-- that answer, which is what 𝔼 hands back to its caller.
 -- The universe 'univ' is forwarded to the atom.
 formation :: [Binding] -> Expression -> State -> DataizeContext -> IO (Maybe (Evaluation, State))
 formation bds univ state ctx = do
@@ -535,9 +536,10 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- passed explicitly as the second argument (rather than threaded behind the
 -- scenes), matching how the morphing 𝕄 and dataization 𝔻 functions carry it.
 -- Every firing is reported to '_saveEval', which the '--evaluations' option
--- turns into one record per line. A nested firing — an atom that dataizes its
--- own arguments — completes first, so it is reported before the firing that
--- triggered it.
+-- turns into one record per line. The reported result is the normal form 𝔼
+-- returns, never the atom's raw answer, so the protocol and the caller see the
+-- same term. A nested firing — an atom that dataizes its own arguments —
+-- completes first, so it is reported before the firing that triggered it.
 _evaluate :: DataizeContext -> State -> BuildTermMethodS
 _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   form <- buildExpressionThrows expr subst

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -16,7 +16,7 @@ import Logger (logDebug)
 import Matcher
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath
-import System.IO (IOMode (AppendMode), hPutStrLn, hSetEncoding, utf8, withFile)
+import System.IO (Handle, hPutStrLn)
 import Text.Printf (printf)
 import Yaml
 
@@ -69,18 +69,16 @@ data Evaluation = Evaluation
 
 type SaveEvalFunc = Evaluation -> IO ()
 
--- Append one evaluation to the protocol file as a single tab-separated line:
--- the λ function name, its argument formation and its result. Both expressions
--- are rendered by the caller, which flattens them, so a record never spills over
--- more than one line. The encoding is pinned to UTF-8 rather than taken from the
--- locale, since the file is read back by other programs.
-saveEval :: FilePath -> (Expression -> IO String) -> SaveEvalFunc
-saveEval file render (Evaluation func bindings outcome) = do
+-- Append one evaluation to the protocol as a single tab-separated line: the λ
+-- function name, its argument formation and its result. Both expressions are
+-- rendered by the caller, which flattens them, so a record never spills over
+-- more than one line. The handle stays open for the whole run, since a run may
+-- fire thousands of atoms and reopening the file for each of them buys nothing.
+saveEval :: Handle -> (Expression -> IO String) -> SaveEvalFunc
+saveEval handle render (Evaluation func bindings outcome) = do
   rendered <- mapM render [bindings, outcome]
-  withFile file AppendMode $ \handle -> do
-    hSetEncoding handle utf8
-    hPutStrLn handle (intercalate "\t" (T.unpack func : rendered))
-  logDebug (printf "Saved evaluation of '%s' to '%s'" (T.unpack func) file)
+  hPutStrLn handle (intercalate "\t" (T.unpack func : rendered))
+  logDebug (printf "Saved the evaluation of '%s'" (T.unpack func))
 
 dontSaveEval :: SaveEvalFunc
 dontSaveEval _ = pure ()

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -10,10 +10,13 @@
 module Deps where
 
 import AST
+import Data.List (intercalate)
+import qualified Data.Text as T
 import Logger (logDebug)
 import Matcher
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath
+import System.IO (IOMode (AppendMode), hPutStrLn, hSetEncoding, utf8, withFile)
 import Text.Printf (printf)
 import Yaml
 
@@ -54,3 +57,30 @@ saveStep (Just dir) ext render step expr = do
 
 dontSaveStep :: SaveStepFunc
 dontSaveStep = saveStep Nothing "" (\_ -> pure "") 0
+
+-- One firing of an atom, the way the Evaluation function 𝔼 sees it: the name of
+-- the λ function, the formation it fired against with the λ binding removed, and
+-- the term it produced.
+data Evaluation = Evaluation
+  { _function :: T.Text
+  , _arguments :: Expression
+  , _result :: Expression
+  }
+
+type SaveEvalFunc = Evaluation -> IO ()
+
+-- Append one evaluation to the protocol file as a single tab-separated line:
+-- the λ function name, its argument formation and its result. Both expressions
+-- are rendered by the caller, which flattens them, so a record never spills over
+-- more than one line. The encoding is pinned to UTF-8 rather than taken from the
+-- locale, since the file is read back by other programs.
+saveEval :: FilePath -> (Expression -> IO String) -> SaveEvalFunc
+saveEval file render (Evaluation func bindings outcome) = do
+  rendered <- mapM render [bindings, outcome]
+  withFile file AppendMode $ \handle -> do
+    hSetEncoding handle utf8
+    hPutStrLn handle (intercalate "\t" (T.unpack func : rendered))
+  logDebug (printf "Saved evaluation of '%s' to '%s'" (T.unpack func) file)
+
+dontSaveEval :: SaveEvalFunc
+dontSaveEval _ = pure ()

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -79,6 +79,14 @@ withTempFileContent pattern content action =
     hClose h
     action path
 
+readUtf8 :: FilePath -> IO String
+readUtf8 path =
+  withFile path ReadMode $ \stream -> do
+    hSetEncoding stream utf8
+    content <- hGetContents stream
+    _ <- evaluate (length content)
+    pure content
+
 testCLI' :: [String] -> [String] -> Either ExitCode () -> Expectation
 testCLI' args outputs exit = do
   (out, result) <- withStdout (try (runCLI args) :: IO (Either ExitCode ()))
@@ -1084,6 +1092,50 @@ spec = do
     it "does not print bytes with --quiet" $
       withStdin "[[ D> 01- ]]" $
         testCLISucceeded ["dataize", "--quiet"] []
+
+    describe "--evaluations" $ do
+      it "writes one tab-separated record per fired atom" $
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+          records <- readUtf8 path
+          records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
+
+      it "writes a record for every firing" $
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $
+            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+          records <- readUtf8 path
+          lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11", "L_number_plus\t⟦ x ↦ 7 ⟧\t18"]
+
+      it "writes records in canonical syntax without --sweet" $
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--hide-rho"] []
+          records <- readUtf8 path
+          records `shouldEndWith` "\tΦ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
+
+      it "truncates the records left over from the previous run" $
+        withTempFileContent "evaluationsXXXXXX.txt" "L_number_gt\t[[ ]]\t01-\n" $ \path -> do
+          withStdin "[[ D> 01- ]]" $
+            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet"] []
+          records <- readUtf8 path
+          records `shouldBe` ""
+
+      it "fails with --output=xmir" $
+        withStdin "[[ D> 01- ]]" $
+          testCLIFailed
+            ["dataize", "--evaluations=evaluations.txt", "--output=xmir"]
+            ["The --evaluations option can stay together with --output=phi only"]
+
+      it "fails with --output=latex" $
+        withStdin "[[ D> 01- ]]" $
+          testCLIFailed
+            ["dataize", "--evaluations=evaluations.txt", "--output=latex"]
+            ["The --evaluations option can stay together with --output=phi only"]
 
     describe "fails" $ do
       it "with --output != latex and --nonumber" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1118,6 +1118,16 @@ spec = do
           records <- readUtf8 path
           records `shouldEndWith` "\tΦ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
 
+      it "keeps the records of a run that fails" $
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], nope -> [[ L> L_number_nope ]] ]], @ -> 5.plus(6).nope ]]" $
+            testCLIFailed
+              ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"]
+              ["Atom 'L_number_nope' does not exist"]
+          records <- readUtf8 path
+          records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
+
       it "truncates the records left over from the previous run" $
         withTempFileContent "evaluationsXXXXXX.txt" "L_number_gt\t[[ ]]\t01-\n" $ \path -> do
           withStdin "[[ D> 01- ]]" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -13,7 +13,7 @@ import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe)
 import Dataize (DataizeContext (DataizeContext), Steps (Steps), dataize, dataize', emptyState, execBuildTerm, morph)
-import Deps (dontSaveStep)
+import Deps (dontSaveEval, dontSaveStep)
 import Functions (buildTerm)
 import Matcher (substEmpty)
 import Parser (parseExpressionThrows)
@@ -26,7 +26,7 @@ import Yaml qualified
 -- dataization rules (#909): a hidden overlap surfaces as a nondeterministic
 -- failure instead of staying silently green.
 defaultDataizeContext :: Expression -> DataizeContext
-defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True buildTerm dontSaveStep
+defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True buildTerm dontSaveStep dontSaveEval
 
 test :: (Eq a, Show a) => ((Expression, NonEmpty Rewritten) -> Expression -> String -> DataizeContext -> IO ((a, [Rewritten]), String)) -> [(String, Expression, Expression, a)] -> Spec
 test func useCases =
@@ -280,7 +280,7 @@ spec = do
   describe "stops a dataization that never reaches bytes" $
     it "fails on the step limit instead of morphing forever" $ do
       expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
-      dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True buildTerm dontSaveStep)
+      dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True buildTerm dontSaveStep dontSaveEval)
         `shouldThrow` (\e -> "--max-steps=40" `isInfixOf` show (e :: SomeException))
 
   describe "labels every step with a defined rule or operation" $ do


### PR DESCRIPTION
Adds an `--evaluations FILE` option to `dataize`. Every time 𝔼 fires an
atom, one line is appended to the file with three tab-separated fields:
the λ function name, the formation the atom was applied to, and the
expression it returned. So `5.plus(6)` with `--sweet --hide-rho` leaves
behind `L_number_plus	⟦ x ↦ 6 ⟧	11`. Without the flag nothing changes.

The point is to let a tool that drives phino as a subprocess read the
firings directly, instead of diffing consecutive `--sequence` dumps to
find out which atom ran and what forma came back.

Two things worth knowing. The file is truncated when the run starts, so
it always describes exactly one run, and a record is always flattened
onto one line, whatever `--flat` says about the main output. And it
works with `--output=phi` only — a LaTeX record carries a `phiquation`
block and an XMIR one is a whole document, so neither fits on a line;
both are rejected up front with a message. I left `rewrite` alone,
since rewriting rejects the `evaluate` function and never fires an atom.

Closes #1055