### PR TITLE
fix(cli): allow --normalize --rule and apply --shuffle to morph/dataize/contextualize in explain (#1083)

### DIFF
--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -27,6 +27,7 @@ import Margin (defaultMargin)
 import Merge (merge)
 import Parser (parseExpressionThrows)
 import qualified Printer as P
+import qualified Random as R
 import Rewriter
 import Rule (RuleContext (..), matchExpressionWithRule)
 import System.Directory (doesFileExist, getModificationTime)
@@ -204,15 +205,20 @@ runExplain OptsExplain{..} = do
   where
     explained :: IO String
     explained
-      | _morph = pure (explainMorphRules Y.morphingRules)
-      | _dataize = pure (explainDataizeRules Y.dataizationRules)
-      | _contextualize = pure (explainContextualizeRules Y.contextualizationRules)
+      | _morph = explainMorphRules <$> shuffled Y.morphingRules
+      | _dataize = explainDataizeRules <$> shuffled Y.dataizationRules
+      | _contextualize = explainContextualizeRules <$> shuffled Y.contextualizationRules
       | otherwise = explainRules <$> getRules _normalize _shuffle _rules
+    shuffled :: [a] -> IO [a]
+    shuffled xs
+      | _shuffle = R.shuffle xs
+      | otherwise = pure xs
     validateOpts :: IO ()
     validateOpts = do
-      let selected = length (filter id [not (null _rules), _normalize, _morph, _dataize, _contextualize])
-      when (selected == 0) (invalidCLIArguments "Either --rule, --normalize, --morph, --dataize or --contextualize must be specified")
-      when (selected > 1) (invalidCLIArguments "Only one of --rule, --normalize, --morph, --dataize or --contextualize can be specified")
+      let selected = length (filter id [_morph, _dataize, _contextualize])
+      when (selected == 0 && null _rules && not _normalize) (invalidCLIArguments "Either --rule, --normalize, --morph, --dataize or --contextualize must be specified")
+      when (selected > 1) (invalidCLIArguments "Only one of --morph, --dataize or --contextualize can be specified")
+      when (selected == 1 && not (null _rules)) (invalidCLIArguments "The --rule option cannot be used together with --morph, --dataize or --contextualize")
 
 runMerge :: OptsMerge -> IO ()
 runMerge OptsMerge{..} = do

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1538,7 +1538,17 @@ spec = do
     it "fails when more than one rule set is specified" $
       testCLIFailed
         ["explain", "--morph", "--dataize"]
-        ["Only one of --rule, --normalize, --morph, --dataize or --contextualize can be specified"]
+        ["Only one of --morph, --dataize or --contextualize can be specified"]
+
+    it "allows --normalize together with --rule" $
+      testCLISucceeded
+        ["explain", "--normalize", "--rule=resources/normalize/copy.yaml"]
+        ["\\phinoNormalizationRule{copy}"]
+
+    it "allows --shuffle together with --morph" $
+      testCLISucceeded
+        ["explain", "--morph", "--shuffle"]
+        ["\\begin{phinoMorphingInference}"]
 
     it "writes to target file" $
       bracket


### PR DESCRIPTION
Fixes #1083.

## Problem

`explain` (`src/CLI/Runners.hs:200-215`) had two asymmetries versus `rewrite`:

1. **`--normalize --rule` was rejected.** `validateOpts` counted `not (null
   _rules)` and `_normalize` as two separate rule sets and forbade combining
   them, even though `getRules` (`Helpers.hs`) is explicitly built to load
   built-in normalization rules followed by user rules (documented for
   `rewrite` in README).
2. **`--shuffle` was silently ignored** for `--morph`/`--dataize`/
   `--contextualize`: those three branches called
   `explainMorphRules Y.morphingRules` etc. directly, never shuffling.

## Fix

`src/CLI/Runners.hs`:

- `--normalize` may now be combined with `--rule` (both route through
  `getRules`, like `rewrite`); the three morphing branches remain mutually
  exclusive with each other and with `--rule`.
- `--shuffle` now shuffles the `morphingRules`/`dataizationRules`/
  `contextualizationRules` lists before explaining (via `R.shuffle`).

## Changes

- `src/CLI/Runners.hs` — reworked `explained`/`validateOpts`; added a
  `shuffled` helper.
- `test/CLISpec.hs` — `--morph --dataize` message updated; two new tests:
  `--normalize --rule` succeeds, `--morph --shuffle` succeeds.

## Tests

- `test/CLISpec.hs` — 208 CLI examples + 25 explain, 0 failures; verified
  `--shuffle` now changes morph/dataize/contextualize order (was a no-op).

Note: deterministic `--shuffle` via `--seed` is handled by the companion PR
#1093 (adds `--seed` to explain); this PR makes `--shuffle` actually take
effect for the three morphing branches.