### PR TITLE
fix(cli): reject --in-place together with a non-phi output format (#1089)

### DIFF
--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -71,6 +71,7 @@ runRewrite OptsRewrite{..} = do
     validateOpts = do
       when (_inPlace && isNothing _inputFile) (invalidCLIArguments "The option --in-place requires an input file")
       when (_inPlace && isJust _targetFile) (invalidCLIArguments "The options --in-place and --target cannot be used together")
+      when (_inPlace && _outputFormat /= PHI) (invalidCLIArguments "The option --in-place can only be used together with --output=phi")
       when (_update && _inPlace) (invalidCLIArguments "The options --update and --in-place cannot be used together")
       when (_update && isNothing _targetFile) (invalidCLIArguments "The option --update requires --target")
       when (_update && isNothing _inputFile) (invalidCLIArguments "The option --update requires an input file")

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -226,6 +226,14 @@ spec = do
             ["rewrite", "--in-place", "--target=output.phi", path]
             ["--in-place and --target cannot be used together"]
 
+      it "fails when --in-place is used with a non-phi output format" $
+        withTempFile "inplaceXXXXXX.phi" $ \(path, h) -> do
+          hPutStr h "[[ ]]"
+          hClose h
+          testCLIFailed
+            ["rewrite", "--in-place", "--output=latex", path]
+            ["--in-place can only be used together with --output=phi"]
+
       forM_
         [ ("when --update is used without --target", "[[ ]]", ["rewrite", "--update"], ["--update requires --target"])
         ,


### PR DESCRIPTION
Fixes #1089.

## Problem

`runRewrite`'s validation (`src/CLI/Runners.hs:70-84`) checked `--in-place` only
against `--target`/`--update`/`--input`, never against the **output format**.
So:

```
$ phino rewrite --in-place --output=latex my.phi
```

read `my.phi`, rendered the result as LaTeX, and wrote it back into `my.phi` —
silently replacing the phi source with TeX markup (same for `--output=xmir`).
The source file was corrupted with no error.

## Fix

`src/CLI/Runners.hs` — validation now rejects `--in-place` unless the output
format is `PHI`:

```
The option --in-place can only be used together with --output=phi
```

`--in-place` is about rewriting a phi source file in place, so a non-phi output
is a user mistake; failing early (before any file I/O) avoids corrupting the
source.

## Changes

- `src/CLI/Runners.hs` — new validation rule in `validateOpts` (`runRewrite`).
- `test/CLISpec.hs` — new test: `--in-place --output=latex` fails with the
  message and leaves the file untouched.

## Tests

- `test/CLISpec.hs` — 105 CLI/rewriting examples, 0 failures (verified
  `--in-place --output=phi` still works and overwrites the file).