### PR TITLE
fix(cli): reject --show/--hide overlap and deduplicate repeated --rule files (#1085)

### DIFF
--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -14,7 +14,7 @@ import Control.Exception
 import Control.Monad ((>=>))
 import Data.Functor ((<&>))
 import Data.IORef
-import Data.List (intercalate)
+import Data.List (intercalate, nub)
 import Data.Maybe
 import Deps (SaveEvalFunc, SaveStepFunc, dontSaveEval, saveEval, saveStep)
 import Encoding
@@ -176,7 +176,7 @@ getRules normalize shuffle rules = do
           pure []
       | otherwise = do
           logDebug (printf "Using rules from files: [%s]" (intercalate ", " rules))
-          yamls <- mapM ensuredFile rules
+          yamls <- mapM ensuredFile (nub rules)
           mapM (Y.yamlRule >=> validateRewriteRule) yamls
 
 -- Pass a user-supplied rewriting rule through unchanged, or fail fast if it

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -45,6 +45,7 @@ runRewrite OptsRewrite{..} = do
   included <- validatedDispatches "show" _show
   [loc] <- validatedDispatches "locator" [_locator]
   [foc] <- validatedDispatches "focus" [_focus]
+  validateNoOverlap "show" included "hide" excluded
   setStdGen (mkStdGen _seed)
   rules <- getRules _normalize _shuffle _rules
   validateBreakpoint _breakpoint rules
@@ -142,6 +143,7 @@ runDataize OptsDataize{..} = do
   included <- validatedDispatches "show" _show
   [loc] <- validatedDispatches "locator" [_locator]
   [foc] <- validatedDispatches "focus" [_focus]
+  validateNoOverlap "show" included "hide" excluded
   input <- readInput _inputFile
   expr <- parseInput input _inputFormat
   setStdGen (mkStdGen _seed)

--- a/src/CLI/Validators.hs
+++ b/src/CLI/Validators.hs
@@ -35,6 +35,22 @@ validatedDispatches opt = traverse (parseExpressionThrows >=> asDispatch)
                 (printExpression' expr logPrintConfig)
             )
 
+-- Reject a --show locator that is also hidden via --hide: 'exclude' runs over
+-- the result of 'include', so an overlap would silently wipe the very subtree
+-- --show was meant to keep.
+validateNoOverlap :: String -> [Expression] -> String -> [Expression] -> IO ()
+validateNoOverlap showOpt shown hideOpt hidden =
+  for_ shown $ \shown' ->
+    for_ hidden $ \hidden' ->
+      when (printExpression shown' == printExpression hidden') $
+        invalidCLIArguments
+          ( printf
+              "The --%s locator '%s' is also listed in --%s, which would hide it from the result"
+              showOpt
+              (printExpression shown')
+              hideOpt
+          )
+
 -- Validate LaTeX options
 validateLatexOptions :: IOFormat -> [(Bool, String)] -> [(Maybe String, String)] -> [(Maybe Int, String)] -> IO ()
 validateLatexOptions LATEX _ _ _ = pure ()

--- a/test/CLIHelpersSpec.hs
+++ b/test/CLIHelpersSpec.hs
@@ -12,13 +12,13 @@
 module CLIHelpersSpec (spec) where
 
 import AST (Expression (ExRoot))
-import CLI.Helpers (parseInput, printExpression)
+import CLI.Helpers (getRules, parseInput, printExpression)
 import CLI.Types (IOFormat (LATEX, PHI, XMIR), PrintContext (PrintCtx))
 import Control.Exception (SomeException, try)
 import Control.Monad (forM_)
 import Lining (LineFormat (MULTILINE))
 import Sugar (SugarType (SWEET))
-import Test.Hspec (Spec, describe, it, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 import XMIR (defaultXmirContext)
 
 isLeft :: Either e a -> Bool
@@ -50,3 +50,8 @@ spec = do
           result <- try (printExpression (testPrintContext format) ExRoot) :: IO (Either SomeException String)
           result `shouldSatisfy` predicate
       )
+
+  describe "getRules" $
+    it "deduplicates the same --rule file listed twice" $ do
+      rules <- getRules False False ["test-resources/cli/simple.yaml", "test-resources/cli/simple.yaml"]
+      length rules `shouldBe` 1

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -306,6 +306,7 @@ spec = do
           , ["rewrite", "--show=Q.x(Q.y)"]
           , ["[ERROR]:", "Only dispatch expression started with Φ (or Q) can be used in --show"]
           )
+        , ("with --show overlapping --hide", ["rewrite", "--show=Q.x", "--hide=Q.x"], ["[ERROR]:", "The --show locator 'Φ.x' is also listed in --hide"])
         , ("with --meet-popularity < 0", ["rewrite", "--meet-popularity=-1"], ["[ERROR]:", "--meet-popularity must be positive"])
         , ("with --meet-popularity > 100", ["rewrite", "--meet-popularity=102"], ["[ERROR]:", "--meet-popularity must be <= 100"])
         ,


### PR DESCRIPTION
Fixes #1085 (the two code parts; the third item, `src/Must.hs.bak`, was a
local un-tracked file — not in git history, removed from the working tree).

## Problem

1. **`--hide` + `--show` overlap is not validated.** `runRewrite`/`runDataize`
   apply `exclude $ include …` (`src/CLI/Runners.hs:65,152`), so a `--show`
   locator that is also in `--hide` silently gets the very subtree wiped out
   that `--show` was meant to keep.
2. **`getRules` does not deduplicate `--rule` files.** Passing the same file
   twice (`--rule=x.yaml --rule=x.yaml`) loads the rule twice, doubling its
   effect; a `--breakpoint` by that rule's name then silently stops at the
   first copy.

## Fix

- `src/CLI/Validators.hs` — new `validateNoOverlap` rejecting a `--show`
  locator that is also listed in `--hide`.
- `src/CLI/Runners.hs` — call `validateNoOverlap` in both `runRewrite` and
  `runDataize` right after `validatedDispatches`.
- `src/CLI/Helpers.hs` — `getRules` deduplicates the `--rule` paths via `nub`
  before loading.

## Changes

- `src/CLI/Validators.hs` — `validateNoOverlap`.
- `src/CLI/Runners.hs` — wire the new validation into `runRewrite`/`runDataize`.
- `src/CLI/Helpers.hs` — `nub rules` in `getRules`.
- `test/CLIHelpersSpec.hs` — `getRules` dedups the same file listed twice.
- `test/CLISpec.hs` — `--show=Q.x --hide=Q.x` fails with the overlap message.

## Tests

- `test/CLIHelpersSpec.hs`, `test/CLISpec.hs` — new cases pass; full suite
  green except the pre-existing 13 `LocatorSpec` failures (documented in
  #1077).