### PR TITLE
fix(filter): apply every fqn in include, not only the first one (#1088)

### DIFF
--- a/src/Filter.hs
+++ b/src/Filter.hs
@@ -34,7 +34,7 @@ exclude ((expr, maybeRule) : rest) exprs = (exclude' expr exprs, maybeRule) : ex
 
 include' :: Expression -> [Expression] -> Expression
 include' expr fqns = case mapMaybe pick fqns of
-  [] -> ExFormation [BiVoid AtRho]
+  [] -> def
   forms -> mergeForms forms
   where
     def :: Expression

--- a/src/Filter.hs
+++ b/src/Filter.hs
@@ -4,6 +4,7 @@
 module Filter (include, exclude) where
 
 import AST
+import Data.Maybe (mapMaybe)
 import Misc
 import Rewriter
 
@@ -31,15 +32,22 @@ exclude [] _ = []
 exclude rs [] = rs
 exclude ((expr, maybeRule) : rest) exprs = (exclude' expr exprs, maybeRule) : exclude rest exprs
 
-include' :: Expression -> Expression -> Expression
-include' ex@(ExFormation _) fqn =
-  let def = ExFormation [BiVoid AtRho]
-   in case fqnToAttrs fqn of
-        Just fqn' -> case includedFormation ex fqn' of
-          Just e -> e
-          _ -> def
-        _ -> def
+include' :: Expression -> [Expression] -> Expression
+include' expr fqns = case mapMaybe pick fqns of
+  [] -> ExFormation [BiVoid AtRho]
+  forms -> mergeForms forms
   where
+    def :: Expression
+    def = ExFormation [BiVoid AtRho]
+    pick :: Expression -> Maybe Expression
+    pick fqn = do
+      attrs <- fqnToAttrs fqn
+      includedFormation expr attrs
+    mergeForms :: [Expression] -> Expression
+    mergeForms forms =
+      let bds = concat [bs | ExFormation bs <- forms]
+          bds' = filter (\bd -> attributeFromBinding bd /= Just AtRho) bds
+       in ExFormation (withVoidRho bds')
     includedFormation :: Expression -> [Attribute] -> Maybe Expression
     includedFormation (ExFormation bindings) [at] =
       let bs = [bd | bd <- bindings, attributeFromBinding bd == Just at]
@@ -52,9 +60,8 @@ include' ex@(ExFormation _) fqn =
           | otherwise = includedBindings bs as
         includedBindings _ _ = Nothing
     includedFormation _ _ = Nothing
-include' _ _ = ExFormation [BiVoid AtRho]
 
 include :: [Rewritten] -> [Expression] -> [Rewritten]
 include [] _ = []
 include rs [] = rs
-include ((expr, maybeRule) : rest) (fqn : _) = (include' expr fqn, maybeRule) : include rest [fqn]
+include ((expr, maybeRule) : rest) exprs = (include' expr exprs, maybeRule) : include rest exprs

--- a/test/FilterSpec.hs
+++ b/test/FilterSpec.hs
@@ -87,7 +87,7 @@ spec = do
             expr' `shouldBe` defaultHidden
         )
 
-      it "recurses over a multi-element rewrite list, pinning every element to the first fqn" $ do
+      it "recurses over a multi-element rewrite list, pinning every element to the fqns" $ do
         first' <- parseExpressionThrows "[[ x -> ?, y -> ? ]]"
         second' <- parseExpressionThrows "[[ x -> ?, y -> ? ]]"
         fqn <- parseExpressionThrows "Q.x"
@@ -95,3 +95,11 @@ spec = do
         let included = F.include [(first', Just "rule-a"), (second', Just "rule-b")] [fqn, ExRoot]
         map fst included `shouldBe` [expected, expected]
         map snd included `shouldBe` [Just "rule-a", Just "rule-b"]
+
+      it "keeps every matching fqn, not only the first one" $ do
+        expr <- parseExpressionThrows "[[ x -> ?, y -> ? ]]"
+        firstFqn <- parseExpressionThrows "Q.x"
+        secondFqn <- parseExpressionThrows "Q.y"
+        expected <- parseExpressionThrows "[[ x -> ?, y -> ? ]]"
+        let [(expr', _)] = F.include [(expr, Nothing)] [firstFqn, secondFqn]
+        expr' `shouldBe` expected


### PR DESCRIPTION
Fixes #1088.

## Problem

`Filter.include` (`src/Filter.hs:57-60`) applied **only the first** locator and
silently dropped the rest:

```haskell
include ((expr, maybeRule) : rest) (fqn : _) = (include' expr fqn, maybeRule) : include rest [fqn]
```

`exclude` (`Filter.hs:29-32`) honestly applies all locators to every expression;
`include` did not, so a library call like `include rs [locator1, locator2]` kept
only the subtree under `locator1`. If `locator1` matched nothing but `locator2`
would, the result was the empty `⟦ ρ ↦ ∅ ⟧` — a silent wrong answer.

## Fix

- `src/Filter.hs` — `include'` now takes a list of fqns, applies each one, and
  merges the matching subtrees into a single formation (`withVoidRho`, with the
  per-subtree `ρ` removed so the result stays a valid formation).
- `include` passes the whole fqn list through, mirroring `exclude`.

The CLI is unaffected: `--show` is still limited to one occurrence, so the
single-fqn behavior is unchanged; only the library API stops dropping fqns.

## Changes

- `src/Filter.hs` — `include' :: Expression -> [Expression] -> Expression`
  applying every fqn and merging matches; `include` forwards the full list.
- `test/FilterSpec.hs` — new test: `include` with `Q.x` and `Q.y` keeps both
  subtrees (`[[ x -> ?, y -> ? ]]`); existing multi-element test renamed to
  reflect the new semantics.

## Tests

- `test/FilterSpec.hs` — both existing include fallbacks and the new
  merge-two-fqns case pass; full `CLI` suite (which drives `include` via
  `--show`) is green.