### PR TITLE
fix(dataize): make L_number_eq answer a boolean, not a number (#1074)

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -487,6 +487,14 @@ bitwise op self univ state ctx = do
   (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
   pure (maybe ExTermination dataBytes (op rho b), rstate)
 
+-- The 12 primitive λ-atoms every EO data operation reduces to. phino mirrors
+-- EO's set exactly: bytes {and, concat, eq, not, or, right, size, slice} and
+-- number {div, gt, plus, times}. There is deliberately no 'L_number_eq': EO's
+-- 'number.eq' (eo-runtime/src/main/eo/number/eq.eo) is pure EO — a formation
+-- composing 'is-nan', 'or', 'and' and 'L_bytes_eq', with no λ of its own — so
+-- nothing is left for a phino atom to implement. Names like 'L_bool_if' or
+-- 'L_string_slice' must stay unimplemented too: the EO lowering declares them
+-- precisely so that '--partial' parks on them and renders the call to Java.
 atom :: T.Text -> Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
 atom "L_number_plus" self univ state ctx = do
   (left, lstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
@@ -499,15 +507,6 @@ atom "L_number_times" self univ state ctx = do
   (right, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
   case (asNumber left, asNumber right) of
     (Just first, Just second) -> pure (DataNumber (numToBts (first * second)), rstate)
-    _ -> pure (ExTermination, rstate)
-atom "L_number_eq" self univ state ctx = do
-  (x, lstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
-  case (asNumber x, asNumber rho) of
-    (Just first, Just self') ->
-      if self' == first
-        then pure (DataNumber (numToBts first), rstate)
-        else pure (ExDispatch self (AtLabel "y"), rstate)
     _ -> pure (ExTermination, rstate)
 atom "L_number_div" self univ state ctx = do
   (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -55,10 +55,14 @@ testDataize useCases =
 
 -- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
 -- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
--- expression under φ. Alongside them stand the objects the atoms hand results
--- to: 'string' carries the 'cant-slice' complaint, while 'true' and 'false' fill
--- in for the real bool objects, since the single byte an EO bool dataizes to is
--- all these cases assert. Those bytes are EO's own: 'true.eo' asserts
+-- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
+-- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
+-- expression under φ. 'number.eq' is the one operation with no atom of its own:
+-- EO spells it out of 'L_bytes_eq' (eq.eo), so the fixture composes it the same
+-- way. Alongside them stand the objects the atoms hand results to: 'string'
+-- carries the 'cant-slice' complaint, while 'true' and 'false' fill in for the
+-- real bool objects, since the single byte an EO bool dataizes to is all these
+-- cases assert. Those bytes are EO's own: 'true.eo' asserts
 -- 'true.as-bytes.eq FF-' and 'bool.eo' branches 'if' over 'FF-' and '00-', so a
 -- universe copied from here starts with a bool an EO program recognizes.
 primitives :: String -> String
@@ -84,7 +88,7 @@ primitives src =
     , "    times -> [[ x -> ?, L> L_number_times ]],"
     , "    div -> [[ x -> ?, L> L_number_div ]],"
     , "    gt -> [[ x -> ?, L> L_number_gt ]],"
-    , "    eq -> [[ x -> ?, y -> ?, L> L_number_eq ]]"
+    , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]]"
     , "  ]],"
     , "  string -> [[ as-bytes -> ?, @ -> $.as-bytes ]],"
     , "  true -> [[ @ -> [[ D> FF- ]] ]],"
@@ -621,6 +625,7 @@ spec = do
           [ "[["
           , "  bytes -> [["
           , "    data -> ?,"
+          , "    eq -> [[ b -> ?, L> L_bytes_eq ]],"
           , "    @ -> $.data"
           , "  ]],"
           , "  number -> [["
@@ -628,11 +633,13 @@ spec = do
           , "    @ -> $.as-bytes,"
           , "    times -> [[ x -> ?, L> L_number_times ]],"
           , "    plus -> [[ x -> ?, L> L_number_plus ]],"
-          , "    eq -> [[ x -> ?, y -> ?, L> L_number_eq ]]"
+          , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]]"
           , "  ]],"
+          , "  true -> [[ if -> [[ t -> ?, f -> ?, @ -> t ]] ]],"
+          , "  false -> [[ if -> [[ t -> ?, f -> ?, @ -> f ]] ]],"
           , "  fac -> [["
           , "    x -> ?,"
-          , "    @ -> $.x.eq("
+          , "    @ -> $.x.eq( 1 ).if("
           , "      1,"
           , "      $.x.times($.^.fac($.x.plus(-1)))"
           , "    )"
@@ -690,6 +697,10 @@ spec = do
       , ("tells 1000 is greater than 200", "1000.gt( 200 )", BtOne "FF")
       , ("tells 42 is not greater than 42.5", "42.gt( 42.5 )", BtOne "00")
       , ("tells zero is greater than a negative", "0.gt( -5 )", BtOne "FF")
+      , ("tells 5 equals 5", "5.eq( 5 )", BtOne "FF")
+      , ("tells 5 is not equal to 6", "5.eq( 6 )", BtOne "00")
+      , ("adds two numbers", "5.plus( 6 )", BtMany ["40", "26", "00", "00", "00", "00", "00", "00"])
+      , ("multiplies two numbers", "5.times( 6 )", BtMany ["40", "3E", "00", "00", "00", "00", "00", "00"])
       ,
         ( "conjoins two long bytes"
         , raw "02-EF-D4-05-5E-78-3A" ++ ".and( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
@@ -753,7 +764,6 @@ spec = do
       , ("cannot multiply by a non-numeric operand", "5.times( " ++ raw "--" ++ " )")
       , ("cannot divide by a non-numeric divisor", "5.div( " ++ raw "--" ++ " )")
       , ("cannot compare against a non-numeric threshold", "5.gt( " ++ raw "--" ++ " )")
-      , ("cannot test equality against a non-numeric operand", "5.eq( " ++ raw "--" ++ ", 6 )")
       , -- A number atom also rejects a non-empty operand whose byte array is not
         -- 8 bytes long (e.g. 2 or 5 bytes): such an array carries no number, and
         -- the atom must yield ⊥ instead of crashing on 'btsToNum' (issue #1072).
@@ -761,7 +771,6 @@ spec = do
       , ("cannot multiply by a 2-byte operand", "5.times( " ++ raw "20-1F" ++ " )")
       , ("cannot divide by a 3-byte divisor", "5.div( " ++ raw "CA-FE-BE" ++ " )")
       , ("cannot compare against a 4-byte threshold", "5.gt( " ++ raw "FF-FF-FF-FF" ++ " )")
-      , ("cannot test equality against a 6-byte operand", "5.eq( " ++ raw "CA-FE-BE-20-1F-EE" ++ ", 6 )")
       , -- 'right' rejects a shift distance that is not a plain 8-byte integer;
         -- empty bytes carry no such integer, so the shift atom is stuck too.
         ("cannot shift right by a non-integer distance", raw "C0-43-00-00-00-00-00-00" ++ ".right( " ++ raw "--" ++ " )")


### PR DESCRIPTION
Closes #1074

## What

`L_number_eq` is gone. As @yegor256 clarified in #1074, EO has no `number.eq`
atom: `Φ.number.eq` in the merged XMIR is a pure-EO formation (voids `ρ` and
`x`, a `φ` that is an `.if`) composing `is-nan`, `or`, `and` and `L_bytes_eq` —
no `λ` kid, so there is nothing for a phino atom to implement. phino's data
atoms now mirror EO's set exactly: bytes {and, concat, eq, not, or, right,
size, slice} and number {div, gt, plus, times}.

## How

- `src/Dataize.hs`: the `atom "L_number_eq"` clause is removed; a comment above
  `atom` records why — EO spells `number.eq` out of `L_bytes_eq` (eq.eo), and
  names like `L_bool_if`/`L_string_slice` must stay unimplemented so that
  `--partial` parks on them and the EO lowering renders the call to Java.
- `test/DataizeSpec.hs`:
  - the `primitives` fixture now composes `number.eq` the way `eq.eo` does:
    `eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]]`;
  - `5.eq( 5 )` → `FF` and `5.eq( 6 )` → `00` pin that composition (the `true`
    byte is `FF-` since #1111), plus happy paths for `plus`/`times`;
  - the two `L_number_eq` stuck-atom cases are dropped — there is no atom to be
    stuck, a composed `eq` over non-numeric bytes simply compares them;
  - the `Factorial` case now branches through a boolean `if`
    (`$.x.eq( 1 ).if( 1, … )`) with `true`/`false` objects carrying `if`, and
    still dataizes to `6.0`.

## Notes

- `cabal build all --ghc-options=-Werror`, `hlint` and `fourmolu --mode check`
  pass. The full local suite keeps its 13 pre-existing `LocatorSpec` failures
  (GHC 9.10 `HasCallStack` backtraces, #1077/#1100), unrelated to this change.
- When #1110 (`atoms` catalogue) lands, its `L_number_eq` entry should be
  dropped along with the atom.
