### PR TITLE
fix(cli): validate the top-level XMIR shape before rewriting instead of failing at print time (#1082)

### DIFF
--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -52,6 +52,7 @@ runRewrite OptsRewrite{..} = do
   validateBreakpoint _breakpoint rules
   input <- readInput _inputFile
   expr <- parseInput input _inputFormat
+  validateXmirTopLevel _outputFormat expr
   seedTaus expr
   logDebug (printf "Amount of rewriting cycles across all the rules: %d, per rule: %d" _maxCycles _maxDepth)
   let listing = case (rules, _inputFormat, _outputFormat) of
@@ -230,6 +231,7 @@ runMerge OptsMerge{..} = do
   inputs' <- traverse (readInput . Just) _inputs
   exprs <- traverse (`parseInput` _inputFormat) inputs'
   expr <- merge exprs
+  validateXmirTopLevel _outputFormat expr
   let listing = const (escapeXMLText (P.printExpression' expr (_sugarType, UNICODE, _flat, _margin)))
       xmirCtx = XmirContext _omitListing _omitComments listing
       printCtx = toPrintCtx xmirCtx

--- a/src/CLI/Validators.hs
+++ b/src/CLI/Validators.hs
@@ -74,5 +74,19 @@ validateXmirOptions _ bools _ =
   let (bools', opts) = unzip bools
    in validateBoolOpts (zip bools' (map (printf "The --%s can be used only with --output=xmir") opts))
 
+-- Check that an expression is printable as XMIR: its top level must be a
+-- single binding followed by ρ ↦ ∅ (the shape 'expressionToXMIR' accepts).
+-- Called right after parsing, so a bad shape fails before any rewriting or
+-- dataization work instead of at print time (issue #1082).
+validateXmirTopLevel :: IOFormat -> Expression -> IO ()
+validateXmirTopLevel XMIR (ExFormation [_, BiVoid AtRho]) = pure ()
+validateXmirTopLevel XMIR expr =
+  invalidCLIArguments
+    ( printf
+        "Expression cannot be printed with --output=xmir: its top level must be a single binding followed by ρ ↦ ∅, but got: %s"
+        (printExpression expr)
+    )
+validateXmirTopLevel _ _ = pure ()
+
 validateBoolOpts :: [(Bool, String)] -> IO ()
 validateBoolOpts bools = forM_ bools (\(bool, msg) -> when bool (invalidCLIArguments msg))

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -215,6 +215,12 @@ spec = do
           , ["it's expected rewriting cycles to be in range [1], but rewriting has already reached 2"]
           )
         , ("when --in-place is used without input file", "[[ ]]", ["rewrite", "--in-place"], ["--in-place requires an input file"])
+        ,
+          ( "with --output=xmir on a non-top-level expression"
+          , "⟦ x ↦ 1, ρ ↦ 2 ⟧"
+          , ["rewrite", "--output=xmir"]
+          , ["[ERROR]:", "its top level must be a single binding followed by ρ ↦ ∅"]
+          )
         ]
         (\(desc, input, args, expected) -> it desc (withStdin input (testCLIFailed args expected)))
 


### PR DESCRIPTION
Fixes #1082 (the "late failure" part).

## Problem

`--output=xmir` accepted any input expression, ran the full rewrite, and only
**at print time** failed when the top level did not match the shape
`expressionToXMIR` accepts (`[BiTau (AtLabel _) arg, BiVoid AtRho]`,
`src/XMIR.hs:170-175`):

```
$ phino rewrite --output=xmir '⟦ x ↦ 1, ρ ↦ 2 ⟧'
... (all the rewriting work runs) ...
[ERROR]: XMIR does not support such top-level expression:
⟦ x ↦ 1, ρ ↦ 2 ⟧
```

The user pays the whole computation cost and gets the failure at the very end.
The same happened for `merge --output=xmir`.

## Fix

`src/CLI/Validators.hs` — new `validateXmirTopLevel`: for `--output=xmir`, the
expression's top level must be a single binding followed by `ρ ↦ ∅` (the shape
`rootExpression`/`expressionToXMIR` accept). Otherwise a clear early error is
raised.

`src/CLI/Runners.hs` — called right after parsing in `runRewrite` and after
`merge` in `runMerge`, before any rewriting/merging work.

## Changes

- `src/CLI/Validators.hs` — `validateXmirTopLevel`.
- `src/CLI/Runners.hs` — wire it into `runRewrite`/`runMerge`.
- `test/CLISpec.hs` — new test: `rewrite --output=xmir` on `⟦ x ↦ 1, ρ ↦ 2 ⟧`
  fails early with the shape message.

## Tests

- `test/CLISpec.hs` — 105 CLI/rewriting examples, 0 failures; full suite green
  except the pre-existing 13 `LocatorSpec` failures (documented in #1077).

Note: the residual-program shape of `--partial --output=xmir` (issue #1076) is
out of scope here — this PR addresses the late-failure UX for plain rewrite and
merge.