### PR TITLE
feat(dataize): #1060 partial evaluation with --partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ works with, since one record must fit into one line.
 An atom that cannot fire fails the run: its λ function is unknown to phino,
 or one of its inputs reaches such an atom. This is what happens when a
 data input is replaced on purpose by a placeholder formation, such as
-`⟦ λ ⤍ Sym_arg_0 ⟧`. With `--park-stuck`, the run ends successfully
-instead: the stuck application stays in place as a normal-form subterm,
-everything the calculus demanded before it stays evaluated, and the
-residual expression is printed in place of the bytes:
+`⟦ λ ⤍ Sym_arg_0 ⟧`. With `--partial`, dataization becomes partial
+evaluation instead: what the known inputs decide is computed, the rest
+survives as the residual program, which is printed in place of the bytes,
+and the run ends successfully:
 
 ```bash
-$ cat stuck.phi
+$ cat partial.phi
 ⟦
   bytes(data) ↦ ⟦ φ ↦ data ⟧,
   number(as-bytes) ↦ ⟦
@@ -141,19 +141,21 @@ $ cat stuck.phi
   ⟧,
   φ ↦ 2.times(3).plus(⟦ λ ⤍ Sym_arg_0 ⟧)
 ⟧
-$ phino dataize --park-stuck --sweet --hide-rho stuck.phi
+$ phino dataize --partial --sweet --hide-rho partial.phi
 ⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧
 ```
 
-Here `2.times(3)` was evaluated (its result, `6`, sits in the hidden `ρ`
-of the residue), while `plus` waits for an `x` no atom can produce.
-Each parked site also lands in the `--evaluations` file, as a record with
-the first two fields only, since there is no result to report; the inner
-stuck atom comes first, then the known atom whose input reached it:
+Here `2.times(3)` was decided by literals, so it was computed (its result,
+`6`, sits in the hidden `ρ` of the residual program), while `plus` waits
+for an `x` no atom can produce, so it stays in place as a normal-form
+subterm. Each such stuck site also lands in the `--evaluations` file, as a
+record with the first two fields only, since there is no result to report;
+the inner stuck atom comes first, then the known atom whose input reached
+it:
 
 ```bash
-$ phino dataize --park-stuck --evaluations=atoms.tsv --quiet \
-    --sweet --hide-rho stuck.phi
+$ phino dataize --partial --evaluations=atoms.tsv --quiet \
+    --sweet --hide-rho partial.phi
 $ cat -T atoms.tsv
 L_number_times^I⟦ x ↦ 3 ⟧^I6
 Sym_arg_0^I⟦⟧
@@ -161,8 +163,8 @@ L_number_plus^I⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧
 ```
 
 Evaluation stays demand-driven, as the calculus prescribes: an argument
-that nothing asked for before the run got stuck is left as it is, for the
-next iteration.
+that nothing asked for before the run got stuck is left as it is in the
+residual program, for the next iteration.
 
 ## Rewrite
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,43 @@ Records follow the syntax of the other options, such as `--sweet` and
 beginning of every run, and `--output=phi` is the only output format it
 works with, since one record must fit into one line.
 
