### PR TITLE
fix(yaml): require non-empty and/or conditions and reject fractional literals (#1090)

### DIFF
--- a/src/Yaml.hs
+++ b/src/Yaml.hs
@@ -77,7 +77,9 @@ instance FromJSON Number where
         [ Length <$> o .: "length"
         , Domain <$> o .: "domain"
         ]
-    Number num -> pure (Literal (round num))
+    Number num
+      | toRational (round num :: Integer) == toRational num -> pure (Literal (round num))
+      | otherwise -> fail (printf "Expected an integer, got a fractional number %s" (show num))
     String txt -> case parseIndex (unpack txt) of
       Right mt -> pure (MetaIndex mt)
       Left err -> fail err
@@ -99,8 +101,16 @@ instance FromJSON Condition where
       ( \v -> do
           validateYamlObject v ["and", "or", "not", "nf", "absolute", "eq", "gt", "in", "matches", "part-of", "disjoint", "formation"]
           asum
-            [ And <$> v .: "and"
-            , Or <$> v .: "or"
+            [ do
+                conds <- v .: "and"
+                if null conds
+                  then fail "The 'and' condition requires at least one element"
+                  else pure (And conds)
+            , do
+                conds <- v .: "or"
+                if null conds
+                  then fail "The 'or' condition requires at least one element"
+                  else pure (Or conds)
             , Not <$> v .: "not"
             , NF <$> v .: "nf"
             , Absolute <$> v .: "absolute"

--- a/test/YamlSpec.hs
+++ b/test/YamlSpec.hs
@@ -156,3 +156,19 @@ spec = do
   describe "rejects a numerable expression that is neither an object, a number nor an index meta" $
     it "fails on a bare boolean" $
       (decodeYaml' "true" :: Either Yaml.ParseException Number) `shouldSatisfy` isLeft
+
+  describe "parses a literal number" $
+    it "accepts a whole number" $
+      (decodeYaml' "5" :: Either Yaml.ParseException Number) `shouldSatisfy` (not . isLeft)
+
+  describe "rejects a fractional literal number" $
+    it "fails on a fraction instead of silently rounding it" $
+      (decodeYaml' "2.5" :: Either Yaml.ParseException Number) `shouldSatisfy` isLeft
+
+  describe "rejects an empty 'and' condition" $
+    it "fails on 'and: []'" $
+      (decodeYaml' "and: []" :: Either Yaml.ParseException Condition) `shouldSatisfy` isLeft
+
+  describe "rejects an empty 'or' condition" $
+    it "fails on 'or: []'" $
+      (decodeYaml' "or: []" :: Either Yaml.ParseException Condition) `shouldSatisfy` isLeft


### PR DESCRIPTION
Fixes #1090 (the two implemented parts; see note below).

## Problem

Two small inconsistencies between the YAML condition parser and the string
`--when` parser:

1. **`and`/`or` arity.** The string parser (`Condition.hs`) parses `and(...)`/
   `or(...)` with `sepBy1`, so an empty list never parses. But the YAML path
   (`Yaml.hs` `v .: "and"`/`.: "or"`) accepted `and: []`/`or: []`, producing an
   `And []`/`Or []` that the string parser cannot express — the two parsers
   disagreed about the language.
2. **Fractional `Number` literals.** `Yaml.hs:80` did `Literal (round num)`,
   silently rounding a fraction with banker's rounding (e.g. `2.5` → `2`)
   without any warning, while the string parser (`Condition.hs` `L.decimal`)
   accepts only integers. A YAML author writing `2.5` got `2` silently.

## Fix

- `src/Yaml.hs` — `and`/`or` now require at least one element (matching the
  string parser); a fractional `Number` literal is rejected with a descriptive
  message instead of being rounded.

## Changes

- `src/Yaml.hs` — non-empty checks for `And`/`Or`; integer-only guard for
  `Number` literals.
- `test/YamlSpec.hs` — tests for `and: []`, `or: []`, `2.5` (rejected) and a
  whole `5` (accepted).

## Tests

- `test/YamlSpec.hs` — 35 examples, 0 failures; `ConditionSpec`, `RewriterSpec`
  and `CLI/rewriting` suites all green.

## Note

The third item in #1090 (seeding the initial expression into the rewriter's
seen-set) was considered but **rejected**: it changes rewrite semantics — a
legitimate return to the initial expression under `--sequence`/`--max-cycles`
would be flagged as a loop, breaking `prints many expressions with --sequence`
and the `--headers` tests. Left as-is.