### PR TITLE
fix(sugar): #1067 unescape a string literal before desugaring it

### DIFF
--- a/src/Bytes.hs
+++ b/src/Bytes.hs
@@ -12,6 +12,7 @@ module Bytes
   , strToBts
   , bytesToBts
   , btsToStr
+  , unescapeStr
   , btsToNum
   , btsToUnescapedStr
   , btsAnd
@@ -197,6 +198,39 @@ btsToStr bytes = escapeStr (btsToUnescapedStr bytes)
         escapeChar c
           | isPrint c && c /= '\\' && c /= '"' = [c]
           | otherwise = printf "\\x%02x" (ord c)
+
+-- The inverse of the escaping that 'btsToStr' applies, so that a sweet string
+-- literal can be turned back into the very bytes it was printed from. A
+-- backslash that starts no escape 'btsToStr' can produce is kept as it stands,
+-- together with the character behind it
+-- >>> unescapeStr "hello"
+-- "hello"
+-- >>> unescapeStr "h\\\""
+-- "h\""
+-- >>> unescapeStr "e\\ne"
+-- "e\ne"
+-- >>> unescapeStr "\\\\"
+-- "\\"
+-- >>> unescapeStr "\\t"
+-- "\t"
+-- >>> unescapeStr "\\x01"
+-- "\SOH"
+unescapeStr :: String -> String
+unescapeStr = go
+  where
+    go :: String -> String
+    go "" = ""
+    go ('\\' : 'x' : high : low : rest)
+      | Just code <- hexPair high low = chr code : go rest
+    go ('\\' : escaped : rest)
+      | Just unescaped <- lookup escaped escapes = unescaped : go rest
+    go (char : rest) = char : go rest
+    hexPair :: Char -> Char -> Maybe Int
+    hexPair high low = case readHex [high, low] of
+      [(code, "")] -> Just code
+      _ -> Nothing
+    escapes :: [(Char, Char)]
+    escapes = [('"', '"'), ('\\', '\\'), ('n', '\n'), ('t', '\t')]
 
 -- >>> btsToUnescapedStr (BtMany ["01", "02"])
 -- "\SOH\STX"

--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -10,7 +10,7 @@
 module Sugar (toSalty, withSugarType, withoutRho, SugarType (..), ToSalty) where
 
 import AST
-import Bytes (numToBts, strToBts)
+import Bytes (numToBts, strToBts, unescapeStr)
 import CST
 import Misc (toDouble)
 
@@ -180,7 +180,7 @@ instance ToSalty EXPRESSION where
     saltifyPrimitive
       (toCST (BaseObject "string") (indent + 1, EOL))
       (toCST (BaseObject "bytes") (indent + 2, EOL))
-      (toCST (ExFormation [BiDelta (strToBts str)]) (indent + 2, EOL))
+      (toCST (ExFormation [BiDelta (strToBts (unescapeStr str))]) (indent + 2, EOL))
       tab
       rhos
   toSalty EX_PHI_MEET{..} = EX_PHI_MEET prefix idx (toSalty expr)

--- a/test/BytesSpec.hs
+++ b/test/BytesSpec.hs
@@ -21,6 +21,7 @@ import Bytes
   , bytesToBts
   , numToBts
   , strToBts
+  , unescapeStr
   )
 import Control.Exception (evaluate)
 import Control.Monad (forM_)
@@ -86,6 +87,40 @@ spec = do
       ]
       ( \(desc, bts, str) ->
           it desc $ btsToStr bts `shouldBe` str
+      )
+
+  describe "unescapeStr" $
+    forM_
+      [ ("empty", "", "")
+      , ("nothing to unescape", "hello", "hello")
+      , ("double quote", "h\\\"", "h\"")
+      , ("backslash", "\\\\", "\\")
+      , ("newline", "e\\ne", "e\ne")
+      , ("tab", "\\t", "\t")
+      , ("hex escape", "\\x01", "\SOH")
+      , ("uppercase hex escape", "\\xFF", "\255")
+      , ("backslash before an escape", "\\\\n", "\\n")
+      , ("unknown escape is kept as it stands", "\\q", "\\q")
+      , ("trailing backslash is kept", "a\\", "a\\")
+      , ("truncated hex escape is kept", "\\x0", "\\x0")
+      ]
+      ( \(desc, escaped, unescaped) ->
+          it desc $ unescapeStr escaped `shouldBe` unescaped
+      )
+
+  describe "btsToStr/unescapeStr round trip" $
+    forM_
+      [ ("empty", BtEmpty)
+      , ("plain word", BtMany ["68", "65", "6C", "6C", "6F"])
+      , ("double quote", BtOne "22")
+      , ("backslash", BtOne "5C")
+      , ("newline", BtOne "0A")
+      , ("tab", BtOne "09")
+      , ("non-printable", BtMany ["01", "02"])
+      , ("text around a newline", BtMany ["65", "0A", "65"])
+      ]
+      ( \(desc, bts) ->
+          it desc $ strToBts (unescapeStr (btsToStr bts)) `shouldBe` bts
       )
 
   describe "btsToUnescapedStr" $

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -412,6 +412,10 @@ spec = do
       withStdin "[[foo ↦ x]]" $
         testCLISucceeded ["rewrite"] ["⟦ foo ↦ ξ.x, ρ ↦ ∅ ⟧"]
 
