### PR TITLE
fix(bytes): escape codepoints above U+00FF as \u so strings round-trip (#1073)

### DIFF
--- a/src/Bytes.hs
+++ b/src/Bytes.hs
@@ -256,7 +256,15 @@ btsToStr bytes = escapeStr (btsToUnescapedStr bytes)
         escapeChar '\t' = "\\t"
         escapeChar c
           | isPrint c && c /= '\\' && c /= '"' = [c]
-          | otherwise = printf "\\x%02x" (ord c)
+          | ord c <= 0xFF = printf "\\x%02x" (ord c)
+          | ord c <= 0xFFFF = printf "\\u%04x" (ord c)
+          | otherwise = surrogates (ord c)
+        surrogates :: Int -> String
+        surrogates code =
+          let rest = code - 0x10000
+              high = 0xD800 + rest `div` 0x400
+              low = 0xDC00 + rest `mod` 0x400
+           in printf "\\u%04x\\u%04x" high low
 
 -- The inverse of the escaping that 'btsToStr' applies, so that a sweet string
 -- literal can be turned back into the very bytes it was printed from. A
@@ -279,11 +287,28 @@ unescapeStr = go
   where
     go :: String -> String
     go "" = ""
+    go ('\\' : 'u' : digits) = goUnicode digits
     go ('\\' : 'x' : high : low : rest)
       | Just code <- hexPair high low = chr code : go rest
     go ('\\' : escaped : rest)
       | Just unescaped <- lookup escaped escapes = unescaped : go rest
     go (char : rest) = char : go rest
+    goUnicode :: String -> String
+    goUnicode (h1 : h2 : h3 : h4 : rest)
+      | Just code <- hexQuad h1 h2 h3 h4 =
+          if code >= 0xD800 && code <= 0xDBFF
+            then case rest of
+              ('\\' : 'u' : l1 : l2 : l3 : l4 : rest')
+                | Just low <- hexQuad l1 l2 l3 l4
+                , low >= 0xDC00 && low <= 0xDFFF ->
+                    chr (0x10000 + (code - 0xD800) * 0x400 + (low - 0xDC00)) : go rest'
+              _ -> chr code : go rest
+            else chr code : go rest
+    goUnicode rest = go rest
+    hexQuad :: Char -> Char -> Char -> Char -> Maybe Int
+    hexQuad a b c d = case readHex [a, b, c, d] of
+      [(code, "")] -> Just code
+      _ -> Nothing
     hexPair :: Char -> Char -> Maybe Int
     hexPair high low = case readHex [high, low] of
       [(code, "")] -> Just code

--- a/test/BytesSpec.hs
+++ b/test/BytesSpec.hs
@@ -126,6 +126,8 @@ spec = do
       , ("escapes newline", BtOne "0A", "\\n")
       , ("escapes tab", BtOne "09", "\\t")
       , ("escapes non-printable", BtOne "01", "\\x01")
+      , ("escapes a non-printable above U+00FF as \\u", BtMany ["61", "E2", "80", "A8", "7A"], "a\\u2028z")
+      , ("keeps a printable emoji above U+FFFF as is", BtMany ["F0", "9F", "98", "80"], "\x1F600")
       , ("mixed printable and quote", BtMany ["61", "22", "62"], "a\\\"b")
       ]
       ( \(desc, bts, str) ->
@@ -146,6 +148,9 @@ spec = do
       , ("unknown escape is kept as it stands", "\\q", "\\q")
       , ("trailing backslash is kept", "a\\", "a\\")
       , ("truncated hex escape is kept", "\\x0", "\\x0")
+      , ("unicode escape", "a\\u2028z", "a\x2028z")
+      , ("uppercase unicode escape", "\\u2028", "\x2028")
+      , ("surrogate pair", "\\uD83D\\uDE00", "\x1F600")
       ]
       ( \(desc, escaped, unescaped) ->
           it desc $ unescapeStr escaped `shouldBe` unescaped
@@ -161,6 +166,9 @@ spec = do
       , ("tab", BtOne "09")
       , ("non-printable", BtMany ["01", "02"])
       , ("text around a newline", BtMany ["65", "0A", "65"])
+      , ("text around a line separator", BtMany ["61", "E2", "80", "A8", "7A"])
+      , ("text around a paragraph separator", BtMany ["61", "E2", "80", "A9", "7A"])
+      , ("emoji above U+FFFF", BtMany ["F0", "9F", "98", "80"])
       ]
       ( \(desc, bts) ->
           it desc $ strToBts (unescapeStr (btsToStr bts)) `shouldBe` bts


### PR DESCRIPTION
Fixes #1073.

## Problem

`btsToStr` (`src/Bytes.hs:257-259`) printed non-printable codepoints as
`\x%02x` with the full `ord`, so a codepoint above 0xFF (e.g. U+2028 LINE
SEPARATOR) became `\x2028` (4 hex digits). Both readers — `unescapeStr`
(`Bytes.hs:282-291`) and the parser's `hexEscape` (`Parser.hs:261-266`) — parse
exactly 2 hex digits. So `\x2028` was read back as `\x20` (space) + literal
`"28"`, silently corrupting any string containing U+2028/U+2029.

Repro (before):
```
$ phino rewrite --sweet '⟦ φ ↦ Φ.string( Φ.bytes(⟦ Δ ⤍ 61-E2-80-A8-7A ⟧) ) ⟧'
⟦ φ ↦ "a\x2028z" ⟧
# reparsing gives "a 28z" → bytes 61 20 32 38 7A instead of 61 E2 80 A8 7A
```

## Fix

- `src/Bytes.hs` — `escapeChar` now emits `\u%04x` for codepoints in `(0xFF,
  0xFFFF]` and a `\uHHHH\uHHHH` surrogate pair above `0xFFFF`; `\x%02x` stays
  for `<= 0xFF`. Printable characters (including emoji) are still emitted raw.
- `src/Bytes.hs` — `unescapeStr` now reads `\uHHHH` (4 hex) and combines
  surrogate pairs, matching what `escapeChar` writes. The parser already
  supported `\u` (`Parser.hs:234-260`), so only `Bytes.hs` needed the change.

## Changes

- `src/Bytes.hs` — `escapeChar`/`surrogates`; `unescapeStr`/`goUnicode`/`hexQuad`.
- `test/BytesSpec.hs` — new `btsToStr`, `unescapeStr`, and round-trip cases for
  U+2028, U+2029, and a printable emoji above U+FFFF.

## Tests

- `test/BytesSpec.hs` — 133 examples, 0 failures; verified `rewrite --sweet`
  round-trips `"a\u2028z"` identically (print → reparse is byte-identical).