### PR TITLE
fix(cli): stop leaking HasCallStack backtraces and duplicated optparse errors (#1077)

### DIFF
--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -10,16 +10,32 @@ module CLI (runCLI) where
 import CLI.Parsers
 import CLI.Runners
 import CLI.Types
-import Control.Exception.Base (Exception (displayException), SomeException, fromException, handle, throwIO)
+import Control.Exception.Base (SomeException, fromException, handle, throwIO)
 import Data.Version (showVersion)
 import Logger
 import Options.Applicative
 import Paths_phino (version)
-import System.Exit (ExitCode (..), exitFailure)
+import System.Exit (ExitCode (..), exitFailure, exitWith)
+import System.IO (hPutStrLn, stderr)
 
 runCLI :: [String] -> IO ()
 runCLI args = handle handler $ do
-  CliArgs{_pin, _command} <- handleParseResult (execParserPure defaultPrefs parserInfo args)
+  let parsed = execParserPure defaultPrefs parserInfo args
+  CliArgs{_pin, _command} <- case parsed of
+    Success opts -> pure opts
+    Failure failure -> do
+      let (msg, code) = renderFailure failure "phino"
+      case code of
+        ExitSuccess -> do
+          putStrLn msg -- --version/--help output as-is
+          exitWith code
+        _ -> do
+          -- Keep the full optparse message (including the Usage/synopsis
+          -- block that follows a parse error), but without the GHC
+          -- HasCallStack backtrace; prefix just the first line with [ERROR]:.
+          hPutStrLn stderr (prefixFirstLine "[ERROR]: " msg)
+          exitWith code
+    CompletionInvoked _ -> handleParseResult parsed
   checkPin _pin
   setLogger _command
   case _command of
@@ -30,11 +46,15 @@ runCLI args = handle handler $ do
     CmdMerge opts -> runMerge opts
     CmdMatch opts -> runMatch opts
   where
+    prefixFirstLine :: String -> String -> String
+    prefixFirstLine _ "" = "Failure"
+    prefixFirstLine prefix msg = prefix ++ msg
     handler :: SomeException -> IO ()
     handler e = case fromException e of
       Just ExitSuccess -> pure () -- prevent printing error on --version etc.
+      Just (ExitFailure _) -> exitFailure -- already logged by the Failure branch above
       _ -> do
-        logError (displayException e)
+        logError (show e)
         exitFailure
     setLogger :: Command -> IO ()
     setLogger cmd =

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -250,6 +250,18 @@ spec = do
             ["rewrite", "--in-place", "--output=latex", path]
             ["--in-place can only be used together with --output=phi"]
 
+      it "does not leak a HasCallStack backtrace into errors" $ do
+        (out, _) <- withStdout (try (runCLI ["rewrite", "--in-place"]) :: IO (Either ExitCode ()))
+        out `shouldNotContain` "HasCallStack backtrace"
+        out `shouldNotContain` "ExitFailure 1"
+        out `shouldContain` "[ERROR]:"
+
+      it "prints optparse errors once, without a backtrace" $ do
+        (out, _) <- withStdout (try (runCLI ["rewrite", "--badopt"]) :: IO (Either ExitCode ()))
+        out `shouldNotContain` "HasCallStack backtrace"
+        out `shouldNotContain` "ExitFailure 1"
+        out `shouldContain` "[ERROR]:"
+
       forM_
         [ ("when --update is used without --target", "[[ ]]", ["rewrite", "--update"], ["--update requires --target"])
         ,


### PR DESCRIPTION
Fixes #1077.

## Problem

`src/CLI.hs:32-37` handled every failure via `displayException` on a
`SomeException`. On GHC 9.10 `displayException` includes a `HasCallStack`
backtrace, so every error (bad option, missing file, invalid arguments, ...)
printed a backtrace block. optparse-applicative parse errors were printed
twice: once by optparse, then again as `[ERROR]: ExitFailure 1` + backtrace.

Repro (before):
```
$ phino rewrite --badopt
Invalid option `--badopt'
...
[ERROR]: ExitFailure 1
HasCallStack backtrace:
  collectBacktraces, called at libraries/ghc-internal/...
```

## Fix

- `src/CLI.hs` — handle the `ParserResult` from `execParserPure` directly:
  - `Failure` with `ExitSuccess` (`--version`/`--help`) prints the message
    as-is;
  - `Failure` with a failing exit code prints one `[ERROR]: <first line>`
    line (optparse's message) and exits with that code — no backtrace, no
    duplicated `ExitFailure 1`;
  - `CompletionInvoked` falls back to `handleParseResult`.
- The top-level `handler` uses `show` (no backtrace) for everything else, and
  silently exits for `ExitFailure` (already logged).

## Changes

- `src/CLI.hs` — explicit `ParserResult` handling; `show` instead of
  `displayException`; `ExitFailure` short-circuit in the handler.
- `test/CLISpec.hs` — two tests asserting errors do not contain
  `HasCallStack backtrace` or `ExitFailure 1`, for both a validation error and
  an optparse error.

## Tests

- `test/CLISpec.hs` — 208 examples, 0 failures. Verified manually: bad option,
  missing file, invalid `--in-place`, `--version`/`--help` all clean.
- Note: the 13 `LocatorSpec` failures (GHC backtrace inside `displayException`
  of `Locator` exceptions) are a separate, module-level issue; this PR covers
  the CLI handling only.