+An atom that cannot fire fails the run: its λ function is unknown to phino,
+or one of its inputs reaches such an atom. This is what happens when a
+data input is replaced on purpose by a placeholder formation, such as
+`⟦ λ ⤍ Sym_arg_0 ⟧`. With `--park-stuck`, the run ends successfully
+instead: the stuck application stays in place as a normal-form subterm,
+everything the calculus demanded before it stays evaluated, and the
+residual expression is printed in place of the bytes:
+
+```bash
+$ cat stuck.phi
+⟦
+  bytes(data) ↦ ⟦ φ ↦ data ⟧,
+  number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧, times(x) ↦ ⟦ λ ⤍ L_number_times ⟧ ⟧,
+  φ ↦ 2.times(3).plus(⟦ λ ⤍ Sym_arg_0 ⟧)
+⟧
+$ phino dataize --park-stuck --sweet --hide-rho stuck.phi
+⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧
+```
+
+Here `2.times(3)` was evaluated (its result, `6`, sits in the hidden `ρ`
+of the residue), while `plus` waits for an `x` no atom can produce.
+Each parked site also lands in the `--evaluations` file, as a record with
+the first two fields only, since there is no result to report; the inner
+stuck atom comes first, then the known atom whose input reached it:
+
+```bash
+$ phino dataize --park-stuck --evaluations=atoms.tsv --quiet --sweet --hide-rho stuck.phi
+$ cat -T atoms.tsv
+L_number_times^I⟦ x ↦ 3 ⟧^I6
+Sym_arg_0^I⟦⟧
+L_number_plus^I⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧
+```
+
+Evaluation stays demand-driven, as the calculus prescribes: an argument
+that nothing asked for before the run got stuck is left as it is, for the
+next iteration.
+
 ## Rewrite
 
 You can rewrite this expression with the help of [rules](#rule-structure)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ residual expression is printed in place of the bytes:
 $ cat stuck.phi
 ⟦
   bytes(data) ↦ ⟦ φ ↦ data ⟧,
-  number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧, times(x) ↦ ⟦ λ ⤍ L_number_times ⟧ ⟧,
+  number(as-bytes) ↦ ⟦
+    φ ↦ as-bytes,
+    plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧,
+    times(x) ↦ ⟦ λ ⤍ L_number_times ⟧
+  ⟧,
   φ ↦ 2.times(3).plus(⟦ λ ⤍ Sym_arg_0 ⟧)
 ⟧
 $ phino dataize --park-stuck --sweet --hide-rho stuck.phi
@@ -148,7 +152,8 @@ the first two fields only, since there is no result to report; the inner
 stuck atom comes first, then the known atom whose input reached it:
 
 ```bash
-$ phino dataize --park-stuck --evaluations=atoms.tsv --quiet --sweet --hide-rho stuck.phi
+$ phino dataize --park-stuck --evaluations=atoms.tsv --quiet \
+    --sweet --hide-rho stuck.phi
 $ cat -T atoms.tsv
 L_number_times^I⟦ x ↦ 3 ⟧^I6
 Sym_arg_0^I⟦⟧

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -106,12 +106,8 @@ parseInput _ LATEX = invalidCLIArguments "LaTeX cannot be used as input format"
 printRewrittens :: PrintContext -> Rewrittens' -> IO String
 printRewrittens ctx@PrintCtx{..} rewrittens@(chain, _)
   | _outputFormat == LATEX && _sequence = rewrittensToLatex rewrittens (printCtxToLatexCtx ctx)
-  | otherwise = withHeaders <$> mapM render (canonized chain)
+  | otherwise = withHeaders <$> mapM (printFocused ctx . fst) (canonized chain)
   where
-    render :: Rewritten -> IO String
-    render (expr, _)
-      | _focus == ExRoot = printInFormat ctx expr
-      | otherwise = locatedExpression _focus expr >>= printExpression ctx
     canonized :: [Rewritten] -> [Rewritten]
     canonized = if _canonize then canonize else id
     -- Prefix every step with an empty line and its header (see 'stepHeaders')
@@ -126,6 +122,13 @@ printRewrittens ctx@PrintCtx{..} rewrittens@(chain, _)
       where
         prefixed :: String -> String -> String
         prefixed = printf "\n%s\n%s"
+
+-- Render one expression in the output format, narrowed to the '--focus'
+-- sub-expression when one is given.
+printFocused :: PrintContext -> Expression -> IO String
+printFocused ctx@PrintCtx{..} expr
+  | _focus == ExRoot = printInFormat ctx expr
+  | otherwise = locatedExpression _focus expr >>= printExpression ctx
 
 printExpression :: PrintContext -> Expression -> IO String
 printExpression ctx@PrintCtx{..} ex = case _outputFormat of

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -202,6 +202,9 @@ optTarget = optional (strOption (long "target" <> short 't' <> metavar "FILE" <>
 optStepsDir :: Parser (Maybe FilePath)
 optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "Directory to save intermediate steps during rewriting/dataizing"))
 
+optParkStuck :: Parser Bool
+optParkStuck = switch (long "park-stuck" <> help "Don't fail on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom): leave the application in place, keep evaluating the rest and print the residual 𝜑-expression instead of bytes")
+
 optEvaluations :: Parser (Maybe FilePath)
 optEvaluations = optional (strOption (long "evaluations" <> metavar "FILE" <> help "File to record every atom fired during dataizing, as one tab-separated line per firing: the λ function name, its argument formation and its result (requires --output=phi)"))
 
@@ -293,6 +296,7 @@ dataizeParser =
             <*> optShuffle
             <*> optSeed
             <*> switch (long "quiet" <> help "Don't print the result of dataization")
+            <*> optParkStuck
             <*> optCompress
             <*> optMaxDepth
             <*> optMaxCycles

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -202,8 +202,8 @@ optTarget = optional (strOption (long "target" <> short 't' <> metavar "FILE" <>
 optStepsDir :: Parser (Maybe FilePath)
 optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "Directory to save intermediate steps during rewriting/dataizing"))
 
-optParkStuck :: Parser Bool
-optParkStuck = switch (long "park-stuck" <> help "Don't fail on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom): leave the application in place, keep evaluating the rest and print the residual 𝜑-expression instead of bytes")
+optPartial :: Parser Bool
+optPartial = switch (long "partial" <> help "Partial evaluation: compute what the known inputs decide and, instead of failing on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom), leave it in place and print the residual 𝜑-program instead of bytes")
 
 optEvaluations :: Parser (Maybe FilePath)
 optEvaluations = optional (strOption (long "evaluations" <> metavar "FILE" <> help "File to record every atom fired during dataizing, as one tab-separated line per firing: the λ function name, its argument formation and its result (requires --output=phi)"))
@@ -296,7 +296,7 @@ dataizeParser =
             <*> optShuffle
             <*> optSeed
             <*> switch (long "quiet" <> help "Don't print the result of dataization")
-            <*> optParkStuck
+            <*> optPartial
             <*> optCompress
             <*> optMaxDepth
             <*> optMaxCycles

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -150,12 +150,20 @@ runDataize OptsDataize{..} = do
       exclude = (`F.exclude` excluded)
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
-  (bytes, chain) <-
+  (outcome, chain) <-
     withEvalFunc _evaluations printCtx $
-      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle buildTerm save
+      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _parkStuck buildTerm save
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
-  unless _quiet (putStrLn (P.printBytes bytes))
+  unless _quiet (printOutcome printCtx outcome >>= putStrLn)
   where
+    -- The bytes the run reached or, when '--park-stuck' let it end on an atom
+    -- that could not fire, the residual expression, rendered like a rewriting
+    -- result: in the output format, narrowed to '--focus'.
+    printOutcome :: PrintContext -> Outcome -> IO String
+    printOutcome _ (Dataized bytes) = pure (P.printBytes bytes)
+    printOutcome ctx (Parked residue) = do
+      logDebug "Dataization got stuck on an atom that cannot fire, printing the residual expression (--park-stuck)"
+      printFocused ctx residue
     validateOpts :: IO ()
     validateOpts = do
       validateLatexOptions

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -152,17 +152,17 @@ runDataize OptsDataize{..} = do
   save <- saveStepFunc _stepsDir printCtx
   (outcome, chain) <-
     withEvalFunc _evaluations printCtx $
-      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _parkStuck buildTerm save
+      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial buildTerm save
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (printOutcome printCtx outcome >>= putStrLn)
   where
-    -- The bytes the run reached or, when '--park-stuck' let it end on an atom
-    -- that could not fire, the residual expression, rendered like a rewriting
+    -- The bytes the run reached or, when '--partial' let it end on an atom
+    -- that could not fire, the residual program, rendered like a rewriting
     -- result: in the output format, narrowed to '--focus'.
     printOutcome :: PrintContext -> Outcome -> IO String
     printOutcome _ (Dataized bytes) = pure (P.printBytes bytes)
-    printOutcome ctx (Parked residue) = do
-      logDebug "Dataization got stuck on an atom that cannot fire, printing the residual expression (--park-stuck)"
+    printOutcome ctx (Residual residue) = do
+      logDebug "Dataization got stuck on an atom that cannot fire, printing the residual program (--partial)"
       printFocused ctx residue
     validateOpts :: IO ()
     validateOpts = do

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -91,6 +91,7 @@ data OptsDataize = OptsDataize
   , _shuffle :: Bool
   , _seed :: Int
   , _quiet :: Bool
+  , _parkStuck :: Bool
   , _compress :: Bool
   , _maxDepth :: Int
   , _maxCycles :: Int

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -91,7 +91,7 @@ data OptsDataize = OptsDataize
   , _shuffle :: Bool
   , _seed :: Int
   , _quiet :: Bool
-  , _parkStuck :: Bool
+  , _partial :: Bool
   , _compress :: Bool
   , _maxDepth :: Int
   , _maxCycles :: Int

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -587,7 +587,9 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- firing that gets stuck is reported too, with no result, when the run parks
 -- stuck atoms instead of failing on them ('_parkStuck'): the site is what the
 -- caller wants to learn then, and the nested order holds, since the unknown
--- atom is reported before the known one whose input reached it.
+-- atom is reported before the known one whose input reached it. The report is
+-- made before the signal goes on to the spine, where 'parking' attaches the
+-- derivation to it.
 _evaluate :: DataizeContext -> State -> BuildTermMethodS
 _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   form <- buildExpressionThrows expr subst
@@ -602,8 +604,6 @@ _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
       Nothing -> throwIO (userError "Function evaluate() expects a formation with a λ binding")
     _ -> throwIO (userError "Function evaluate() expects a formation")
   where
-    -- Report the firing that got stuck before letting the signal go on to the
-    -- spine, where 'parking' attaches the derivation to it
     parked :: T.Text -> Expression -> DataizeException -> IO a
     parked func args failure@(Stuck _) = do
       when ctx._parkStuck (ctx._saveEval (Evaluation func args Nothing))

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -75,7 +75,7 @@ data DataizeContext = DataizeContext
   , _steps :: Steps
   , _depthSensitive :: Bool
   , _shuffle :: Bool
-  , _parkStuck :: Bool
+  , _partial :: Bool
   , _buildTerm :: BuildTermFunc
   , _saveStep :: SaveStepFunc
   , _saveEval :: SaveEvalFunc
@@ -90,8 +90,8 @@ data DataizeException
   | -- A 'Stuck' caught by a frame of the 𝕄/𝔻 spine, together with the
     -- derivation that frame had reached (see 'parking'). The head of the chain
     -- is the working expression with the stuck application left intact and
-    -- everything reduced before it already in place: the residue that
-    -- '_parkStuck' turns into the 'Parked' outcome.
+    -- everything reduced before it already in place: the residual program that
+    -- '_partial' turns into the 'Residual' outcome.
     StuckAt T.Text (NonEmpty Rewritten)
   deriving anyclass (Exception)
 
@@ -101,11 +101,12 @@ instance Show DataizeException where
   show (Stuck func) = printf "Atom '%s' does not exist" (T.unpack func)
   show (StuckAt func _) = show (Stuck func)
 
--- What a run of 𝔻 ends with: the bytes it reached or, under '_parkStuck', the
--- residual expression it got stuck on, the stuck atom parked in place.
+-- What a run of 𝔻 ends with: the bytes it reached or, under '_partial', the
+-- residual program: what the known inputs decided is computed, the stuck atom
+-- and everything depending on it survive in place.
 data Outcome
   = Dataized Bytes
-  | Parked Expression
+  | Residual Expression
   deriving stock (Eq, Show)
 
 -- Charge one step of the 𝕄/𝔻 recursion to the budget, refusing to descend once
@@ -234,9 +235,10 @@ morph (expr, seq) univ state caller = do
 -- Dataize the expression located at '_locator'. The whole input expression is
 -- itself the universe Q (the 'e' argument) threaded through 𝔻 and 𝕄, so it is
 -- passed both as the located target and as the universe. An atom that cannot
--- fire fails the run, unless '_parkStuck' is on: then the run ends on the
--- residue the spine had reached (see 'StuckAt'), with the stuck application
--- parked in it as a normal-form subterm, and the chain of steps that led there.
+-- fire fails the run, unless '_partial' is on: dataization is then a partial
+-- evaluation, and the run ends on the residual program the spine had reached
+-- (see 'StuckAt'), with the stuck application parked in it as a normal-form
+-- subterm, and the chain of steps that led there.
 dataize :: Expression -> DataizeContext -> IO (Outcome, [Rewritten])
 dataize universe ctx@DataizeContext{..} = do
   expr <- locatedExpression _locator universe
@@ -245,7 +247,7 @@ dataize universe ctx@DataizeContext{..} = do
   result <- try (dataize' (expr, (universe, Nothing) :| []) universe emptyState ctx)
   case result of
     Right ((bytes, seq), _state) -> pure (Dataized bytes, reverse seq)
-    Left (StuckAt _ seq) | _parkStuck -> pure (Parked (fst (NE.head seq)), reverse (NE.toList seq))
+    Left (StuckAt _ seq) | _partial -> pure (Residual (fst (NE.head seq)), reverse (NE.toList seq))
     Left failure -> throwIO (failure :: DataizeException)
 
 -- The Dataization function 𝔻 retrieves bytes from an expression. It is partial
@@ -584,8 +586,8 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- returns, never the atom's raw answer, so the protocol and the caller see the
 -- same term. A nested firing — an atom that dataizes its own arguments —
 -- completes first, so it is reported before the firing that triggered it. A
--- firing that gets stuck is reported too, with no result, when the run parks
--- stuck atoms instead of failing on them ('_parkStuck'): the site is what the
+-- firing that gets stuck is reported too, with no result, when the run is a
+-- partial evaluation rather than a failure ('_partial'): the site is what the
 -- caller wants to learn then, and the nested order holds, since the unknown
 -- atom is reported before the known one whose input reached it. The report is
 -- made before the signal goes on to the spine, where 'parking' attaches the
@@ -606,7 +608,7 @@ _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   where
     parked :: T.Text -> Expression -> DataizeException -> IO a
     parked func args failure@(Stuck _) = do
-      when ctx._parkStuck (ctx._saveEval (Evaluation func args Nothing))
+      when ctx._partial (ctx._saveEval (Evaluation func args Nothing))
       throwIO failure
     parked _ _ failure = throwIO failure
 _evaluate _ _ _ _ = throwIO (userError "Function evaluate() requires exactly 2 expression arguments")

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -11,13 +10,13 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Dataize (morph, dataize, dataize', DataizeContext (..), Steps (..), State, emptyState, execBuildTerm) where
+module Dataize (morph, dataize, dataize', DataizeContext (..), DataizeException (..), Outcome (..), Steps (..), State, emptyState, execBuildTerm) where
 
 import AST
 import Builder (buildBytesThrows, buildExpressionThrows)
 import Bytes (btsAnd, btsConcat, btsEqual, btsNot, btsOr, btsShift, btsSize, btsSlice, btsToNum, numToBts, strToBts)
-import Control.Exception (Exception, throwIO)
-import Control.Monad (foldM)
+import Control.Exception (Exception, catch, throwIO, try)
+import Control.Monad (foldM, when)
 import Data.Int (Int32)
 import Data.List (find, partition)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -76,17 +75,38 @@ data DataizeContext = DataizeContext
   , _steps :: Steps
   , _depthSensitive :: Bool
   , _shuffle :: Bool
+  , _parkStuck :: Bool
   , _buildTerm :: BuildTermFunc
   , _saveStep :: SaveStepFunc
   , _saveEval :: SaveEvalFunc
   }
 
-newtype DataizeException = OutOfSteps Int
+data DataizeException
+  = OutOfSteps Int
+  | -- An atom could not fire: 'atom' does not know its λ function, or the
+    -- dataization of one of its inputs met an atom it does not know. The name
+    -- is that of the innermost unknown atom, the one 𝔼 actually failed on.
+    Stuck T.Text
+  | -- A 'Stuck' caught by a frame of the 𝕄/𝔻 spine, together with the
+    -- derivation that frame had reached (see 'parking'). The head of the chain
+    -- is the working expression with the stuck application left intact and
+    -- everything reduced before it already in place: the residue that
+    -- '_parkStuck' turns into the 'Parked' outcome.
+    StuckAt T.Text (NonEmpty Rewritten)
   deriving anyclass (Exception)
 
 instance Show DataizeException where
   show (OutOfSteps limit) =
     printf "Dataization did not finish before reaching the limit of steps: --max-steps=%d" limit
+  show (Stuck func) = printf "Atom '%s' does not exist" (T.unpack func)
+  show (StuckAt func _) = show (Stuck func)
+
+-- What a run of 𝔻 ends with: the bytes it reached or, under '_parkStuck', the
+-- residual expression it got stuck on, the stuck atom parked in place.
+data Outcome
+  = Dataized Bytes
+  | Parked Expression
+  deriving stock (Eq, Show)
 
 -- Charge one step of the 𝕄/𝔻 recursion to the budget, refusing to descend once
 -- it is gone. '--max-cycles' and '--max-depth' bound only the normalization run
@@ -100,31 +120,46 @@ deeper ctx@DataizeContext{_steps = Steps limit spent}
   | spent >= limit = throwIO (OutOfSteps limit)
   | otherwise = pure ctx{_steps = Steps limit (spent + 1)}
 
--- Resolve formation for LAMBDA Morphing rule.
--- If formation contains λ binding, the called atom result is returned, together
--- with the name of the fired function and the formation the atom fired against,
--- since 𝔼 has to report all three. This is not the report itself: its '_result'
--- is the atom's raw answer, while the one 𝔼 reports carries the normal form of
--- that answer, which is what 𝔼 hands back to its caller.
--- The universe 'univ' is forwarded to the atom.
-formation :: [Binding] -> Expression -> State -> DataizeContext -> IO (Maybe (Evaluation, State))
-formation bds univ state ctx = do
-  let (lambda, bds') = maybeLambda bds
-  case lambda of
-    Just (BiLambda (Function func)) -> do
-      (obj, state') <- atom func (ExFormation bds') univ state ctx
-      pure (Just (Evaluation func (ExFormation bds') obj, state'))
-    _ -> pure Nothing
+-- Split the λ binding off a formation for the LAMBDA morphing rule: the name of
+-- the atom to fire and the formation it fires against, the λ binding removed —
+-- the two things 𝔼 reports besides the result. A formation with no λ binding,
+-- or with more than one, has nothing to fire.
+lambda :: [Binding] -> Maybe (T.Text, Expression)
+lambda bds = case partition isLambda bds of
+  ([BiLambda (Function func)], rest) -> Just (func, ExFormation rest)
+  _ -> Nothing
   where
-    maybeLambda :: [Binding] -> (Maybe Binding, [Binding])
-    maybeLambda = maybeBinding (\case BiLambda _ -> True; _ -> False)
-    maybeBinding :: (Binding -> Bool) -> [Binding] -> (Maybe Binding, [Binding])
-    maybeBinding _ [] = (Nothing, [])
-    maybeBinding func bds =
-      let (found, rest) = partition func bds
-       in case found of
-            [bd] -> (Just bd, rest)
-            _ -> (Nothing, bds)
+    isLambda :: Binding -> Bool
+    isLambda (BiLambda _) = True
+    isLambda _ = False
+
+-- Run one frame of the 𝕄/𝔻 spine, attaching its derivation to a stuck atom
+-- escaping it. 'Stuck' is raised deep inside an atom, which knows nothing about
+-- the chain, so the innermost spine frame it reaches is the one to record where
+-- the derivation stopped: the head of that frame's chain is the working
+-- expression with the stuck application intact and everything reduced before
+-- it already in place. Outer frames see 'StuckAt' and let it pass, since their
+-- chains are prefixes of that one; a side-computation running on a chain of its
+-- own strips the chain off again (see 'unparked') before the signal reaches
+-- the spine.
+parking :: NonEmpty Rewritten -> IO a -> IO a
+parking seq action = action `catch` rethrow
+  where
+    rethrow :: DataizeException -> IO a
+    rethrow (Stuck func) = throwIO (StuckAt func seq)
+    rethrow failure = throwIO failure
+
+-- Strip the derivation off a stuck atom escaping a side-computation that ran
+-- on a chain of its own — an atom dataizing its input through '_dataize', or a
+-- 'morph' premise through '_morph'. That chain is not the spine's, so it is
+-- dropped and the spine frame around the side-computation attaches its own
+-- (see 'parking').
+unparked :: IO a -> IO a
+unparked action = action `catch` rethrow
+  where
+    rethrow :: DataizeException -> IO a
+    rethrow (StuckAt func _) = throwIO (Stuck func)
+    rethrow failure = throwIO failure
 
 -- The Morphing function 𝕄 maps normal forms to formations. It is ternary,
 -- 𝕄(n, e, s): besides the term 'n' it takes the universe 'e' ('univ') — a plain
@@ -148,11 +183,12 @@ formation bds univ state ctx = do
 morph :: Morphed -> Expression -> State -> DataizeContext -> IO (Morphed, State)
 morph (expr, seq) univ state caller = do
   ctx <- deeper caller
-  rules <- if ctx._shuffle then shuffle Y.morphingRules else pure Y.morphingRules
-  matched <- firstMatch ctx rules
-  case matched of
-    Just (rule, subst) -> reduce ctx rule subst
-    Nothing -> throwIO (userError "no morphing rule matched")
+  parking seq $ do
+    rules <- if ctx._shuffle then shuffle Y.morphingRules else pure Y.morphingRules
+    matched <- firstMatch ctx rules
+    case matched of
+      Just (rule, subst) -> reduce ctx rule subst
+      Nothing -> throwIO (userError "no morphing rule matched")
   where
     firstMatch :: DataizeContext -> [Y.MorphRule] -> IO (Maybe (Y.MorphRule, Subst))
     firstMatch _ [] = pure Nothing
@@ -197,14 +233,20 @@ morph (expr, seq) univ state caller = do
 
 -- Dataize the expression located at '_locator'. The whole input expression is
 -- itself the universe Q (the 'e' argument) threaded through 𝔻 and 𝕄, so it is
--- passed both as the located target and as the universe.
-dataize :: Expression -> DataizeContext -> IO Dataized
+-- passed both as the located target and as the universe. An atom that cannot
+-- fire fails the run, unless '_parkStuck' is on: then the run ends on the
+-- residue the spine had reached (see 'StuckAt'), with the stuck application
+-- parked in it as a normal-form subterm, and the chain of steps that led there.
+dataize :: Expression -> DataizeContext -> IO (Outcome, [Rewritten])
 dataize universe ctx@DataizeContext{..} = do
   expr <- locatedExpression _locator universe
   -- Dataization starts from the empty state; the final state is not yet
   -- consumed by any caller, so it is discarded here.
-  ((bytes, seq), _state) <- dataize' (expr, (universe, Nothing) :| []) universe emptyState ctx
-  pure (bytes, reverse seq)
+  result <- try (dataize' (expr, (universe, Nothing) :| []) universe emptyState ctx)
+  case result of
+    Right ((bytes, seq), _state) -> pure (Dataized bytes, reverse seq)
+    Left (StuckAt _ seq) | _parkStuck -> pure (Parked (fst (NE.head seq)), reverse (NE.toList seq))
+    Left failure -> throwIO (failure :: DataizeException)
 
 -- The Dataization function 𝔻 retrieves bytes from an expression. It is partial
 -- and ternary, 𝔻(n, e, s): besides the term 'n' it takes the universe 'e' ('univ'),
@@ -230,11 +272,12 @@ dataize universe ctx@DataizeContext{..} = do
 dataize' :: Dataizable -> Expression -> State -> DataizeContext -> IO (Dataized, State)
 dataize' (expr, seq) univ state caller = do
   ctx <- deeper caller
-  rules <- if ctx._shuffle then shuffle Y.dataizationRules else pure Y.dataizationRules
-  matched <- firstMatch ctx rules
-  case matched of
-    Just (rule, subst) -> reduce ctx rule subst
-    Nothing -> throwIO (userError (unmatched expr))
+  parking seq $ do
+    rules <- if ctx._shuffle then shuffle Y.dataizationRules else pure Y.dataizationRules
+    matched <- firstMatch ctx rules
+    case matched of
+      Just (rule, subst) -> reduce ctx rule subst
+      Nothing -> throwIO (userError (unmatched expr))
   where
     -- 𝔻 is partial: the terminator ⊥ signals an error and lies outside its
     -- domain (see #955), so it matches no clause and lands here. Name it in the
@@ -398,10 +441,11 @@ normalized expr seq ctx@DataizeContext{..} = do
 -- it first reduces the expression to a normal form, since 𝔻 only accepts normal
 -- forms. The universe 'univ' itself is forwarded unchanged, so morphing Φ under
 -- this context still resolves to the true universe rather than to this
--- synthetic, binding-prepended formation.
+-- synthetic, binding-prepended formation. The chain is the synthetic one, so a
+-- stuck atom met on the way leaves without it (see 'unparked').
 _dataize :: Expression -> Expression -> State -> DataizeContext -> IO (Bytes, State)
 _dataize expr univ state ctx@DataizeContext{_buildTerm = buildTerm} = case univ of
-  ExFormation bds -> do
+  ExFormation bds -> unparked $ do
     (TeAttribute attr) <- buildTerm "random-tau" [] substEmpty
     let synthetic = ExFormation (BiTau attr expr : bds)
     (normal, seq) <- normalized expr ((synthetic, Nothing) :| []) ctx
@@ -513,7 +557,7 @@ atom "L_bytes_slice" self univ state ctx = do
       ExApplication
         (ExDispatch self (AtLabel "cant-slice"))
         (ArAlpha (Alpha 0) (DataString (strToBts (printf "cannot slice '%d' bytes from offset '%d' of bytes of size %d" count from size))))
-atom func _ _ _ _ = throwIO (userError (printf "Atom '%s' does not exist" (T.unpack func)))
+atom func _ _ _ _ = throwIO (Stuck func)
 
 -- Augment the injected, context-free term builder with the dataization and
 -- morphing operations that need the universe: 'evaluate' applies an atom and
@@ -539,30 +583,42 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- turns into one record per line. The reported result is the normal form 𝔼
 -- returns, never the atom's raw answer, so the protocol and the caller see the
 -- same term. A nested firing — an atom that dataizes its own arguments —
--- completes first, so it is reported before the firing that triggered it.
+-- completes first, so it is reported before the firing that triggered it. A
+-- firing that gets stuck is reported too, with no result, when the run parks
+-- stuck atoms instead of failing on them ('_parkStuck'): the site is what the
+-- caller wants to learn then, and the nested order holds, since the unknown
+-- atom is reported before the known one whose input reached it.
 _evaluate :: DataizeContext -> State -> BuildTermMethodS
 _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   form <- buildExpressionThrows expr subst
   univ <- buildExpressionThrows universe subst
   case form of
-    ExFormation bds -> do
-      resolved <- formation bds univ state ctx
-      case resolved of
-        Just (fired, state') -> do
-          (normal, _) <- normalized fired._result ((univ, Nothing) :| []) ctx
-          ctx._saveEval (Evaluation fired._function fired._arguments normal)
-          pure (TeExpression normal, state')
-        Nothing -> throwIO (userError "Function evaluate() expects a formation with a λ binding")
+    ExFormation bds -> case lambda bds of
+      Just (func, args) -> do
+        (raw, state') <- atom func args univ state ctx `catch` parked func args
+        (normal, _) <- normalized raw ((univ, Nothing) :| []) ctx
+        ctx._saveEval (Evaluation func args (Just normal))
+        pure (TeExpression normal, state')
+      Nothing -> throwIO (userError "Function evaluate() expects a formation with a λ binding")
     _ -> throwIO (userError "Function evaluate() expects a formation")
+  where
+    -- Report the firing that got stuck before letting the signal go on to the
+    -- spine, where 'parking' attaches the derivation to it
+    parked :: T.Text -> Expression -> DataizeException -> IO a
+    parked func args failure@(Stuck _) = do
+      when ctx._parkStuck (ctx._saveEval (Evaluation func args Nothing))
+      throwIO failure
+    parked _ _ failure = throwIO failure
 _evaluate _ _ _ _ = throwIO (userError "Function evaluate() requires exactly 2 expression arguments")
 
 -- The Morphing function 𝕄 exposed as a build-term function so a rule can morph
 -- a sub-expression in its 'where' (the 'md' and 'ma' rules morph
 -- the head before re-attaching it). The step chain is discarded: the producing
--- rule splices the surrounding normalization steps itself. The state is threaded
--- through and the new state returned alongside the morphed term.
+-- rule splices the surrounding normalization steps itself, and a stuck atom met
+-- on the way leaves without it (see 'unparked'). The state is threaded through
+-- and the new state returned alongside the morphed term.
 _morph :: Expression -> DataizeContext -> State -> BuildTermMethodS
-_morph univ ctx state [ArgExpression expr] subst = do
+_morph univ ctx state [ArgExpression expr] subst = unparked $ do
   built <- buildExpressionThrows expr subst
   ((morphed, _), state') <- morph (built, (univ, Nothing) :| []) univ state ctx
   pure (TeExpression morphed, state')

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -62,8 +62,8 @@ dontSaveStep = saveStep Nothing "" (\_ -> pure "") 0
 -- One firing of an atom, the way the Evaluation function 𝔼 sees it: the name of
 -- the λ function, the formation it fired against with the λ binding removed, and
 -- the term it produced. A firing that got stuck — the atom is unknown, or one of
--- its inputs reached such an atom — and was parked in place (see '--park-stuck')
--- has no result.
+-- its inputs reached such an atom — and survived in the residual program of a
+-- partial evaluation (see '--partial') has no result.
 data Evaluation = Evaluation
   { _function :: T.Text
   , _arguments :: Expression

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -11,6 +11,7 @@ module Deps where
 
 import AST
 import Data.List (intercalate)
+import Data.Maybe (maybeToList)
 import qualified Data.Text as T
 import Logger (logDebug)
 import Matcher
@@ -60,23 +61,26 @@ dontSaveStep = saveStep Nothing "" (\_ -> pure "") 0
 
 -- One firing of an atom, the way the Evaluation function 𝔼 sees it: the name of
 -- the λ function, the formation it fired against with the λ binding removed, and
--- the term it produced.
+-- the term it produced. A firing that got stuck — the atom is unknown, or one of
+-- its inputs reached such an atom — and was parked in place (see '--park-stuck')
+-- has no result.
 data Evaluation = Evaluation
   { _function :: T.Text
   , _arguments :: Expression
-  , _result :: Expression
+  , _result :: Maybe Expression
   }
 
 type SaveEvalFunc = Evaluation -> IO ()
 
 -- Append one evaluation to the protocol as a single tab-separated line: the λ
--- function name, its argument formation and its result. Both expressions are
+-- function name, its argument formation and its result; a parked firing has no
+-- result, so its record stops after the second field. The expressions are
 -- rendered by the caller, which flattens them, so a record never spills over
 -- more than one line. The handle stays open for the whole run, since a run may
 -- fire thousands of atoms and reopening the file for each of them buys nothing.
 saveEval :: Handle -> (Expression -> IO String) -> SaveEvalFunc
 saveEval handle render (Evaluation func bindings outcome) = do
-  rendered <- mapM render [bindings, outcome]
+  rendered <- mapM render (bindings : maybeToList outcome)
   hPutStrLn handle (intercalate "\t" (T.unpack func : rendered))
   logDebug (printf "Saved the evaluation of '%s'" (T.unpack func))
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1146,6 +1146,53 @@ spec = do
             ["dataize", "--evaluations=evaluations.txt", "--output=latex"]
             ["The --evaluations option can stay together with --output=phi only"]
 
+    -- A placeholder formation ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input
+    -- names an atom phino cannot fire; the run used to die on it, discarding
+    -- what it had already evaluated (#1060)
+    describe "--park-stuck" $ do
+      let stuck = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], times(x) -> [[ L> L_number_times ]] ]], @ -> 2.times(3).plus([[ L> Sym_arg_0 ]]) ]]"
+      it "fails on an atom that cannot fire without the flag" $
+        withStdin stuck $
+          testCLIFailed ["dataize", "--sweet", "--hide-rho"] ["Atom 'Sym_arg_0' does not exist"]
+
+      it "prints the residue with the stuck application intact and exits successfully" $
+        withStdin stuck $
+          testCLISucceeded
+            ["dataize", "--park-stuck", "--sweet", "--hide-rho"]
+            ["⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
+
+      it "keeps what was evaluated before the stuck site in the residue" $
+        withStdin stuck $
+          testCLISucceeded
+            ["dataize", "--park-stuck", "--sweet"]
+            ["as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
+
+      it "records every parked site in --evaluations with no result" $
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin stuck $
+            testCLISucceeded ["dataize", "--park-stuck", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+          records <- readUtf8 path
+          lines records
+            `shouldBe` [ "L_number_times\t⟦ x ↦ 3 ⟧\t6"
+                       , "Sym_arg_0\t⟦⟧"
+                       , "L_number_plus\t⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧"
+                       ]
+
+      it "still prints bytes when nothing gets stuck" $
+        withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+          testCLISucceeded ["dataize", "--park-stuck"] ["40-26-00-00-00-00-00-00"]
+
+      it "prints the chain of steps ending in the residue with --sequence" $
+        withStdin stuck $
+          testCLISucceeded
+            ["dataize", "--park-stuck", "--sequence", "--sweet", "--hide-rho", "--flat"]
+            ["2.times( 3 ).plus( ⟦ λ ⤍ Sym_arg_0 ⟧ )", "⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
+
+      it "still stops on the terminator ⊥, since a wrong operand is not a stuck atom" $
+        withStdin "[[ ]]" $
+          testCLIFailed ["dataize", "--park-stuck"] ["terminator ⊥"]
+
     describe "fails" $ do
       it "with --output != latex and --nonumber" $
         withStdin "" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1149,7 +1149,7 @@ spec = do
     -- A placeholder formation ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input
     -- names an atom phino cannot fire; the run used to die on it, discarding
     -- what it had already evaluated (#1060)
-    describe "--park-stuck" $ do
+    describe "--partial" $ do
       let stuck = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], times(x) -> [[ L> L_number_times ]] ]], @ -> 2.times(3).plus([[ L> Sym_arg_0 ]]) ]]"
       it "fails on an atom that cannot fire without the flag" $
         withStdin stuck $
@@ -1158,20 +1158,20 @@ spec = do
       it "prints the residue with the stuck application intact and exits successfully" $
         withStdin stuck $
           testCLISucceeded
-            ["dataize", "--park-stuck", "--sweet", "--hide-rho"]
+            ["dataize", "--partial", "--sweet", "--hide-rho"]
             ["⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
 
       it "keeps what was evaluated before the stuck site in the residue" $
         withStdin stuck $
           testCLISucceeded
-            ["dataize", "--park-stuck", "--sweet"]
+            ["dataize", "--partial", "--sweet"]
             ["as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
 
-      it "records every parked site in --evaluations with no result" $
+      it "records every stuck site in --evaluations with no result" $
         withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
           hClose stream
           withStdin stuck $
-            testCLISucceeded ["dataize", "--park-stuck", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+            testCLISucceeded ["dataize", "--partial", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
           records <- readUtf8 path
           lines records
             `shouldBe` [ "L_number_times\t⟦ x ↦ 3 ⟧\t6"
@@ -1181,17 +1181,17 @@ spec = do
 
       it "still prints bytes when nothing gets stuck" $
         withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
-          testCLISucceeded ["dataize", "--park-stuck"] ["40-26-00-00-00-00-00-00"]
+          testCLISucceeded ["dataize", "--partial"] ["40-26-00-00-00-00-00-00"]
 
       it "prints the chain of steps ending in the residue with --sequence" $
         withStdin stuck $
           testCLISucceeded
-            ["dataize", "--park-stuck", "--sequence", "--sweet", "--hide-rho", "--flat"]
+            ["dataize", "--partial", "--sequence", "--sweet", "--hide-rho", "--flat"]
             ["2.times( 3 ).plus( ⟦ λ ⤍ Sym_arg_0 ⟧ )", "⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
 
       it "still stops on the terminator ⊥, since a wrong operand is not a stuck atom" $
         withStdin "[[ ]]" $
-          testCLIFailed ["dataize", "--park-stuck"] ["terminator ⊥"]
+          testCLIFailed ["dataize", "--partial"] ["terminator ⊥"]
 
     describe "fails" $ do
       it "with --output != latex and --nonumber" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -11,9 +11,10 @@ import Control.Exception (SomeException)
 import Control.Monad
 import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Maybe (fromMaybe)
-import Dataize (DataizeContext (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph)
-import Deps (Term (TeExpression), dontSaveEval, dontSaveStep)
+import Data.Maybe (fromMaybe, isJust)
+import Data.IORef (modifyIORef, newIORef, readIORef)
+import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph)
+import Deps (Evaluation (..), Term (TeExpression), dontSaveEval, dontSaveStep)
 import Functions (buildTerm)
 import Matcher (substEmpty)
 import Parser (parseExpressionThrows)
@@ -27,7 +28,7 @@ import Yaml qualified
 -- dataization rules (#909): a hidden overlap surfaces as a nondeterministic
 -- failure instead of staying silently green.
 defaultDataizeContext :: Expression -> DataizeContext
-defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True buildTerm dontSaveStep dontSaveEval
+defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval
 
 test :: (Eq a, Show a) => ((Expression, NonEmpty Rewritten) -> Expression -> String -> DataizeContext -> IO ((a, [Rewritten]), String)) -> [(String, Expression, Expression, a)] -> Spec
 test func useCases =
@@ -50,7 +51,7 @@ testDataize useCases =
       expr <- parseExpressionThrows src
       loc' <- parseExpressionThrows loc
       (value, _) <- dataize expr (defaultDataizeContext loc')
-      value `shouldBe` res
+      value `shouldBe` Dataized res
 
 -- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
 -- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
@@ -101,7 +102,18 @@ testAtom useCases =
       expr <- parseExpressionThrows (primitives src)
       loc <- parseExpressionThrows "Q"
       (value, _) <- dataize expr (defaultDataizeContext loc)
-      value `shouldBe` res
+      value `shouldBe` Dataized res
+
+-- Dataize under '--park-stuck', collecting every report 𝔼 makes on the way,
+-- in the order it makes them
+parked :: String -> IO ((Outcome, [Rewritten]), [Evaluation])
+parked src = do
+  expr <- parseExpressionThrows (primitives src)
+  reports <- newIORef []
+  let ctx = (defaultDataizeContext ExRoot){_parkStuck = True, _saveEval = \report -> modifyIORef reports (report :)}
+  result <- dataize expr ctx
+  collected <- readIORef reports
+  pure (result, reverse collected)
 
 -- An atom with no answer yields ⊥, which stops the whole dataization
 testStuckAtom :: [(String, String)] -> Spec
@@ -390,8 +402,57 @@ spec = do
   describe "stops a dataization that never reaches bytes" $
     it "fails on the step limit instead of morphing forever" $ do
       expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
-      dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True buildTerm dontSaveStep dontSaveEval)
+      dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True False buildTerm dontSaveStep dontSaveEval)
         `shouldThrow` (\e -> "--max-steps=40" `isInfixOf` show (e :: SomeException))
+
+  -- An atom phino does not know — a placeholder such as ⟦ λ ⤍ Sym_arg_0 ⟧
+  -- standing in for a data input (#1060) — fails the run, and so does a known
+  -- atom whose input reaches one. Under '_parkStuck' the run ends on the residue
+  -- instead: the working expression the spine had reached, with the stuck
+  -- application intact and everything the calculus demanded before it already
+  -- evaluated, while 𝔼 reports each parked site with no result.
+  describe "parks an atom that cannot fire (--park-stuck)" $ do
+    -- the parser gives every formation its void ρ
+    let placeholder = ExFormation [BiLambda (Function "Sym_arg_0"), BiVoid AtRho]
+    it "fails on it without the flag, naming the unknown atom" $ do
+      expr <- parseExpressionThrows (primitives "2.times(3).plus([[ L> Sym_arg_0 ]])")
+      dataize expr (defaultDataizeContext ExRoot)
+        `shouldThrow` (\e -> "Atom 'Sym_arg_0' does not exist" `isInfixOf` show (e :: SomeException))
+    it "leaves the saturated application of the known atom in place, the placeholder inside it" $ do
+      ((outcome, _), _) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+      case outcome of
+        Parked (ExFormation bds) -> do
+          bds `shouldContain` [BiLambda (Function "L_number_plus")]
+          bds `shouldContain` [BiTau (AtLabel "x") placeholder]
+        other -> expectationFailure ("expected a parked formation, got " ++ show other)
+    it "keeps what was evaluated before the stuck site in the residue" $ do
+      ((outcome, _), _) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+      case outcome of
+        Parked (ExFormation bds) -> do
+          let rho = [value | BiTau AtRho value <- bds]
+          length rho `shouldBe` 1
+          -- 2 × 3 = 6.0, whose IEEE 754 bytes are 40-18-00-00-00-00-00-00
+          show rho `shouldContain` show (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
+          -- the times application is gone: ρ is the number it produced, its 'as-bytes' bound
+          [() | ExFormation inner <- rho, BiTau (AtLabel "as-bytes") _ <- inner] `shouldBe` [()]
+        other -> expectationFailure ("expected a parked formation, got " ++ show other)
+    it "reports the firing that succeeded with its result and every parked site without one" $ do
+      (_, reports) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+      map (._function) reports `shouldBe` ["L_number_times", "Sym_arg_0", "L_number_plus"]
+      map (isJust . (._result)) reports `shouldBe` [True, False, False]
+    it "parks an unknown atom dataized directly" $ do
+      ((outcome, chain), reports) <- parked "[[ L> Sym_arg_0 ]]"
+      outcome `shouldBe` Parked placeholder
+      map (._function) reports `shouldBe` ["Sym_arg_0"]
+      map fst chain `shouldEndWith` [placeholder]
+    it "still reaches bytes when nothing is stuck" $ do
+      ((outcome, _), reports) <- parked "2.times(3)"
+      outcome `shouldBe` Dataized (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
+      map (._function) reports `shouldBe` ["L_number_times"]
+    it "stops on the terminator ⊥ as before, since a wrong operand is not a stuck atom" $ do
+      expr <- parseExpressionThrows (primitives (raw "20-1F" ++ ".and( " ++ raw "CA-FE-BE" ++ " )"))
+      dataize expr ((defaultDataizeContext ExRoot){_parkStuck = True})
+        `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
   -- '_maxDepth'/'_maxCycles' bound the normalization rewriter that a 'box' or
   -- 'norm' dataization step splices in (see 'normalized'); with
@@ -403,12 +464,12 @@ spec = do
     forM_
       [
         ( "--max-cycles"
-        , DataizeContext ExRoot 25 0 (Steps 250 0) True True buildTerm dontSaveStep dontSaveEval
+        , DataizeContext ExRoot 25 0 (Steps 250 0) True True False buildTerm dontSaveStep dontSaveEval
         , "--max-cycles=0"
         )
       ,
         ( "--max-depth"
-        , DataizeContext ExRoot 0 25 (Steps 250 0) True True buildTerm dontSaveStep dontSaveEval
+        , DataizeContext ExRoot 0 25 (Steps 250 0) True True False buildTerm dontSaveStep dontSaveEval
         , "--max-depth=0"
         )
       ]
@@ -418,14 +479,14 @@ spec = do
             dataize expr ctx `shouldThrow` (\e -> message `isInfixOf` show (e :: SomeException))
       )
     forM_
