### PR TITLE
fix(cli): remove the ineffective --seed option from match (#1091)

### DIFF
--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -385,7 +385,6 @@ matchParser =
             <*> optLogLines
             <*> optSugar
             <*> optLineFormat
-            <*> optSeed
             <*> optional (strOption (long "pattern" <> metavar "EXPRESSION" <> help "Pattern expression to match against"))
             <*> optional (strOption (long "when" <> metavar "CONDITION" <> help "Predicate for matched substitutions"))
             <*> argInputFile

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -255,8 +255,6 @@ runMatch :: OptsMatch -> IO ()
 runMatch OptsMatch{..} = do
   input <- readInput _inputFile
   expr <- parseInput input PHI
-  setStdGen (mkStdGen _seed)
-  seedTaus expr
   if isNothing _pattern
     then logDebug "The --pattern is not provided, no substitutions are built"
     else do

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -183,7 +183,6 @@ data OptsMatch = OptsMatch
   , _logLines :: Int
   , _sugarType :: SugarType
   , _flat :: LineFormat
-  , _seed :: Int
   , _pattern :: Maybe String
   , _when :: Maybe String
   , _inputFile :: Maybe FilePath

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1625,9 +1625,9 @@ spec = do
       withStdin "[[ x -> Q.x ]]" $
         testCLISucceeded ["match", "--pattern=Q.!t"] ["t >> x"]
 
-    it "accepts --seed flag" $
+    it "does not accept a --seed flag (matching has nothing random)" $
       withStdin "[[ x -> Q.x ]]" $
-        testCLISucceeded ["match", "--seed=3", "--pattern=Q.!t"] ["t >> x"]
+        testCLIFailed ["match", "--seed=3", "--pattern=Q.!t"] ["Invalid option `--seed=3'"]
 
     it "prints many substitutions" $
       withStdin "[[ x -> Q.x, y -> Q.y ]]" $


### PR DESCRIPTION
Fixes #1091 (the `--seed` part; the benchmark part is tracked separately).

## Problem

`match` accepted a `--seed` option, but matching has nothing random:
`runMatch` calls neither `shuffle` nor `randomString` (the CLI `match` takes
only `--pattern`, no `--rule`, so no `where` extensions can fire). Verified:
`match --seed=1` and `--seed=7` produce identical output. `setStdGen` and
`seedTaus` in `runMatch` were dead code, and the help text promised a
reproducibility that the flag does not provide.

## Fix

- `src/CLI/Types.hs` — remove `_seed` from `OptsMatch`.
- `src/CLI/Parsers.hs` — remove `optSeed` from `matchParser`.
- `src/CLI/Runners.hs` — drop the `setStdGen`/`seedTaus` calls from `runMatch`.

## Changes

- `src/CLI/Types.hs`, `src/CLI/Parsers.hs`, `src/CLI/Runners.hs` — `--seed`
  removed from `match`.
- `test/CLISpec.hs` — "accepts --seed flag" replaced with a test asserting
  `match --seed=3` is rejected as an unknown option.

## Tests

- `test/CLISpec.hs` — 11 CLI/match examples, 0 failures; full suite green
  except the pre-existing 13 `LocatorSpec` failures (documented in #1077).

## Remaining

The second half of #1091 — benchmarks not covering `dataize`/`--partial`/
`--evaluations`/the new atoms — is a larger feature and left for a follow-up.