### PR TITLE
feat(cli): add `morph` command, exposing 𝕄 outside of 𝔻

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,9 @@ via `benchmark/mvnw`.
 components: `library` (`src/`), executable `phino` (`app/`), test suite
 `spec` (`test/`), benchmark suite `bench` (`benchmark/`).
 
-### Five CLI commands
+### Six CLI commands
 
-`rewrite` | `dataize` | `explain` | `merge` | `match` — all wired in
+`rewrite` | `dataize` | `morph` | `explain` | `merge` | `match` — all wired in
 `src/CLI/Runners.hs`, parsed in `src/CLI/Parsers.hs`.
 
 ### Two-phase rendering pipeline
@@ -86,7 +86,11 @@ type alias.
 `Dataize.hs` implements the formal Morphing (M) and Dataization (D)
 functions with named rules: PRIM, NMZ, LAMBDA, PHI (morphing) and DELTA,
 BOX, NORM (dataization). All configuration is threaded through
-`DataizeContext` and `RewriteContext` records — no global state.
+`DataizeContext` and `RewriteContext` records — no global state. Each
+function has a top-level wrapper that locates the subterm and starts the
+chain (`morph`, `dataize`) and a recursive worker the rules drive
+(`morph'`, `dataize'`); the `morph` and `dataize` commands enter through
+the wrappers.
 
 ### Test pattern: YAML packs
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,47 @@ $ phino dataize --max-steps=50 problem.phi
 [ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=50
 ```
 
+## Morph
+
+Dataization insists on bytes. Morphing 𝕄 asks a different question: evaluate
+as far as the object model allows, without demanding data. It resolves Φ
+against the universe, peels dispatches and applications through
+normalization, fires whichever atoms sit under a dispatch, and stops at the
+first formation it reaches, handing that formation back untouched. The
+`morph` command runs 𝕄 on its own:
+
+```bash
+$ cat two.phi
+⟦
+  bytes(data) ↦ ⟦ φ ↦ data ⟧,
+  number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
+  φ ↦ 5.plus( 6 ).plus( 7 )
+⟧
+$ phino dataize --sweet --hide-rho two.phi
+40-32-00-00-00-00-00-00
+$ phino morph --locator=Q.φ --sweet --hide-rho two.phi
+⟦ x ↦ 7, λ ⤍ L_number_plus ⟧
+```
+
+The inner `5.plus( 6 )` fires, because `.plus` is dispatched on its result,
+and `11` lands in the `ρ` hidden by `--hide-rho`. The outer application is
+saturated but bare, so 𝕄 returns it and is finished; firing it is
+dataization's job and takes `dataize` on to `18`.
+
+The default locator `Q` morphs the whole top formation, which 𝕄 returns
+unchanged, so `--locator` is how one aims 𝕄 at a subterm, exactly as in
+`dataize`. Unlike 𝔻, 𝕄 is total: where no formation is reachable the answer
+is the terminator `⊥`, printed rather than reported as a failed run:
+
+```bash
+$ phino morph --locator=Q.x <<< '⟦ x ↦ ξ ⟧'
+⊥
+```
+
+The whole `dataize` option surface applies unchanged — `--sequence`,
+`--headers`, `--steps-dir`, `--evaluations`, `--partial`, `--max-steps`,
+`--shuffle`/`--seed`, `--output`, `--focus` and the rest.
+
 ## Rewrite
 
 You can rewrite this expression with the help of [rules](#rule-structure)

--- a/src/CLI.hs
+++ b/src/CLI.hs
@@ -25,6 +25,7 @@ runCLI args = handle handler $ do
   case _command of
     CmdRewrite opts -> runRewrite opts
     CmdDataize opts -> runDataize opts
+    CmdMorph opts -> runMorph opts
     CmdExplain opts -> runExplain opts
     CmdMerge opts -> runMerge opts
     CmdMatch opts -> runMatch opts
@@ -40,6 +41,7 @@ runCLI args = handle handler $ do
       let (level, lns) = case cmd of
             CmdRewrite OptsRewrite{_logLevel, _logLines} -> (_logLevel, _logLines)
             CmdDataize OptsDataize{_logLevel, _logLines} -> (_logLevel, _logLines)
+            CmdMorph OptsMorph{_logLevel, _logLines} -> (_logLevel, _logLines)
             CmdExplain OptsExplain{_logLevel, _logLines} -> (_logLevel, _logLines)
             CmdMerge OptsMerge{_logLevel, _logLines} -> (_logLevel, _logLines)
             CmdMatch OptsMatch{_logLevel, _logLines} -> (_logLevel, _logLines)

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -172,7 +172,7 @@ optShow =
     )
 
 optLocator :: Parser String
-optLocator = strOption (long "locator" <> metavar "FQN" <> help "Location of object to dataize. Must be a valid dispatch expression; e.g. Q.foo.bar" <> value "Q" <> showDefault)
+optLocator = strOption (long "locator" <> metavar "FQN" <> help "Location of object to rewrite, dataize or morph. Must be a valid dispatch expression; e.g. Q.foo.bar" <> value "Q" <> showDefault)
 
 optFocus :: Parser String
 optFocus =
@@ -203,7 +203,7 @@ optStepsDir :: Parser (Maybe FilePath)
 optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "Directory to save intermediate steps during rewriting/dataizing"))
 
 optPartial :: Parser Bool
-optPartial = switch (long "partial" <> help "Partial evaluation: compute what the known inputs decide and, instead of failing on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom), leave it in place and print the residual 𝜑-program instead of bytes")
+optPartial = switch (long "partial" <> help "Partial evaluation: compute what the known inputs decide and, instead of failing on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom), leave it in place and print the residual 𝜑-program")
 
 optEvaluations :: Parser (Maybe FilePath)
 optEvaluations = optional (strOption (long "evaluations" <> metavar "FILE" <> help "File to record every atom fired during dataizing, as one tab-separated line per firing: the λ function name, its argument formation and its result (requires --output=phi)"))
@@ -317,6 +317,47 @@ dataizeParser =
             <*> argInputFile
         )
 
+morphParser :: Parser Command
+morphParser =
+  CmdMorph
+    <$> ( OptsMorph
+            <$> optLogLevel
+            <*> optLogLines
+            <*> optInputFormat
+            <*> optOutputFormat
+            <*> optSugar
+            <*> optHideRho
+            <*> optLineFormat
+            <*> optOmitListing
+            <*> optOmitComments
+            <*> optNonumber
+            <*> optSequence
+            <*> optHeaders
+            <*> optCanonize
+            <*> optDepthSensitive
+            <*> optShuffle
+            <*> optSeed
+            <*> switch (long "quiet" <> help "Don't print the result of morphing")
+            <*> optPartial
+            <*> optCompress
+            <*> optMaxDepth
+            <*> optMaxCycles
+            <*> optMaxSteps
+            <*> optMargin
+            <*> optMeetPopularity
+            <*> optMeetLength
+            <*> optHide
+            <*> optShow
+            <*> optLocator
+            <*> optFocus
+            <*> optExpression
+            <*> optLabel
+            <*> optMeetPrefix
+            <*> optStepsDir
+            <*> optEvaluations
+            <*> argInputFile
+        )
+
 rewriteParser :: Parser Command
 rewriteParser =
   CmdRewrite
@@ -396,6 +437,7 @@ commandParser =
   hsubparser
     ( command "rewrite" (info rewriteParser (progDesc "Rewrite the 𝜑-expression"))
         <> command "dataize" (info dataizeParser (progDesc "Dataize the 𝜑-expression"))
+        <> command "morph" (info morphParser (progDesc "Morph the 𝜑-expression"))
         <> command "explain" (info explainParser (progDesc "Explain rules in LaTeX format"))
         <> command "merge" (info mergeParser (progDesc "Merge 𝜑-expressions into single one by merging their top level formations"))
         <> command "match" (info matchParser (progDesc "Match 𝜑-expression against provided pattern and build matched substitutions"))

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -202,6 +202,67 @@ runDataize OptsDataize{..} = do
         _meetPrefix
         _outputFormat
 
+-- Run 𝕄 on its own, the way 'runDataize' runs 𝔻. The whole option surface of
+-- 'dataize' applies unchanged, since the two commands differ only in the
+-- judgment they run; what differs here is the answer printed: 𝕄 is total and
+-- always hands back a 𝜑-expression — a formation, or the terminator ⊥ where no
+-- formation is reachable — so there are no bytes to print and no failure to
+-- report where 𝔻 would give up.
+runMorph :: OptsMorph -> IO ()
+runMorph OptsMorph{..} = do
+  validateOpts
+  excluded <- validatedDispatches "hide" _hide
+  included <- validatedDispatches "show" _show
+  [loc] <- validatedDispatches "locator" [_locator]
+  [foc] <- validatedDispatches "focus" [_focus]
+  validateNoOverlap "show" included "hide" excluded
+  input <- readInput _inputFile
+  expr <- parseInput input _inputFormat
+  setStdGen (mkStdGen _seed)
+  seedTaus expr
+  let printCtx = toPrintCtx foc
+      exclude = (`F.exclude` excluded)
+      include = (`F.include` included)
+  save <- saveStepFunc _stepsDir printCtx
+  (morphed, chain) <-
+    withEvalFunc _evaluations printCtx $
+      morph expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial buildTerm save
+  when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
+  unless _quiet (printFocused printCtx morphed >>= putStrLn)
+  where
+    validateOpts :: IO ()
+    validateOpts = do
+      validateLatexOptions
+        _outputFormat
+        [(_nonumber, "nonumber"), (_compress, "compress")]
+        [(_expression, "expression"), (_label, "label"), (_meetPrefix, "meet-prefix")]
+        [(_meetPopularity, "meet-popularity"), (_meetLength, "meet-length")]
+      validateXmirOptions _outputFormat [(_omitListing, "omit-listing"), (_omitComments, "omit-comments")] _focus
+      when (length _show > 1) (invalidCLIArguments "The option --show can be used only once")
+      when
+        (isJust _evaluations && _outputFormat /= PHI)
+        (invalidCLIArguments "The --evaluations option can stay together with --output=phi only, since one record must fit into one line")
+    toPrintCtx :: Expression -> PrintContext
+    toPrintCtx focus =
+      PrintCtx
+        _sugarType
+        _hideRho
+        _flat
+        _margin
+        defaultXmirContext
+        _nonumber
+        _compress
+        _canonize
+        _sequence
+        _headers
+        (justMeetPopularity _meetPopularity)
+        (justMeetLength _meetLength)
+        focus
+        _expression
+        _label
+        _meetPrefix
+        _outputFormat
+
 runExplain :: OptsExplain -> IO ()
 runExplain OptsExplain{..} = do
   setStdGen (mkStdGen _seed)

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -56,6 +56,7 @@ instance Show CmdException where
 data Command
   = CmdRewrite OptsRewrite
   | CmdDataize OptsDataize
+  | CmdMorph OptsMorph
   | CmdExplain OptsExplain
   | CmdMerge OptsMerge
   | CmdMatch OptsMatch
@@ -74,6 +75,48 @@ instance Show IOFormat where
   show LATEX = "latex"
 
 data OptsDataize = OptsDataize
+  { _logLevel :: LogLevel
+  , _logLines :: Int
+  , _inputFormat :: IOFormat
+  , _outputFormat :: IOFormat
+  , _sugarType :: SugarType
+  , _hideRho :: Bool
+  , _flat :: LineFormat
+  , _omitListing :: Bool
+  , _omitComments :: Bool
+  , _nonumber :: Bool
+  , _sequence :: Bool
+  , _headers :: Bool
+  , _canonize :: Bool
+  , _depthSensitive :: Bool
+  , _shuffle :: Bool
+  , _seed :: Int
+  , _quiet :: Bool
+  , _partial :: Bool
+  , _compress :: Bool
+  , _maxDepth :: Int
+  , _maxCycles :: Int
+  , _maxSteps :: Int
+  , _margin :: Int
+  , _meetPopularity :: Maybe Int
+  , _meetLength :: Maybe Int
+  , _hide :: [String]
+  , _show :: [String]
+  , _locator :: String
+  , _focus :: String
+  , _expression :: Maybe String
+  , _label :: Maybe String
+  , _meetPrefix :: Maybe String
+  , _stepsDir :: Maybe FilePath
+  , _evaluations :: Maybe FilePath
+  , _inputFile :: Maybe FilePath
+  }
+
+-- The option surface of 'morph' is that of 'dataize': the two commands read the
+-- same input, aim the same '_locator' at the same subterm and print through the
+-- same formatting flags, differing only in the judgment they run — 𝕄, which
+-- stops at the first formation it reaches, against 𝔻, which insists on bytes.
+data OptsMorph = OptsMorph
   { _logLevel :: LogLevel
   , _logLines :: Int
   , _inputFormat :: IOFormat

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -10,7 +10,7 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Dataize (morph, dataize, dataize', DataizeContext (..), DataizeException (..), Outcome (..), Steps (..), State, emptyState, execBuildTerm) where
+module Dataize (morph, morph', dataize, dataize', DataizeContext (..), DataizeException (..), Outcome (..), Steps (..), State, emptyState, execBuildTerm) where
 
 import AST
 import Builder (buildBytesThrows, buildExpressionThrows)
@@ -64,7 +64,7 @@ data Steps = Steps
 -- The evaluation context carries the configuration plus the step budget spent so
 -- far. Nothing global is fixed here: the universe (the second argument 'e' of
 -- 𝕄(n, e, s) and 𝔻(n, e, s)) is a plain expression threaded as an argument to
--- 'dataize'', 'morph' and on to the atoms, and the state 's' is threaded the same
+-- 'dataize'', 'morph'' and on to the atoms, and the state 's' is threaded the same
 -- way (see 'State'). The working expression needed for normalization is taken
 -- from the head of the step chain, so no separate wrapper type is threaded
 -- around.
@@ -181,8 +181,8 @@ unparked action = action `catch` rethrow
 -- argument and its individual steps (alpha, copy, dot, …) are spliced into the
 -- chain before morphing continues. Every other premise is a side-computation
 -- evaluated in isolation by 'sidePremise', its own steps discarded.
-morph :: Morphed -> Expression -> State -> DataizeContext -> IO (Morphed, State)
-morph (expr, seq) univ state caller = do
+morph' :: Morphed -> Expression -> State -> DataizeContext -> IO (Morphed, State)
+morph' (expr, seq) univ state caller = do
   ctx <- deeper caller
   parking seq $ do
     rules <- if ctx._shuffle then shuffle Y.morphingRules else pure Y.morphingRules
@@ -222,15 +222,39 @@ morph (expr, seq) univ state caller = do
           built <- buildExpressionThrows inner final
           labelled <- leadsTo seq rule.name built ctx
           (normal', seq') <- normalized built labelled ctx
-          morph (normal', seq') univ state' ctx
+          morph' (normal', seq') univ state' ctx
         _ -> do
           (final, state') <- sides ctx (rule.premises `excluding` [concl]) subst
           built <- buildExpressionThrows arg final
           seq' <- leadsTo seq rule.name built ctx
-          morph (built, seq') univ state' ctx
+          morph' (built, seq') univ state' ctx
       Just _ -> throwIO (userError (printf "morphing rule '%s' must conclude with a 'morph' premise" rule.name))
     sides :: DataizeContext -> [Y.Premise] -> Subst -> IO (Subst, State)
     sides ctx premises subst = foldM (sidePremise univ ctx) (subst, state) premises
+
+-- Morph the expression located at '_locator' — 𝕄 asked on its own, the way
+-- 'dataize' asks 𝔻. The whole input expression is itself the universe Φ (the 'e'
+-- argument) threaded through 𝕄, so it is passed both as the located target and
+-- as the universe; the default locator Q therefore morphs the top formation,
+-- which 'mf' hands back unchanged, and '_locator' is how one aims 𝕄 at a
+-- subterm. Unlike 𝔻, 𝕄 is total: it stops at the first formation it reaches
+-- ('mf') and never demands bytes, and where no formation is reachable it answers
+-- with the terminator ⊥ ('dead', 'xi', 'mg', 'mad', 'maad') rather than failing.
+-- Only the atoms 'ml' fires can still get stuck, and '_partial' parks them just
+-- as it does under 𝔻: the answer is then the residual subterm the spine had
+-- reached, taken from '_locator' of its working expression.
+morph :: Expression -> DataizeContext -> IO (Expression, [Rewritten])
+morph universe ctx@DataizeContext{..} = do
+  expr <- locatedExpression _locator universe
+  -- Morphing starts from the empty state; the final state is not yet
+  -- consumed by any caller, so it is discarded here.
+  result <- try (morph' (expr, (universe, Nothing) :| []) universe emptyState ctx)
+  case result of
+    Right ((morphed, seq), _state) -> pure (morphed, reverse (NE.toList seq))
+    Left (StuckAt _ seq) | _partial -> do
+      residue <- locatedExpression _locator (fst (NE.head seq))
+      pure (residue, reverse (NE.toList seq))
+    Left failure -> throwIO (failure :: DataizeException)
 
 -- Dataize the expression located at '_locator'. The whole input expression is
 -- itself the universe Q (the 'e' argument) threaded through 𝔻 and 𝕄, so it is
@@ -320,7 +344,7 @@ dataize' (expr, seq) univ state caller = do
         Just morphed@(Y.Premise _ (Y.OpMorph inner)) -> do
           (final, state') <- sides ctx (rule.premises `excluding` [concl, morphed]) subst
           built <- buildExpressionThrows inner final
-          ((morphed', seq'), state'') <- morph (built, seq) univ state' ctx
+          ((morphed', seq'), state'') <- morph' (built, seq) univ state' ctx
           dataize' (morphed', seq') univ state'' ctx
         -- The dataize argument is produced with no 'normalize'/'morph' spine to
         -- splice: 'fire' by its 'evaluate' side-computation (𝔼 now yields a
@@ -623,6 +647,6 @@ _evaluate _ _ _ _ = throwIO (userError "Function evaluate() requires exactly 2 e
 _morph :: Expression -> DataizeContext -> State -> BuildTermMethodS
 _morph univ ctx state [ArgExpression expr] subst = unparked $ do
   built <- buildExpressionThrows expr subst
-  ((morphed, _), state') <- morph (built, (univ, Nothing) :| []) univ state ctx
+  ((morphed, _), state') <- morph' (built, (univ, Nothing) :| []) univ state ctx
   pure (TeExpression morphed, state')
 _morph _ _ _ _ _ = throwIO (userError "Function morph() requires exactly 1 expression argument")

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1304,7 +1304,7 @@ spec = do
 
     it "hands the top formation back untouched under the default locator" $
       withStdin "[[ D> 01- ]]" $
-        testCLISucceeded ["morph", "--flat"] ["⟦ Δ ⤍ 01- ⟧"]
+        testCLISucceeded ["morph", "--flat", "--hide-rho"] ["⟦ Δ ⤍ 01- ⟧"]
 
     it "stops at the bare saturated λ-formation" $
       withStdin chained $
@@ -1334,11 +1334,21 @@ spec = do
       withStdin "[[ x -> $ ]]" $
         testCLIFailed ["dataize", "--locator=Q.x"] ["terminator ⊥"]
 
+    -- The chain carries the spine: the morphing rules that reduced the term
+    -- ('maa', then the terminal 'mf') with the normalization steps they spliced
+    -- in ('alpha', 'copy'). The 'ml' firing of the inner call is not there by
+    -- design — it happens in a side premise, which reduces on a chain of its
+    -- own and discards it
     it "prints the chain of morphing steps with --sequence" $
       withStdin chained $
         testCLISucceeded
           ["morph", "--locator=Q.@", "--sequence", "--headers", "--sweet", "--hide-rho", "--flat"]
-          ["mf", "ml", "⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+          [ "Rule 'maa'"
+          , "Rule 'alpha'"
+          , "Rule 'copy'"
+          , "Rule 'mf'"
+          , "⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"
+          ]
 
     it "does not print the result with --quiet" $
       withStdin "[[ D> 01- ]]" $
@@ -1364,13 +1374,23 @@ spec = do
 
     it "accepts --seed, --shuffle and --depth-sensitive" $
       withStdin "[[ D> 01- ]]" $
-        testCLISucceeded ["morph", "--seed=7", "--shuffle", "--depth-sensitive", "--flat"] ["⟦ Δ ⤍ 01- ⟧"]
+        testCLISucceeded ["morph", "--seed=7", "--shuffle", "--depth-sensitive", "--flat", "--hide-rho"] ["⟦ Δ ⤍ 01- ⟧"]
 
-    it "fails on --max-steps instead of morphing forever" $
+    -- The division 𝔻 cannot finish, whatever '--max-steps' it is given (#1052),
+    -- is no work at all for 𝕄: the term is already a formation, so 'mf' hands
+    -- it back and the atom is never fired
+    it "returns the λ-formation dataize cannot finish on" $
       withStdin "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧" $
+        testCLISucceeded
+          ["morph", "--locator=Q.@", "--max-steps=40", "--flat", "--hide-rho"]
+          ["⟦ λ ⤍ L_number_div"]
+
+    -- '--max-steps' bounds the 𝕄 recursion just as it bounds the 𝕄/𝔻 one
+    it "fails once the --max-steps budget is spent" $
+      withStdin chained $
         testCLIFailed
-          ["morph", "--locator=Q.@", "--max-steps=40"]
-          ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=40"]
+          ["morph", "--locator=Q.@", "--max-steps=3"]
+          ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=3"]
 
     -- 𝕄 never fires a bare λ-formation, so only the atoms sitting under a
     -- dispatch ('ml') can get stuck; '--partial' parks them exactly as under 𝔻

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1291,6 +1291,126 @@ spec = do
       withStdin "[[ D> 01- ]]" $
         testCLISucceeded ["dataize", "--depth-sensitive"] ["01-"]
 
+  -- 𝕄 was reachable only from inside 𝔻, through the 'norm' rule of the
+  -- dataization relation, so there was no way to ask phino for 𝕄(n, Φ) on its
+  -- own (#1114)
+  describe "morph" $ do
+    -- Two chained atom calls: the inner one fires under 'ml', because '.plus'
+    -- is dispatched on its result, while the outer application is saturated but
+    -- bare, so 'mf' hands it back and firing it is 𝔻's job
+    let chained = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]"
+    it "prints help" $
+      testCLISucceeded ["morph", "--help"] ["Morph the 𝜑-expression"]
+
+    it "hands the top formation back untouched under the default locator" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded ["morph", "--flat"] ["⟦ Δ ⤍ 01- ⟧"]
+
+    it "stops at the bare saturated λ-formation" $
+      withStdin chained $
+        testCLISucceeded
+          ["morph", "--locator=Q.@", "--sweet", "--hide-rho", "--flat"]
+          ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+
+    -- The same term under 𝔻, which insists on bytes and fires what 𝕄 left bare
+    it "leaves to dataize the firing that takes the same term to bytes" $
+      withStdin chained $
+        testCLISucceeded ["dataize"] ["40-32-00-00-00-00-00-00"]
+
+    -- 'mf' hands a formation back as it is, so '--locator' is how one aims 𝕄 at
+    -- a subterm worth navigating: here it resolves Φ against the universe and
+    -- peels the dispatch through 𝒩
+    it "morphs the subterm --locator aims at" $
+      withStdin "[[ ex -> Q.x, x -> [[ D> 42- ]] ]]" $
+        testCLISucceeded ["morph", "--locator=Q.ex", "--flat", "--hide-rho"] ["⟦ Δ ⤍ 42- ⟧"]
+
+    -- 𝕄 is total and 𝔻 is not: where the derivation dies, 𝕄 answers ⊥ ('xi'
+    -- here) and the run succeeds, while 𝔻 has no bytes to give and fails
+    it "prints ⊥ instead of failing the run" $
+      withStdin "[[ x -> $ ]]" $
+        testCLISucceeded ["morph", "--locator=Q.x"] ["⊥"]
+
+    it "fails to dataize what it morphs to ⊥" $
+      withStdin "[[ x -> $ ]]" $
+        testCLIFailed ["dataize", "--locator=Q.x"] ["terminator ⊥"]
+
+    it "prints the chain of morphing steps with --sequence" $
+      withStdin chained $
+        testCLISucceeded
+          ["morph", "--locator=Q.@", "--sequence", "--headers", "--sweet", "--hide-rho", "--flat"]
+          ["mf", "ml", "⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+
+    it "does not print the result with --quiet" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded ["morph", "--quiet"] []
+
+    it "records the atoms it fires with --evaluations" $
+      withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+        hClose stream
+        withStdin chained $
+          testCLISucceeded ["morph", "--locator=Q.@", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+        records <- readUtf8 path
+        lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11"]
+
+    it "saves morphing steps to dir with --steps-dir" $
+      withTempDirectory "phino-steps-morph" $ \dir ->
+        withStdin chained $ do
+          testCLISucceeded
+            ["morph", "--locator=Q.@", "--steps-dir=" ++ dir, "--sweet", "--hide-rho", "--flat"]
+            ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+          steps <- sort <$> listDirectory dir
+          steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
+          length steps `shouldSatisfy` (> 0)
+
+    it "accepts --seed, --shuffle and --depth-sensitive" $
+      withStdin "[[ D> 01- ]]" $
+        testCLISucceeded ["morph", "--seed=7", "--shuffle", "--depth-sensitive", "--flat"] ["⟦ Δ ⤍ 01- ⟧"]
+
+    it "fails on --max-steps instead of morphing forever" $
+      withStdin "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧" $
+        testCLIFailed
+          ["morph", "--locator=Q.@", "--max-steps=40"]
+          ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=40"]
+
+    -- 𝕄 never fires a bare λ-formation, so only the atoms sitting under a
+    -- dispatch ('ml') can get stuck; '--partial' parks them exactly as under 𝔻
+    describe "--partial" $ do
+      let stuck = "[[ @ -> [[ L> Sym_arg_0 ]].foo ]]"
+      it "fails on an atom that cannot fire without the flag" $
+        withStdin stuck $
+          testCLIFailed ["morph", "--locator=Q.@"] ["Atom 'Sym_arg_0' does not exist"]
+
+      it "prints the residue with the stuck application intact and exits successfully" $
+        withStdin stuck $
+          testCLISucceeded
+            ["morph", "--locator=Q.@", "--partial", "--flat", "--hide-rho"]
+            ["⟦ λ ⤍ Sym_arg_0 ⟧.foo"]
+
+    describe "fails" $ do
+      it "with --output != latex and --nonumber" $
+        withStdin "" $
+          testCLIFailed
+            ["morph", "--nonumber", "--output=xmir"]
+            ["The --nonumber option can stay together with --output=latex only"]
+
+      it "with --evaluations and --output != phi" $
+        withStdin "[[ D> 01- ]]" $
+          testCLIFailed
+            ["morph", "--evaluations=evaluations.txt", "--output=latex"]
+            ["The --evaluations option can stay together with --output=phi only"]
+
+      it "with --show used more than once" $
+        withStdin "" $
+          testCLIFailed
+            ["morph", "--show=Q.a", "--show=Q.b"]
+            ["The option --show can be used only once"]
+
+      it "with wrong --locator option" $
+        withStdin "" $
+          testCLIFailed
+            ["morph", "--locator=Q.x(Q.y)"]
+            ["[ERROR]:", "Only dispatch expression started with Φ (or Q) can be used in --locator"]
+
   describe "explain" $ do
     it "prints help" $
       testCLISucceeded

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -13,7 +13,7 @@ import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe, isJust)
-import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph)
+import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph, morph')
 import Deps (Evaluation (..), Term (TeExpression), dontSaveEval, dontSaveStep)
 import Functions (buildTerm)
 import Matcher (substEmpty)
@@ -52,6 +52,16 @@ testDataize useCases =
       loc' <- parseExpressionThrows loc
       (value, _) <- dataize expr (defaultDataizeContext loc')
       value `shouldBe` Dataized res
+
+testMorph :: [(String, String, String, String)] -> Spec
+testMorph useCases =
+  forM_ useCases $ \(name, loc, src, res) ->
+    it name $ do
+      expr <- parseExpressionThrows src
+      loc' <- parseExpressionThrows loc
+      expected <- parseExpressionThrows res
+      (morphed, _) <- morph expr (defaultDataizeContext loc')
+      morphed `shouldBe` expected
 
 -- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
 -- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
@@ -133,9 +143,46 @@ testStuckAtom useCases =
 
 spec :: Spec
 spec = do
-  describe "morph" $
+  -- The top-level 𝕄 entry point, the one the 'morph' command runs: it locates
+  -- the subterm, threads the whole input expression as the universe and hands
+  -- back the morphed expression together with the chain that led to it (#1114).
+  describe "morph" $ do
+    testMorph
+      [ ("hands the top formation back untouched under the Q locator", "Q", "[[ D> 00- ]]", "[[ D> 00- ]]")
+      , -- 𝕄 is total where 𝔻 is not: the 'xi' axiom morphs ξ to ⊥, so the run
+        -- ends with an answer rather than with a failure
+        ("answers ⊥ where no formation is reachable", "Q.x", "[[ x -> $ ]]", "T")
+      ]
+
+    -- The chain runs oldest step first and carries the rule that produced the
+    -- step after it, exactly as 'dataize' reports its own, so '--sequence'
+    -- prints both the same way
+    it "reports the chain of steps oldest first" $ do
+      expr <- parseExpressionThrows "[[ D> 00- ]]"
+      (morphed, chain) <- morph expr (defaultDataizeContext ExRoot)
+      morphed `shouldBe` expr
+      map snd chain `shouldBe` [Just "mf", Nothing]
+      map fst chain `shouldBe` [expr, expr]
+
+    -- 𝕄 never fires a bare λ-formation, so only an atom sitting under a
+    -- dispatch (the 'ml' rule) can get stuck
+    describe "a stuck atom under 'ml'" $ do
+      let stuck :: IO (Expression, Expression)
+          stuck = (,) <$> parseExpressionThrows "[[ x -> [[ L> Sym_arg_0 ]].foo ]]" <*> parseExpressionThrows "Q.x"
+      it "fails the run without '_partial'" $ do
+        (expr, loc) <- stuck
+        morph expr (defaultDataizeContext loc)
+          `shouldThrow` (\e -> "Atom 'Sym_arg_0' does not exist" `isInfixOf` show (e :: SomeException))
+
+      it "is parked in the residue under '_partial'" $ do
+        (expr, loc) <- stuck
+        expected <- parseExpressionThrows "[[ L> Sym_arg_0 ]].foo"
+        (residue, _) <- morph expr (defaultDataizeContext loc){_partial = True}
+        residue `shouldBe` expected
+
+  describe "morph'" $
     test'
-      morph
+      morph'
       [ ("[[ D> 00- ]] => [[ D> 00- ]]", ExFormation [BiDelta (BtOne "00")], ExRoot, ExFormation [BiDelta (BtOne "00")])
       , ("T => T", ExTermination, ExRoot, ExTermination)
       , ("$ => X", ExXi, ExRoot, ExTermination)
@@ -181,11 +228,11 @@ spec = do
   -- and every such normal form is covered by some morphing clause (an axiom
   -- like 'mf'/'dead'/'xi'/'universe'/'mg' or a recursive rule), so the "no rule
   -- matched" fallback never fires along any real derivation. It is still total
-  -- code, reachable by calling 'morph' directly (bypassing normalization) on a
+  -- code, reachable by calling 'morph'' directly (bypassing normalization) on a
   -- raw meta 𝑛, an AST node the matcher never binds to any concrete pattern.
-  describe "morph fails when no morphing rule matches the term" $
+  describe "morph' fails when no morphing rule matches the term" $
     it "throws instead of looping when handed a bare, unmatched meta" $
-      morph (ExMeta "unbound", (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
+      morph' (ExMeta "unbound", (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
         `shouldThrow` (\e -> "no morphing rule matched" `isInfixOf` show (e :: SomeException))
 
   -- Symmetric to the morphing fallback above: every normal form 𝔻 actually
@@ -266,7 +313,7 @@ spec = do
       dataize' (form, (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
         `shouldThrow` (\e -> "non-formation universe" `isInfixOf` show (e :: SomeException))
 
-  -- 'defaultDataizeContext' runs with '_shuffle' on, so 'morph' walks the
+  -- 'defaultDataizeContext' runs with '_shuffle' on, so 'morph'' walks the
   -- morphing rules in a random order on every step. Every clause is
   -- order-independent (the known overlaps were removed in #856 and #860), so the
   -- outcome must never depend on that order: morphing each input many times under
@@ -289,7 +336,7 @@ spec = do
           ]
     forM_ cases $ \(desc, input, univ, expected) ->
       it ("morphs " ++ desc ++ " to the same form across 100 random rule orders") $ do
-        results <- replicateM 100 (fst . fst <$> morph (input, (univ, Nothing) :| []) univ emptyState (defaultDataizeContext ExRoot))
+        results <- replicateM 100 (fst . fst <$> morph' (input, (univ, Nothing) :| []) univ emptyState (defaultDataizeContext ExRoot))
         nub results `shouldBe` [expected]
 
   -- 'md' fires only when its head is not a formation ('not (formation 𝑛)'),
@@ -317,7 +364,7 @@ spec = do
     it "drills a chained λ-formation dispatch down to the base 'ml'" $ do
       let base = ExFormation [BiLambda (Function "F")]
           chain = ExDispatch (ExDispatch (ExDispatch base (AtLabel "a")) (AtLabel "b")) (AtLabel "c")
-      morph (chain, (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
+      morph' (chain, (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
         `shouldThrow` (\e -> "Atom 'F' does not exist" `isInfixOf` show (e :: SomeException))
 
   -- 'norm' matches the bare meta 𝑛, which unifies with any expression, so it is
@@ -401,7 +448,7 @@ spec = do
 
   -- '--max-cycles' and '--max-depth' reach only the normalization run inside a
   -- single step, so the 𝕄/𝔻 recursion itself was unbounded: this division, whose
-  -- λ-atom keeps re-firing on a term that never reduces to bytes, sent 'morph'
+  -- λ-atom keeps re-firing on a term that never reduces to bytes, sent 'morph''
   -- through md → ma → universe → mf → mphi → ml forever and no CLI option could
   -- stop it (#1052). '--max-steps' bounds that recursion and fails once the
   -- budget is gone.


### PR DESCRIPTION
Closes #1114.

Morphing 𝕄 was implemented (`morph`, `src/Dataize.hs`) and formalized
(`resources/morphing.yaml`), but reachable only from inside 𝔻, through the
`norm` rule of `resources/dataization.yaml`. `explain --morph` printed the rules;
it did not run them. This adds a `morph` command that runs 𝕄 on its own.

## What changed

`src/Dataize.hs` splits 𝕄 the way 𝔻 is already split: the recursive worker the
rules drive is now `morph'`, and a new top-level `morph` wrapper locates the
subterm, threads the whole input expression as the universe and returns the
morphed expression together with its chain of steps (oldest first), instead of
`(Outcome, [Rewritten])`.

Two behaviours the issue asked to pin down:

* the default locator `Q` morphs the whole top formation, which `mf` returns
  unchanged, so `--locator` is how one aims 𝕄 at a subterm, exactly as in
  `dataize`;
* 𝕄 is total where 𝔻 is not, so `morph` prints `⊥` (`dead`, `xi`, `mg`, `mad`,
  `maad`) where `dataize` fails the run. Only the atoms `ml` fires can still get
  stuck, and `--partial` parks them exactly as under 𝔻, answering with the
  residual subterm.

`src/CLI/Types.hs` gains `CmdMorph` and an `OptsMorph` record mirroring
`OptsDataize`; `src/CLI/Parsers.hs` gains `morphParser` and
`command "morph" (info morphParser (progDesc "Morph the 𝜑-expression"))` next to
`dataize`; `src/CLI/Runners.hs` gains `runMorph` beside `runDataize`. The whole
`dataize` option surface applies unchanged — `--sequence`, `--headers`,
`--steps-dir`, `--evaluations`, `--partial`, `--max-steps`, `--shuffle`/`--seed`,
`--output`, `--focus`.

Two shared help strings were generalized, since they now cover three commands:
`--locator` no longer says "object to dataize", and `--partial` no longer ends
with "instead of bytes".

## The boundary it makes visible

```
$ cat two.phi
⟦
  bytes(data) ↦ ⟦ φ ↦ data ⟧,
  number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
  φ ↦ 5.plus( 6 ).plus( 7 )
⟧
$ phino dataize --sweet --hide-rho two.phi
40-32-00-00-00-00-00-00
$ phino morph --locator=Q.φ --sweet --hide-rho two.phi
⟦ x ↦ 7, λ ⤍ L_number_plus ⟧
```

The inner `5.plus( 6 )` fires under `ml`, because `.plus` is dispatched on its
result. The outer application is saturated but bare, so `mf` returns it and 𝕄 is
finished; firing it is 𝔻's job and takes `dataize` on to `18`.

## Tests and docs

* `test/CLISpec.hs`: a `describe "morph"` block — the example above, the
  ⊥-versus-failure contrast against `dataize`, `--locator`, `--sequence`
  with `--headers`, `--quiet`, `--evaluations`, `--steps-dir`, `--partial` with
  and without a stuck atom, `--max-steps`, and the option validations.
* `test/DataizeSpec.hs`: wrapper tests (formation returned untouched, ⊥ answer,
  chain shape, stuck atom with and without `_partial`), plus the rename of the
  existing `morph` cases to `morph'`.
* `README.md`: a `## Morph` section; `CLAUDE.md`: the command count and the
  wrapper/worker split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCXhcLD16gx4e1t41dLA7i

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCXhcLD16gx4e1t41dLA7i)_