### PR TITLE
fix(dataize): guard asNumber against non-8-byte operands (#1072)

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -457,10 +457,12 @@ _dataize expr univ state ctx@DataizeContext{_buildTerm = buildTerm} = case univ 
 
 -- A number atom only operates on numeric data. Empty bytes — a genuine
 -- zero-length byte array ⟦Δ ⤍ --⟧ — carry no number, so the operand is rejected
--- and the atom yields ⊥.
+-- and the atom yields ⊥. So does any byte array whose length is not 8: 'btsToNum'
+-- throws on such arrays, so the size is checked up front, exactly like 'asInt'.
 asNumber :: Bytes -> Maybe Double
-asNumber BtEmpty = Nothing
-asNumber bts = Just (either toDouble id (btsToNum bts))
+asNumber bts
+  | btsSize bts /= 8 = Nothing
+  | otherwise = Just (either toDouble id (btsToNum bts))
 
 -- An operand that EO reads as a Java 'int' — a shift distance or a slice bound.
 -- 'Expect.at(…).that(Integer)' turns down anything but a whole number inside the

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -7,7 +7,7 @@ module Functions (buildTerm, execFunctions) where
 
 import AST
 import Builder
-import Bytes (btsToNum, btsToUnescapedStr, numToBts, strToBts)
+import Bytes (btsSize, btsToNum, btsToUnescapedStr, numToBts, strToBts)
 import Control.Exception (throwIO)
 import Control.Monad (when)
 import qualified Data.ByteString.Char8 as B
@@ -63,7 +63,11 @@ argToString :: Y.ExtraArgument -> Subst -> IO String
 argToString arg subst = argToBytes arg subst <&> btsToUnescapedStr
 
 argToNumber :: Y.ExtraArgument -> Subst -> IO Double
-argToNumber arg subst = argToBytes arg subst <&> either toDouble id . btsToNum
+argToNumber arg subst = do
+  bts <- argToBytes arg subst
+  case btsSize bts of
+    8 -> pure (either toDouble id (btsToNum bts))
+    _ -> throwIO (userError (printf "Expected 8 bytes for a number, got %d" (btsSize bts)))
 
 _contextualize :: BuildTermMethod
 _contextualize [Y.ArgExpression expr, Y.ArgExpression context] subst = do

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -752,6 +752,14 @@ spec = do
       , ("cannot divide by a non-numeric divisor", "5.div( " ++ raw "--" ++ " )")
       , ("cannot compare against a non-numeric threshold", "5.gt( " ++ raw "--" ++ " )")
       , ("cannot test equality against a non-numeric operand", "5.eq( " ++ raw "--" ++ ", 6 )")
+      , -- A number atom also rejects a non-empty operand whose byte array is not
+        -- 8 bytes long (e.g. 2 or 5 bytes): such an array carries no number, and
+        -- the atom must yield ⊥ instead of crashing on 'btsToNum' (issue #1072).
+        ("cannot add a 5-byte operand", "5.plus( " ++ raw "68-65-6C-6C-6F" ++ " )")
+      , ("cannot multiply by a 2-byte operand", "5.times( " ++ raw "20-1F" ++ " )")
+      , ("cannot divide by a 3-byte divisor", "5.div( " ++ raw "CA-FE-BE" ++ " )")
+      , ("cannot compare against a 4-byte threshold", "5.gt( " ++ raw "FF-FF-FF-FF" ++ " )")
+      , ("cannot test equality against a 6-byte operand", "5.eq( " ++ raw "CA-FE-BE-20-1F-EE" ++ ", 6 )")
       , -- 'right' rejects a shift distance that is not a plain 8-byte integer;
         -- empty bytes carry no such integer, so the shift atom is stuck too.
         ("cannot shift right by a non-integer distance", raw "C0-43-00-00-00-00-00-00" ++ ".right( " ++ raw "--" ++ " )")

--- a/test/FunctionsSpec.hs
+++ b/test/FunctionsSpec.hs
@@ -206,6 +206,12 @@ spec = describe "Functions" $ do
       , ("number fails on an expression that is not a string", "number", [ArgExpression (DataNumber (numToBts 1))], "expects expression to be 'Φ.string'")
       , ("number fails on the wrong number of arguments", "number", [], "number() requires exactly 1 argument")
       ,
+        ( "sum fails on a byte array that is not 8 bytes long"
+        , "sum"
+        , [ArgExpression (DataNumber (BtMany ["68", "65", "6C", "6C", "6F"]))]
+        , "Expected 8 bytes for a number, got 5"
+        )
+      ,
         ( "an unsupported function name fails with a descriptive message"
         , "no-such-function"
         , []


### PR DESCRIPTION
Fixes #1072.

## Problem

`asNumber` in `src/Dataize.hs:461-463` passed any non-empty bytes straight into
`btsToNum`, which throws `error "Expected 8 bytes for conversion"` on arrays
whose length is not 8 (`src/Bytes.hs:113`). The sibling `asInt`
(`Dataize.hs:468-473`) guards with `btsSize bts /= 8 -> Nothing` and is safe,
so `asNumber` was the asymmetric one that crashed instead of yielding ⊥.

Repro:
```
$ phino dataize --max-steps=60 \
    '⟦ φ ↦ ⟦ λ ⤍ L_number_plus, ρ ↦ ⟦ Δ ⤍ 40-14-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 68-65 ⟧ ⟧ ⟧'
[ERROR]: Expected 8 bytes for conversion, got 2
```

Affected all number atoms (`L_number_plus/times/div/gt/eq`) plus the `sum`
where-function (`Functions.argToNumber`, which called `btsToNum` unguarded).

## Fix

- `src/Dataize.hs` — `asNumber` now rejects any array whose size is not 8
  (`Nothing`, i.e. the terminator), exactly like `asInt`.
- `src/Functions.hs` — `argToNumber` checks `btsSize` and raises a descriptive
  `userError` instead of letting `btsToNum` throw a raw `error`.

## Changes

- `src/Dataize.hs` — size guard in `asNumber`.
- `src/Functions.hs` — size check in `argToNumber` (+ `btsSize` import).

## Tests

- `test/DataizeSpec.hs` — five `testStuckAtom` cases: `plus`/`times`/`div`/`gt`/`eq`
  on non-empty non-8-byte operands now yield ⊥ (not a crash).
- `test/FunctionsSpec.hs` — `sum` on a 5-byte byte array raises
  "Expected 8 bytes for a number, got 5".

Note: the pre-existing 13 `LocatorSpec` failures (GHC `HasCallStack` backtrace
noise, issue #1077) are unrelated to this change and reproduce on clean master.
