### PR TITLE
fix(test): spell EO's `true` as `FF-` in the primitives fixture

### DIFF
--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -58,7 +58,9 @@ testDataize useCases =
 -- expression under φ. Alongside them stand the objects the atoms hand results
 -- to: 'string' carries the 'cant-slice' complaint, while 'true' and 'false' fill
 -- in for the real bool objects, since the single byte an EO bool dataizes to is
--- all these cases assert.
+-- all these cases assert. Those bytes are EO's own: 'true.eo' asserts
+-- 'true.as-bytes.eq FF-' and 'bool.eo' branches 'if' over 'FF-' and '00-', so a
+-- universe copied from here starts with a bool an EO program recognizes.
 primitives :: String -> String
 primitives src =
   unlines
@@ -85,7 +87,7 @@ primitives src =
     , "    eq -> [[ x -> ?, y -> ?, L> L_number_eq ]]"
     , "  ]],"
     , "  string -> [[ as-bytes -> ?, @ -> $.as-bytes ]],"
-    , "  true -> [[ @ -> [[ D> 01- ]] ]],"
+    , "  true -> [[ @ -> [[ D> FF- ]] ]],"
     , "  false -> [[ @ -> [[ D> 00- ]] ]],"
     , "  @ -> " ++ src
     , "]]"
@@ -685,9 +687,9 @@ spec = do
     testAtom
       [ ("divides a positive dividend", "256.div( 16 )", BtMany ["40", "30", "00", "00", "00", "00", "00", "00"])
       , ("divides by zero into infinity", "2.div( 0 )", BtMany ["7F", "F0", "00", "00", "00", "00", "00", "00"])
-      , ("tells 1000 is greater than 200", "1000.gt( 200 )", BtOne "01")
+      , ("tells 1000 is greater than 200", "1000.gt( 200 )", BtOne "FF")
       , ("tells 42 is not greater than 42.5", "42.gt( 42.5 )", BtOne "00")
-      , ("tells zero is greater than a negative", "0.gt( -5 )", BtOne "01")
+      , ("tells zero is greater than a negative", "0.gt( -5 )", BtOne "FF")
       ,
         ( "conjoins two long bytes"
         , raw "02-EF-D4-05-5E-78-3A" ++ ".and( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
@@ -710,7 +712,7 @@ spec = do
         , BtMany ["05", "5E", "78"]
         )
       , ("counts the size of bytes", raw "F1-20-5F-EC-B5-90-32" ++ ".size", BtMany ["40", "1C", "00", "00", "00", "00", "00", "00"])
-      , ("tells equal bytes are equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FE" ++ " )", BtOne "01")
+      , ("tells equal bytes are equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FE" ++ " )", BtOne "FF")
       , ("tells different bytes are not equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FF" ++ " )", BtOne "00")
       , ("takes a part of bytes", raw "20-1F-EE-B5-90" ++ ".slice( 1, 3 )", BtMany ["1F", "EE", "B5"])
       ,


### PR DESCRIPTION
Closes #1109

## What

The `primitives` fixture in `test/DataizeSpec.hs` spelled EO's `true` as a
single `01-` byte. EO spells it `FF-`: `eo-runtime/src/main/eo/true.eo`
asserts `true.as-bytes.eq FF-`, and `bool.eo` defines `if > @` over the
branches `FF-` and `00-`. The neighbouring `false -> [[ @ -> [[ D> 00- ]] ]]`
was already right.

The engine is not involved — `boolean` in `src/Dataize.hs` hands back
`Φ.true`/`Φ.false` and lets the universe supply the bytes — but the fixture's
own docblock says these objects "fill in for the real bool objects", so it is
what documents phino's reading of EO, and anyone copying it as a starting
universe inherited a `true` no EO program would recognize.

## How

- `true` in the fixture now carries `D> FF-`.
- The three assertions riding on that byte expect `BtOne "FF"`: "tells 1000 is
  greater than 200", "tells zero is greater than a negative" and "tells equal
  bytes are equal".
- The docblock now names where those bytes come from, so the next reader does
  not have to take them on trust.

No source change — the false cases (`BtOne "00"`) were already correct and stay
as they are.

## Testing

`cabal test --ghc-options=-Werror` passes, as do `hlint src app test` and
`fourmolu --mode check src app test` (0.17.0.0, as in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzHFG1wiuuaS5oUMky6viE

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzHFG1wiuuaS5oUMky6viE)_