-      [ ("--max-cycles", DataizeContext ExRoot 25 0 (Steps 250 0) False True buildTerm dontSaveStep dontSaveEval)
-      , ("--max-depth", DataizeContext ExRoot 0 25 (Steps 250 0) False True buildTerm dontSaveStep dontSaveEval)
+      [ ("--max-cycles", DataizeContext ExRoot 25 0 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval)
+      , ("--max-depth", DataizeContext ExRoot 0 25 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval)
       ]
       ( \(flag, ctx) ->
           it ("does not throw without --depth-sensitive even once " ++ flag ++ " is exhausted") $ do
             expr <- parseExpressionThrows boxed
             (value, _) <- dataize expr ctx
-            value `shouldBe` BtOne "00"
+            value `shouldBe` Dataized (BtOne "00")
       )
 
   describe "labels every step with a defined rule or operation" $ do

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -9,7 +9,7 @@ module DataizeSpec (spec) where
 import AST
 import Control.Exception (SomeException)
 import Control.Monad
-import Data.IORef (modifyIORef, newIORef, readIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe, isJust)
@@ -110,7 +110,7 @@ parked :: String -> IO ((Outcome, [Rewritten]), [Evaluation])
 parked src = do
   expr <- parseExpressionThrows (primitives src)
   reports <- newIORef []
-  let ctx = (defaultDataizeContext ExRoot){_parkStuck = True, _saveEval = \report -> modifyIORef reports (report :)}
+  let ctx = (defaultDataizeContext ExRoot){_parkStuck = True, _saveEval = \report -> modifyIORef' reports (report :)}
   result <- dataize expr ctx
   collected <- readIORef reports
   pure (result, reverse collected)

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -9,10 +9,10 @@ module DataizeSpec (spec) where
 import AST
 import Control.Exception (SomeException)
 import Control.Monad
+import Data.IORef (modifyIORef, newIORef, readIORef)
 import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe, isJust)
-import Data.IORef (modifyIORef, newIORef, readIORef)
 import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph)
 import Deps (Evaluation (..), Term (TeExpression), dontSaveEval, dontSaveStep)
 import Functions (buildTerm)

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -104,13 +104,13 @@ testAtom useCases =
       (value, _) <- dataize expr (defaultDataizeContext loc)
       value `shouldBe` Dataized res
 
