### PR TITLE
fix(cli): seed the generator in explain so --shuffle is reproducible (#1086)

### DIFF
--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -272,6 +272,7 @@ explainParser =
             <*> optDataize
             <*> optContextualize
             <*> optShuffle
+            <*> optSeed
             <*> optTarget
         )
 

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -199,6 +199,7 @@ runDataize OptsDataize{..} = do
 
 runExplain :: OptsExplain -> IO ()
 runExplain OptsExplain{..} = do
+  setStdGen (mkStdGen _seed)
   validateOpts
   explained >>= printOut _targetFile
   where

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -120,6 +120,7 @@ data OptsExplain = OptsExplain
   , _dataize :: Bool
   , _contextualize :: Bool
   , _shuffle :: Bool
+  , _seed :: Int
   , _targetFile :: Maybe FilePath
   }
 

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1291,6 +1291,23 @@ spec = do
         ["explain", "--rule=resources/normalize/copy.yaml", "--rule=resources/normalize/alpha.yaml"]
         ["\\phinoNormalizationRule{copy}", "\\phinoNormalizationRule{alpha}"]
 
+    it "reproduces the same shuffle order for the same --seed" $ do
+      let args =
+            [ "explain"
+            , "--shuffle"
+            , "--seed=42"
+            , rule "swap-a.yaml"
+            , rule "swap-b.yaml"
+            ]
+      (firstRun, _) <- withStdout (runCLI args)
+      (secondRun, _) <- withStdout (runCLI args)
+      firstRun `shouldBe` secondRun
+
+    it "accepts --seed flag" $
+      testCLISucceeded
+        ["explain", "--seed=7", "--normalize"]
+        ["\\phinoNormalizationRule{alpha}"]
+
     it "explains normalization rules" $
       testCLISucceeded
         ["explain", "--normalize"]


### PR DESCRIPTION
Fixes #1086.

## Problem

`runExplain` (`src/CLI/Runners.hs:200`) never called `setStdGen`, and
`OptsExplain` (`src/CLI/Types.hs:114-124`) had no seed field, so `explain
--shuffle` used `newStdGen` (OS-entropy-seeded) and produced a different rule
order on every run — unlike `rewrite`, which was already fixed for this in
#1016/#1025.

Repro:
```
$ phino explain --normalize --shuffle > a.tex
$ phino explain --normalize --shuffle > b.tex
$ diff a.tex b.tex   # differs
```

## Fix

Mirror the `rewrite` fix (#1025):
- `src/CLI/Types.hs` — add `_seed :: Int` to `OptsExplain`.
- `src/CLI/Parsers.hs` — add `optSeed` to `explainParser`.
- `src/CLI/Runners.hs` — call `setStdGen (mkStdGen _seed)` at the start of
  `runExplain`, before `getRules` shuffles.

## Changes

- `src/CLI/Types.hs` — `_seed` field on `OptsExplain`.
- `src/CLI/Parsers.hs` — `optSeed` wired into `explainParser`.
- `src/CLI/Runners.hs` — seed the generator before `getRules`.

## Tests

- `test/CLISpec.hs` — `explain --shuffle --seed=42` run twice gives identical
  output (same-seed reproducibility); `explain --seed=7 --normalize` accepted.