+    it "keeps the bytes of a string intact while desugaring it" $
+      withStdin "⟦ φ ↦ Φ.string(as-bytes ↦ Φ.bytes(data ↦ ⟦ Δ ⤍ 65-0A-65, ρ ↦ ∅ ⟧)), ρ ↦ ∅ ⟧" $
+        testCLISucceeded ["rewrite", "--flat"] ["Δ ⤍ 65-0A-65"]
+
     it "rewrites with single rule" $
       withStdin "T(x -> Q.y)" $
         testCLISucceeded ["rewrite", "--rule=resources/normalize/dc.yaml"] ["⊥"]

--- a/test/SugarSpec.hs
+++ b/test/SugarSpec.hs
@@ -222,6 +222,21 @@ spec = do
         , EX_STRING "hi" (TAB 1) []
         , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      data ↦ ⟦\n        Δ ⤍ 68-69,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
+      ,
+        ( "EX_STRING unescapes a newline instead of taking its escape literally"
+        , EX_STRING "e\\ne" (TAB 1) []
+        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      data ↦ ⟦\n        Δ ⤍ 65-0A-65,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        )
+      ,
+        ( "EX_STRING unescapes a quote and a backslash into single bytes"
+        , EX_STRING "\\\"\\\\" (TAB 1) []
+        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      data ↦ ⟦\n        Δ ⤍ 22-5C,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        )
+      ,
+        ( "EX_STRING unescapes a hex escape back into its byte"
+        , EX_STRING "\\x01" (TAB 1) []
+        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      data ↦ ⟦\n        Δ ⤍ 01-,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        )
       ]
       (\(desc, sweetExpr, expected) -> it desc (render (toSalty sweetExpr) `shouldBe` expected))
 


### PR DESCRIPTION
Closes #1067.

The sweet printer escapes the bytes of a `Φ.string` (`CST.hs:343` renders
a `DataString` as `EX_STRING (btsToStr bts)`, and `btsToStr` escapes `"`,
`\`, `\n`, `\t` and every unprintable character), but the desugarer at
`Sugar.hs:183` fed that escaped literal straight back to `strToBts`,
which takes the characters as they stand. A text therefore grew on every
round trip: a newline became `5C-6E`, a quote became `5C-22` and a
backslash doubled.

## Changes

- `Bytes.unescapeStr` — the inverse of the escaping `btsToStr` applies.
  It undoes `\"`, `\\`, `\n`, `\t` and `\xNN`; a backslash that starts no
  escape `btsToStr` can produce is kept as it stands, together with the
  character behind it.
- `Sugar.toSalty` now calls `strToBts (unescapeStr str)`, so the
  desugarer reads an escaped literal the same way `quotedStr`
  (`Parser.hs:196`) already does. The number path next to it was already
  symmetric and is untouched.

Before:

```
$ echo '⟦ φ ↦ Φ.string(as-bytes ↦ Φ.bytes(data ↦ ⟦ Δ ⤍ 65-0A-65, ρ ↦ ∅ ⟧)), ρ ↦ ∅ ⟧' | phino rewrite --flat
⟦ φ ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 65-5C-6E-65, ρ ↦ ∅ ⟧ ) ), ρ ↦ ∅ ⟧
```

After: the bytes come back as `65-0A-65`.

## Tests

- `BytesSpec` — 12 `unescapeStr` cases plus an 8-case
  `btsToStr`/`unescapeStr` round trip.
- `SugarSpec` — three `toSalty EX_STRING` cases covering a newline, a
  quote with a backslash, and a hex escape.
- `CLISpec` — the end-to-end case from the issue.

All five new tests fail on `master` (the CLI one with exactly the
`65-5C-6E-65` from the issue) and pass with this change. Full suite:
2193 examples, 0 failures, built with `-Werror`; `fourmolu --mode check`
and `hlint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzXTPrXi7t69nQ2y9pBRAt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzXTPrXi7t69nQ2y9pBRAt)_