### PR TITLE
fix(xmir): escape XML special characters in attribute values and listing (#1071)

### DIFF
--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -54,8 +54,8 @@ runRewrite OptsRewrite{..} = do
   logDebug (printf "Amount of rewriting cycles across all the rules: %d, per rule: %d" _maxCycles _maxDepth)
   let listing = case (rules, _inputFormat, _outputFormat) of
         ([], XMIR, XMIR) -> (\_ -> escapeXML input)
-        ([], _, _) -> const input
-        (_, _, _) -> (\rewritten -> P.printExpression' rewritten (_sugarType, UNICODE, _flat, _margin))
+        ([], _, _) -> (\_ -> escapeXMLText input)
+        (_, _, _) -> (\rewritten -> escapeXMLText (P.printExpression' rewritten (_sugarType, UNICODE, _flat, _margin)))
       xmirCtx = XmirContext _omitListing _omitComments listing
       printCtx = toPrintCtx xmirCtx foc
       exclude = (`F.exclude` excluded)
@@ -220,7 +220,7 @@ runMerge OptsMerge{..} = do
   inputs' <- traverse (readInput . Just) _inputs
   exprs <- traverse (`parseInput` _inputFormat) inputs'
   expr <- merge exprs
-  let listing = const (P.printExpression' expr (_sugarType, UNICODE, _flat, _margin))
+  let listing = const (escapeXMLText (P.printExpression' expr (_sugarType, UNICODE, _flat, _margin)))
       xmirCtx = XmirContext _omitListing _omitComments listing
       printCtx = toPrintCtx xmirCtx
   expr' <- printInFormat printCtx expr

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -15,6 +15,7 @@ module XMIR
   , xmirToPhi
   , defaultXmirContext
   , escapeXML
+  , escapeXMLText
   , XmirContext (XmirContext)
   )
 where
@@ -273,6 +274,17 @@ escapeXML = concatMap escapeChar
     escapeChar '\'' = "&apos;"
     escapeChar ch = [ch]
 
+-- Escape just the characters that are mandatory in XML text content ('&' and
+-- '<'); '>' and the quotes are optional there and staying literal keeps the
+-- content readable, e.g. the '->' arrow inside a <listing>.
+escapeXMLText :: String -> String
+escapeXMLText = concatMap escapeChar
+  where
+    escapeChar :: Char -> String
+    escapeChar '&' = "&amp;"
+    escapeChar '<' = "&lt;"
+    escapeChar ch = [ch]
+
 -- Add indentation (2 spaces per level).
 indent :: Int -> TB.Builder
 indent n = TB.fromText (T.replicate n (T.pack "  "))
@@ -322,7 +334,7 @@ printElement indentLevel (Element name attrs nodes) eol
   where
     attrsText =
       mconcat
-        [ TB.fromString " " <> TB.fromText (nameLocalName k) <> TB.fromString "=\"" <> TB.fromText v <> TB.fromString "\""
+        [ TB.fromString " " <> TB.fromText (nameLocalName k) <> TB.fromString "=\"" <> TB.fromText (T.pack (escapeXML (T.unpack v))) <> TB.fromString "\""
         | (k, v) <- M.toList attrs
         ]
 

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -21,7 +21,7 @@ import Files (allPathsIn)
 import GHC.Generics (Generic)
 import Parser (parseExpressionThrows)
 import System.FilePath (makeRelative)
-import Test.Hspec (Spec, anyException, describe, expectationFailure, it, runIO, shouldBe, shouldContain, shouldThrow)
+import Test.Hspec (Spec, anyException, describe, expectationFailure, it, runIO, shouldBe, shouldContain, shouldReturn, shouldThrow)
 import Text.XML (Document (..), Element (..), Node (NodeElement), Prologue (..))
 import Text.XML.Cursor qualified as C
 import XMIR (XmirContext (XmirContext), defaultXmirContext, escapeXML, expressionToXMIR, parseXMIRThrows, printXMIR, toName, xmirToPhi)
@@ -388,6 +388,13 @@ spec = do
       case formationArg of
         [argCur] -> C.attribute (toName "base") argCur `shouldBe` []
         _ -> expectationFailure "expected exactly one α1 argument"
+
+    it "escapes XML special characters in attribute values" $ do
+      expr <- parseExpressionThrows "[[ a&b -> \"<quoted>\" ]]"
+      xmir' <- expressionToXMIR expr defaultXmirContext
+      let out = printXMIR xmir'
+      out `shouldContain` "name=\"a&amp;b\""
+      xmirToPhi xmir' `shouldReturn` expr
 
   describe "XMIR malformed input containing a processing instruction" $
     it "embeds a processing instruction verbatim when rendering the offending element" $ do


### PR DESCRIPTION
Fixes #1071.

## Problem

`printXMIR` rendered attribute values verbatim, so an object name containing
`&`, `<`, `>`, `"`, `'` produced an invalid XML document:

```
$ echo '⟦ a&b ↦ ⟦ φ ↦ 1 ⟧, ρ ↦ ∅ ⟧' | phino rewrite --output=xmir
<listing>⟦ a&b ↦ ⟦⟧, ρ ↦ ∅ ⟧</listing>   ← invalid (&)
<o name="a&b">                            ← invalid (&)
```

Feeding that XMIR back into phino failed with `Couldn't parse given phi
expression`. The `<listing>` text had the same problem when the input
expression contained `&` or `<`.

## Fix

- `src/XMIR.hs` — `attrsText` in `printElement` now escapes attribute values
  with the existing `escapeXML`.
- `src/XMIR.hs` — new `escapeXMLText` (escapes only `&` and `<`, the characters
  that are mandatory in XML text) applied to the `<listing>` in `Runners.hs`;
  `>` and quotes stay literal so a phi listing like `[[ app -> [[]] ]]` remains
  readable (this preserves the existing CLI behavior for ordinary listings).
- `src/CLI/Runners.hs` — phi listings (rewrite without rules, and merge) now go
  through `escapeXMLText`; the XMIR passthrough keeps the full `escapeXML`.

## Changes

- `src/XMIR.hs` — escape attribute values; add/export `escapeXMLText`.
- `src/CLI/Runners.hs` — apply `escapeXMLText` to phi listings in `rewrite` and
  `merge`.
- `test/XMIRSpec.hs` — new test: `[[ a&b -> "<quoted>" ]]` prints
  `name="a&amp;b"` and round-trips through `xmirToPhi`.

## Tests

- `test/XMIRSpec.hs` — attribute escaping + round-trip.
- Verified: `xmllint` accepts the output for names/content with `&`; phi
  listing `[[ app -> [[]] ]]` stays literal; XMIR passthrough still fully
  escaped (existing CLI tests pass).