### PR TITLE
fix(sugar): carry a meta binding through joinToBindings in PA_FORMATION (#1075)

### DIFF
--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -260,7 +260,7 @@ instance ToSalty PAIR where
       joinToBindings :: [ATTRIBUTE] -> BINDING -> BINDINGS
       joinToBindings [] BI_EMPTY{..} = BDS_EMPTY tab
       joinToBindings [] BI_PAIR{..} = BDS_PAIR eol tab pair bindings
-      joinToBindings [] BI_META{} = error "BI_META unexpected in joinToBindings"
+      joinToBindings [] BI_META{..} = BDS_META eol tab meta bindings
       joinToBindings (attr : rest) bd = BDS_PAIR eol tab (PA_VOID attr arrow EMPTY) (joinToBindings rest bd)
   toSalty pair = pair
 

--- a/test/SugarSpec.hs
+++ b/test/SugarSpec.hs
@@ -364,6 +364,30 @@ spec = do
                 RSB
             )
         )
+      ,
+        ( "PA_FORMATION with void params and a meta tail carries the meta binding through"
+        , PA_FORMATION
+            (AT_LABEL "x")
+            [AT_LABEL "a"]
+            ARROW
+            (EX_FORMATION LSB EOL (TAB 2) (BI_META (META NO_EXCL B "B") (BDS_EMPTY (TAB 2)) (TAB 2)) EOL (TAB 1) RSB)
+        , PA_TAU
+            (AT_LABEL "x")
+            ARROW
+            ( EX_FORMATION
+                LSB
+                EOL
+                (TAB 2)
+                ( BI_PAIR
+                    (PA_VOID (AT_LABEL "a") ARROW EMPTY)
+                    (BDS_META EOL (TAB 2) (META NO_EXCL B "B") (BDS_EMPTY (TAB 2)))
+                    (TAB 2)
+                )
+                EOL
+                (TAB 1)
+                RSB
+            )
+        )
       , ("default clause leaves a PA_VOID pair untouched", PA_VOID (AT_LABEL "x") ARROW QUESTION, PA_VOID (AT_LABEL "x") ARROW QUESTION)
       ]
       (\(desc, sweet, salty) -> it desc (toSalty sweet `shouldBe` salty))


### PR DESCRIPTION
Fixes #1075.

## Problem

`toSalty PA_FORMATION` (`src/Sugar.hs:254-264`) calls `joinToBindings`, whose
case for a trailing meta-binding hit `error "BI_META unexpected in
joinToBindings"` (`Sugar.hs:263`). A formation with void attributes followed by
a meta-binding — e.g. `[[ x(a, ^) -> [[ !B ]] ]]`, which the parser accepts —
crashed the whole CLI under the default SALTY output.

Repro:
```
$ phino rewrite '[[ x(a, ^) -> [[ !B ]] ]]'
[ERROR]: BI_META unexpected in joinToBindings
CallStack (from HasCallStack):
  error, called at src/Sugar.hs:263:37
```

## Fix

`joinToBindings [] BI_META{..}` now builds a `BDS_META` from the meta binding
instead of throwing — the same way the other converters already carry meta
bindings through (e.g. `promote` at `Sugar.hs:82`).

## Changes

- `src/Sugar.hs` — `joinToBindings [] BI_META{..} = BDS_META eol tab meta bindings`.

## Tests

- `test/SugarSpec.hs` — `PA_FORMATION` with void params and a meta tail desugars
  to a `BDS_META` tail (no crash); verified the CLI prints and round-trips the
  expression and `--output=latex` works too.