--- Dataize under '--park-stuck', collecting every report 𝔼 makes on the way,
--- in the order it makes them
-parked :: String -> IO ((Outcome, [Rewritten]), [Evaluation])
-parked src = do
+-- Dataize under '--partial', collecting every report 𝔼 makes on the way, in
+-- the order it makes them
+partially :: String -> IO ((Outcome, [Rewritten]), [Evaluation])
+partially src = do
   expr <- parseExpressionThrows (primitives src)
   reports <- newIORef []
-  let ctx = (defaultDataizeContext ExRoot){_parkStuck = True, _saveEval = \report -> modifyIORef' reports (report :)}
+  let ctx = (defaultDataizeContext ExRoot){_partial = True, _saveEval = \report -> modifyIORef' reports (report :)}
   result <- dataize expr ctx
   collected <- readIORef reports
   pure (result, reverse collected)
@@ -407,11 +407,11 @@ spec = do
 
   -- An atom phino does not know — a placeholder such as ⟦ λ ⤍ Sym_arg_0 ⟧
   -- standing in for a data input (#1060) — fails the run, and so does a known
-  -- atom whose input reaches one. Under '_parkStuck' the run ends on the residue
+  -- atom whose input reaches one. Under '_partial' the run ends on the residue
   -- instead: the working expression the spine had reached, with the stuck
   -- application intact and everything the calculus demanded before it already
   -- evaluated, while 𝔼 reports each parked site with no result.
-  describe "parks an atom that cannot fire (--park-stuck)" $ do
+  describe "partially evaluates around an atom that cannot fire (--partial)" $ do
     -- the parser gives every formation its void ρ
     let placeholder = ExFormation [BiLambda (Function "Sym_arg_0"), BiVoid AtRho]
     it "fails on it without the flag, naming the unknown atom" $ do
@@ -419,39 +419,39 @@ spec = do
       dataize expr (defaultDataizeContext ExRoot)
         `shouldThrow` (\e -> "Atom 'Sym_arg_0' does not exist" `isInfixOf` show (e :: SomeException))
     it "leaves the saturated application of the known atom in place, the placeholder inside it" $ do
-      ((outcome, _), _) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+      ((outcome, _), _) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
       case outcome of
-        Parked (ExFormation bds) -> do
+        Residual (ExFormation bds) -> do
           bds `shouldContain` [BiLambda (Function "L_number_plus")]
           bds `shouldContain` [BiTau (AtLabel "x") placeholder]
-        other -> expectationFailure ("expected a parked formation, got " ++ show other)
+        other -> expectationFailure ("expected a residual formation, got " ++ show other)
     it "keeps what was evaluated before the stuck site in the residue" $ do
-      ((outcome, _), _) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+      ((outcome, _), _) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
       case outcome of
-        Parked (ExFormation bds) -> do
+        Residual (ExFormation bds) -> do
           let rho = [value | BiTau AtRho value <- bds]
           length rho `shouldBe` 1
           -- 2 × 3 = 6.0, whose IEEE 754 bytes are 40-18-00-00-00-00-00-00
           show rho `shouldContain` show (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
           -- the times application is gone: ρ is the number it produced, its 'as-bytes' bound
           [() | ExFormation inner <- rho, BiTau (AtLabel "as-bytes") _ <- inner] `shouldBe` [()]
-        other -> expectationFailure ("expected a parked formation, got " ++ show other)
-    it "reports the firing that succeeded with its result and every parked site without one" $ do
-      (_, reports) <- parked "2.times(3).plus([[ L> Sym_arg_0 ]])"
+        other -> expectationFailure ("expected a residual formation, got " ++ show other)
+    it "reports the firing that succeeded with its result and every stuck site without one" $ do
+      (_, reports) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
       map (._function) reports `shouldBe` ["L_number_times", "Sym_arg_0", "L_number_plus"]
       map (isJust . (._result)) reports `shouldBe` [True, False, False]
-    it "parks an unknown atom dataized directly" $ do
-      ((outcome, chain), reports) <- parked "[[ L> Sym_arg_0 ]]"
-      outcome `shouldBe` Parked placeholder
+    it "leaves an unknown atom dataized directly as the whole residue" $ do
+      ((outcome, chain), reports) <- partially "[[ L> Sym_arg_0 ]]"
+      outcome `shouldBe` Residual placeholder
       map (._function) reports `shouldBe` ["Sym_arg_0"]
       map fst chain `shouldEndWith` [placeholder]
     it "still reaches bytes when nothing is stuck" $ do
-      ((outcome, _), reports) <- parked "2.times(3)"
+      ((outcome, _), reports) <- partially "2.times(3)"
       outcome `shouldBe` Dataized (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
       map (._function) reports `shouldBe` ["L_number_times"]
     it "stops on the terminator ⊥ as before, since a wrong operand is not a stuck atom" $ do
       expr <- parseExpressionThrows (primitives (raw "20-1F" ++ ".and( " ++ raw "CA-FE-BE" ++ " )"))
-      dataize expr ((defaultDataizeContext ExRoot){_parkStuck = True})
+      dataize expr ((defaultDataizeContext ExRoot){_partial = True})
         `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
   -- '_maxDepth'/'_maxCycles' bound the normalization rewriter that a 'box' or


### PR DESCRIPTION
Closes #1060

## What

`dataize` used to abort on an atom it cannot execute: the catch-all in `atom` threw `Atom '…' does not exist`, discarding the partially reduced expression and reporting nothing about where it got stuck. A caller that replaces data inputs with placeholder formations such as `⟦ λ ⤍ Sym_arg_0 ⟧` on purpose (the EO compiler's build-time lowering) had no phino mode that evaluates what literals decide and keeps the rest.

This adds `dataize --partial`: dataization becomes partial evaluation. What the known inputs decide is computed; the rest survives as the residual program. An atom that cannot fire (its λ function is unknown, or one of its inputs reaches such an atom) stays in place as a normal-form subterm, the run exits 0 and prints the residual program through the usual result output (`--sweet`, `--hide-rho`, `--focus`, `--sequence` all apply). Without the flag the run fails exactly as before, with the same message.

```
$ phino dataize --partial --sweet --hide-rho partial.phi   # φ ↦ 2.times(3).plus(⟦ λ ⤍ Sym_arg_0 ⟧)
⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧
```

Each stuck site also lands in the `--evaluations` file (#1055) as a record with the first two fields only, no result term, so the caller learns the stuck sites without parsing the residual program. The inner unknown atom is reported before the known atom whose input reached it, matching the nested order of ordinary firings:

```
L_number_times	⟦ x ↦ 3 ⟧	6
Sym_arg_0	⟦⟧
L_number_plus	⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧
```

## How

* `atom`'s catch-all throws a typed `Stuck` signal instead of a `userError`. Each frame of the 𝕄/𝔻 spine (`morph`, `dataize'`) wraps its body in `parking`, which turns the first `Stuck` it sees into `StuckAt` carrying the frame's derivation chain; outer frames let `StuckAt` pass, since their chains are prefixes. Side-computations that run on a chain of their own (`_dataize` inside atoms, `_morph` premises) strip the chain back off with `unparked`, so the spine frame around them attaches the right one. The head of the resulting chain is the residual program.
* `dataize` now returns an `Outcome` (`Dataized Bytes | Residual Expression`) with the chain; without `_partial`, `StuckAt` is rethrown and shows the old message.
* `Evaluation._result` becomes `Maybe Expression`; `_evaluate` reports a stuck firing with `Nothing` under `_partial`, then rethrows.
* CLI: `--partial` flag on `dataize`, `printFocused` helper shared with `printRewrittens`.

## Notes

Evaluation stays demand-driven, as the calculus prescribes: an argument nothing asked for before the run got stuck (e.g. `2.times(3)` in `⟦ λ ⤍ Sym ⟧.plus(2.times(3))`) is left in normal form in the residual program for the next iteration rather than evaluated speculatively. A wrong operand still yields ⊥ and stops the run as before; only an atom that cannot fire is left in place.

Tests: 7 new unit cases in `DataizeSpec`, 7 new CLI cases in `CLISpec`; full suite is 2169 examples, 0 failures with `-Werror`. README documents the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br5aAMQXJkacBohfGsensK