### PR TITLE
feat(dataize): replace built-in atoms with an `--atoms` registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,17 @@ Matching (`Matcher.hs`) produces `[Subst]` — a list of
 `Map Text MetaValue` — and conditions filter that list. `Builder.hs` then
 applies a substitution to a result template.
 
+### Atoms live outside the binary
+
+`phino` implements no λ function. `Atoms.hs` reads a JSON registry of them
+(the `--atoms` option) and fires each one as a POSIX process under the
+interpreter its `rt` names, feeding it the formation and the universe as JSON
+on stdin and reading the 𝜑-expression it answers with back from stdout. A λ
+name the registry does not carry gets stuck, which is what `--partial` parks
+on. Because a script cannot reduce its own operands, it asks `phino` for them
+with `--inside`, which binds an expression to a synthetic attribute of the
+universe and aims the run at it (`insideUniverse` in `Dataize.hs`).
+
 ### Dependency inversion for circular imports
 
 `Deps.hs` exists solely to break the cycle

--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ registry given with `--atoms`, keyed by λ name:
 ```json
 {
   "L_number_plus": {
-    "rt": "js",
+    "rt": "node",
     "script": "const fs = require('fs'); ..."
   }
 }
 ```
 
-The `rt` field names the interpreter the `script` is written for. Only `js` is
-supported for now, meaning `node`; a registry naming any other runtime is
-refused when the file is read, before dataization starts.
+The `rt` field names the executable the `script` is run under. Only `node` is
+supported for now; a registry naming any other runtime is refused when the file
+is read, before dataization starts.
 
 When 𝔼 reaches a λ function the registry carries, `phino` writes its `script`
 to a temporary file and runs it as a POSIX process under that interpreter, with

--- a/README.md
+++ b/README.md
@@ -100,6 +100,114 @@ $ phino dataize hello.phi
 68-65-6C-6C-6F
 ```
 
+### Atoms
+
+Which λ functions exist is a property of the object model being dataized, not
+of the calculus, so `phino` implements none of them. They come from a JSON
+registry given with `--atoms`, keyed by λ name:
+
+```json
+{
+  "L_number_plus": {
+    "rt": "js",
+    "script": "const fs = require('fs'); ..."
+  }
+}
+```
+
+The `rt` field names the interpreter the `script` is written for. Only `js` is
+supported for now, meaning `node`; a registry naming any other runtime is
+refused when the file is read, before dataization starts.
+
+When 𝔼 reaches a λ function the registry carries, `phino` writes its `script`
+to a temporary file and runs it as a POSIX process under that interpreter, with
+the λ name as the first command-line argument:
+
+```text
+node /tmp/phino-atom-4f2a.js L_number_plus
+```
+
+The name matters: one script may be registered under several λ names and branch
+on it, which is where `node` puts it — `process.argv[2]`. The script is then
+fed one JSON object on `stdin`:
+
+```json
+{
+  "b": "⟦ x ↦ Φ.number( as-bytes ↦ … ), ρ ↦ ⟦ … ⟧ ⟧",
+  "s": "⟦ bytes ↦ ⟦ … ⟧, number ↦ ⟦ … ⟧, φ ↦ … ⟧"
+}
+```
+
+Here `b` is the formation being evaluated, with its λ binding removed so that
+the script may dispatch on it, and `s` is the universe Φ. Both are canonical
+𝜑-calculus on a single line — no syntax sugar, whatever `--sweet` says about
+the output of the run — so a script never has to know about `phino`'s sugar in
+order to find a datum: every byte array is spelled out as a Δ binding.
+
+The script writes one JSON object to `stdout`:
+
+```json
+{ "n": "11" }
+```
+
+The `n` field is the 𝜑-expression the atom answers with, in any syntax
+`phino`'s parser reads — syntax sugar included, so the `11` above and the
+`Φ.number( … )` it stands for are the same answer. `phino` parses it back
+and hands it to 𝔼 as the atom's raw result, normalizing it exactly as it
+normalizes anything else, so `--evaluations`, `--partial` and `--max-steps`
+keep working unchanged. A non-zero exit, output that is not JSON, a missing
+`n` or an `n` that does not parse fails the run, with the script's own
+`stderr` in the message.
+
+A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck
+on it. Without `--atoms` the registry is empty and every atom gets stuck.
+
+### Reducing the operands of an atom
+
+A script gets at the parts of `b` by calling `phino` again, so no API has to be
+exposed for it. The `--inside` option is how it asks: the expression it names
+is bound to a fresh synthetic attribute of the universe taken from the input,
+normalized there, and then dataized. This is the same trick `phino` plays
+internally whenever it has to reduce a sub-expression the program does not
+contain:
+
+```bash
+$ phino dataize --atoms=atoms.json --inside='5.plus( 6 )' universe.phi
+40-26-00-00-00-00-00-00
+```
+
+So a `L_number_plus` that reduces its own operands reads like this:
+
+```js
+const fs = require('fs');
+const { execFileSync } = require('child_process');
+const atom = process.argv[2];
+if (atom !== 'L_number_plus') {
+  throw new Error(`unsupported atom ${atom}`);
+}
+const { b, s } = JSON.parse(fs.readFileSync(0, 'utf8'));
+const dataized = (expr) => execFileSync(
+  'phino',
+  ['dataize', '--atoms=atoms.json', `--inside=${expr}`],
+  { input: s, encoding: 'utf8' }
+).trim();
+const number = (expr) => Buffer.from(dataized(expr).replace(/-/g, ''), 'hex').readDoubleBE(0);
+const sum = Buffer.alloc(8);
+sum.writeDoubleBE(number(`${b}.ρ`) + number(`${b}.x`));
+const hex = [...sum]
+  .map((octet) => octet.toString(16).toUpperCase().padStart(2, '0'))
+  .join('-');
+process.stdout.write(JSON.stringify({
+  n: `Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ${hex} ⟧ ) )`
+}));
+```
+
+The `--inside` option cannot be combined with `--locator`, since it aims the
+run at the binding it mints itself. Both `dataize` and `morph` take `--atoms`
+and `--inside`.
+
+### Recording what fired
+
 Every atom fired on the way to the bytes may be recorded in a machine-readable
 protocol, with the `--evaluations` option. One firing is one line of three
 tab-separated fields: the name of the λ function, the formation it was applied
@@ -112,7 +220,8 @@ $ cat sum.phi
   number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
   φ ↦ 5.plus( 6 )
 ⟧
-$ phino dataize --evaluations=atoms.tsv --quiet --sweet --hide-rho sum.phi
+$ phino dataize --atoms=atoms.json --evaluations=atoms.tsv --quiet \
+    --sweet --hide-rho sum.phi
 $ cat -T atoms.tsv
 L_number_plus^I⟦ x ↦ 6 ⟧^I11
 ```
@@ -122,13 +231,15 @@ Records follow the syntax of the other options, such as `--sweet` and
 beginning of every run, and `--output=phi` is the only output format it
 works with, since one record must fit into one line.
 
-An atom that cannot fire fails the run: its λ function is unknown to phino,
-or one of its inputs reaches such an atom. This is what happens when a
-data input is replaced on purpose by a placeholder formation, such as
-`⟦ λ ⤍ Sym_arg_0 ⟧`. With `--partial`, dataization becomes partial
-evaluation instead: what the known inputs decide is computed, the rest
-survives as the residual program, which is printed in place of the bytes,
-and the run ends successfully:
+### Partial evaluation
+
+An atom that cannot fire fails the run: its λ function is not in the registry
+given with `--atoms`. This is what happens when an operation is deliberately
+left unimplemented — a data input replaced by a placeholder formation such as
+`⟦ λ ⤍ Sym_arg_0 ⟧`, or an operation whose answer is not known yet. With
+`--partial`, dataization becomes partial evaluation instead: what the known
+inputs decide is computed, the rest survives as the residual program, which is
+printed in place of the bytes, and the run ends successfully:
 
 ```bash
 $ cat partial.phi
@@ -137,29 +248,29 @@ $ cat partial.phi
   number(as-bytes) ↦ ⟦
     φ ↦ as-bytes,
     plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧,
-    times(x) ↦ ⟦ λ ⤍ L_number_times ⟧
+    times(x) ↦ ⟦ λ ⤍ L_number_times ⟧,
+    as-bool ↦ ⟦ λ ⤍ L_number_as_bool ⟧
   ⟧,
-  φ ↦ 2.times(3).plus(⟦ λ ⤍ Sym_arg_0 ⟧)
+  φ ↦ 2.times( 3 ).plus( 4 ).as-bool
 ⟧
-$ phino dataize --partial --sweet --hide-rho partial.phi
-⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧
+$ phino dataize --atoms=atoms.json --partial --sweet --hide-rho partial.phi
+⟦ λ ⤍ L_number_as_bool ⟧
 ```
 
-Here `2.times(3)` was decided by literals, so it was computed (its result,
-`6`, sits in the hidden `ρ` of the residual program), while `plus` waits
-for an `x` no atom can produce, so it stays in place as a normal-form
-subterm. Each such stuck site also lands in the `--evaluations` file, as a
-record with the first two fields only, since there is no result to report;
-the inner stuck atom comes first, then the known atom whose input reached
-it:
+Here `2.times( 3 ).plus( 4 )` was decided by the atoms the registry carries, so
+it was computed (its result, `10`, sits in the hidden `ρ` of the residual
+program), while `as-bool` names a λ function no script answers for, so it stays
+in place as a normal-form subterm. Each such stuck site also lands in the
+`--evaluations` file, as a record with the first two fields only, since there is
+no result to report:
 
 ```bash
-$ phino dataize --partial --evaluations=atoms.tsv --quiet \
+$ phino dataize --atoms=atoms.json --partial --evaluations=atoms.tsv --quiet \
     --sweet --hide-rho partial.phi
 $ cat -T atoms.tsv
 L_number_times^I⟦ x ↦ 3 ⟧^I6
-Sym_arg_0^I⟦⟧
-L_number_plus^I⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧
+L_number_plus^I⟦ x ↦ 4 ⟧^I10
+L_number_as_bool^I⟦⟧
 ```
 
 Evaluation stays demand-driven, as the calculus prescribes: an argument
@@ -193,9 +304,9 @@ $ cat two.phi
   number(as-bytes) ↦ ⟦ φ ↦ as-bytes, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
   φ ↦ 5.plus( 6 ).plus( 7 )
 ⟧
-$ phino dataize --sweet --hide-rho two.phi
+$ phino dataize --atoms=atoms.json --sweet --hide-rho two.phi
 40-32-00-00-00-00-00-00
-$ phino morph --locator=Q.φ --sweet --hide-rho two.phi
+$ phino morph --atoms=atoms.json --locator=Q.φ --sweet --hide-rho two.phi
 ⟦ x ↦ 7, λ ⤍ L_number_plus ⟧
 ```
 
@@ -214,9 +325,9 @@ $ phino morph --locator=Q.x <<< '⟦ x ↦ ξ ⟧'
 ⊥
 ```
 
-The whole `dataize` option surface applies unchanged — `--sequence`,
-`--headers`, `--steps-dir`, `--evaluations`, `--partial`, `--max-steps`,
-`--shuffle`/`--seed`, `--output`, `--focus` and the rest.
+The whole `dataize` option surface applies unchanged — `--atoms`, `--inside`,
+`--sequence`, `--headers`, `--steps-dir`, `--evaluations`, `--partial`,
+`--max-steps`, `--shuffle`/`--seed`, `--output`, `--focus` and the rest.
 
 ## Rewrite
 

--- a/README.md
+++ b/README.md
@@ -166,15 +166,18 @@ on it. Without `--atoms` the registry is empty and every atom gets stuck.
 
 A script gets at the parts of `b` by calling `phino` again, so no API has to be
 exposed for it. The `--inside` option is how it asks: the expression it names
-is bound to a fresh synthetic attribute of the universe taken from the input,
-normalized there, and then dataized. This is the same trick `phino` plays
-internally whenever it has to reduce a sub-expression the program does not
-contain:
+is bound to a fresh synthetic attribute of the input expression, which the run
+takes as the universe, normalized there, and then dataized. This is the same
+trick `phino` plays internally whenever it has to reduce a sub-expression the
+program does not contain:
 
 ```bash
 $ phino dataize --atoms=atoms.json --inside='5.plus( 6 )' universe.phi
 40-26-00-00-00-00-00-00
 ```
+
+Here `universe.phi` is the 𝜑-program the atom is being fired inside — the very
+text the script was handed as `s`, which it feeds back on `stdin`.
 
 So a `L_number_plus` that reduces its own operands reads like this:
 

--- a/phino.cabal
+++ b/phino.cabal
@@ -35,6 +35,7 @@ library
   import: warnings
   exposed-modules:
     AST
+    Atoms
     Builder
     Bytes
     Canonizer
@@ -94,6 +95,7 @@ library
     gitrev >=1.3.1 && <1.4,
     megaparsec >=9.5 && <9.9,
     optparse-applicative >=0.18 && <0.20,
+    process >=1.6.17 && <1.7,
     random >=1.2 && <1.4,
     regex-pcre-builtin >=0.95.2 && <0.96,
     scientific >=0.3.7 && <0.4,
@@ -125,6 +127,7 @@ test-suite spec
   hs-source-dirs: test
   other-modules:
     ASTSpec
+    AtomsSpec
     BuilderSpec
     BytesSpec
     CanonizerSpec
@@ -138,6 +141,7 @@ test-suite spec
     EncodingSpec
     FilesSpec
     FilterSpec
+    Fixtures
     FunctionsSpec
     LaTeXSpec
     LiningSpec

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -14,7 +14,7 @@
 --
 -- > {
 -- >   "L_bytes_eq": {
--- >     "rt": "js",
+-- >     "rt": "node",
 -- >     "script": "const fs = require('fs'); ..."
 -- >   }
 -- > }
@@ -60,11 +60,11 @@ import System.IO (Handle, IOMode (WriteMode), hClose, hSetBinaryMode, openBinary
 import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, waitForProcess)
 import Text.Printf (printf)
 
--- The interpreter a script is written for. Only JavaScript for now, meaning
--- 'node'. A registry naming any other runtime is rejected when it is read,
--- before dataization starts, so a run never gets half-way through a program to
--- discover that one of its atoms cannot be run at all.
-data Runtime = RtJs
+-- The interpreter a script is run under, named after the executable itself:
+-- only 'node' for now. A registry naming any other runtime is rejected when it
+-- is read, before dataization starts, so a run never gets half-way through a
+-- program to discover that one of its atoms cannot be run at all.
+data Runtime = RtNode
   deriving stock (Eq, Show)
 
 -- One entry of the registry: the runtime and the source of the script.
@@ -101,20 +101,21 @@ instance Show AtomException where
 
 -- The name a registry spells a runtime with.
 runtimeName :: Runtime -> String
-runtimeName RtJs = "js"
+runtimeName RtNode = "node"
 
 -- The POSIX executable the scripts of a runtime are run under.
 interpreter :: Runtime -> String
-interpreter RtJs = "node"
+interpreter RtNode = "node"
 
 -- The extension the script of a runtime is written to disk with, so the
--- interpreter recognizes the file for what it is.
+-- interpreter recognizes the file for what it is. This is the language, not the
+-- runtime: 'node' loads a file only if it is named '.js'.
 extension :: Runtime -> String
-extension RtJs = "js"
+extension RtNode = "js"
 
 -- Every runtime phino can run, in the order the '--atoms' help lists them.
 runtimes :: [Runtime]
-runtimes = [RtJs]
+runtimes = [RtNode]
 
 runtimeNames :: [String]
 runtimeNames = map runtimeName runtimes

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -56,7 +56,7 @@ import Printer (printExpression')
 import Sugar (SugarType (SALTY))
 import System.Directory (getTemporaryDirectory, removePathForcibly)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
-import System.IO (Handle, IOMode (ReadMode, WriteMode), hClose, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
+import System.IO (Handle, IOMode (WriteMode), hClose, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
 import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, waitForProcess)
 import Text.Printf (printf)
 
@@ -168,45 +168,54 @@ readRegistry path = do
 fireAtom :: T.Text -> Atom -> Expression -> Expression -> IO Expression
 fireAtom func Atom{..} form univ =
   withTemp (printf "phino-atom-.%s" (extension _runtime)) (encodeUtf8 _script) $ \script ->
-    withTemp "phino-atom-.json" (payload form univ) $ \input ->
-      withTemp "phino-atom-.err" "" $ \errors -> do
-        logDebug (printf "Firing atom '%s' as '%s %s %s'" (T.unpack func) (interpreter _runtime) script (T.unpack func))
-        (status, answer) <- executed script input errors
-        complaint <- readErrors errors
-        unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
-        case status of
-          ExitFailure code -> throwIO (AtomBroke func code complaint)
-          ExitSuccess -> answered answer
+    withTemp "phino-atom-.err" "" $ \errors -> do
+      logDebug (printf "Firing atom '%s' as '%s %s %s'" (T.unpack func) (interpreter _runtime) script (T.unpack func))
+      (status, answer) <- executed script errors
+      complaint <- readErrors errors
+      unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
+      case status of
+        ExitFailure code -> throwIO (AtomBroke func code complaint)
+        ExitSuccess -> answered answer
   where
-    -- Run the interpreter with stdin and stderr wired to files, so only stdout
-    -- is a pipe and neither side can ever block waiting for the other to drain
-    -- one. Both streams are bytes: a 𝜑 expression carries characters no
-    -- single-byte locale can spell, so nothing here is left to the locale.
-    executed :: FilePath -> FilePath -> FilePath -> IO (ExitCode, BS.ByteString)
-    executed script input errors =
-      withBinaryFile input ReadMode $ \stdin' ->
-        withBinaryFile errors WriteMode $ \stderr' -> do
-          (stdout', process) <- spawned script stdin' stderr'
-          hSetBinaryMode stdout' True
-          answer <- BS.hGetContents stdout'
-          status <- waitForProcess process
-          pure (status, answer)
-    spawned :: FilePath -> Handle -> Handle -> IO (Handle, ProcessHandle)
-    spawned script stdin' stderr' = do
+    -- Run the interpreter with its input and its output on pipes and its
+    -- complaints in a file. The input is written and closed before the output is
+    -- read, so the parent never has two streams to drain at once — which would
+    -- need threads to be safe — and the script's own stderr, which may be
+    -- anything at all, cannot fill a pipe nobody is reading. Every stream is
+    -- bytes: a 𝜑 expression carries characters no single-byte locale can spell,
+    -- so nothing is left to the locale.
+    executed :: FilePath -> FilePath -> IO (ExitCode, BS.ByteString)
+    executed script errors =
+      withBinaryFile errors WriteMode $ \stderr' -> do
+        (stdin', stdout', process) <- spawned script stderr'
+        hSetBinaryMode stdin' True
+        hSetBinaryMode stdout' True
+        -- A script that dies before reading its input leaves this write with
+        -- nobody to drain it. The failure worth reporting is the one the script
+        -- made, so a broken pipe is swallowed here and the exit status decides.
+        BS.hPut stdin' (payload form univ) `catch` unheard
+        hClose stdin' `catch` unheard
+        answer <- BS.hGetContents stdout'
+        status <- waitForProcess process
+        pure (status, answer)
+    spawned :: FilePath -> Handle -> IO (Handle, Handle, ProcessHandle)
+    spawned script stderr' = do
       spawn <- createProcess started `catch` missing
       case spawn of
-        (_, Just stdout', _, process) -> pure (stdout', process)
-        _ -> throwIO (AtomMute func "" "the interpreter gave phino no stdout to read")
+        (Just stdin', Just stdout', _, process) -> pure (stdin', stdout', process)
+        _ -> throwIO (AtomMute func "" "the interpreter gave phino no streams to talk over")
       where
         started :: CreateProcess
         started =
           (proc (interpreter _runtime) [script, T.unpack func])
-            { std_in = UseHandle stdin'
+            { std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = UseHandle stderr'
             }
     missing :: IOError -> IO a
     missing failure = throwIO (NoRuntime func (interpreter _runtime) (show failure))
+    unheard :: IOError -> IO ()
+    unheard _ = pure ()
     -- Whatever the script complained about, decoded leniently: the stream is
     -- the script's, so it may hold anything at all.
     readErrors :: FilePath -> IO String

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -1,0 +1,251 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+-- Which λ functions exist is a property of the object model being dataized,
+-- not of the calculus. phino therefore implements none of them: it reads a
+-- registry of them from a JSON file given with '--atoms' and fires each one as
+-- a POSIX process. The registry maps a λ name to the runtime that runs it and
+-- the script it runs:
+--
+-- > {
+-- >   "L_bytes_eq": {
+-- >     "rt": "js",
+-- >     "script": "const fs = require('fs'); ..."
+-- >   }
+-- > }
+--
+-- A name absent from the registry has no λ function at all: 𝔼 gets stuck on
+-- it, exactly as it does for a name no one ever declared (see 'Stuck' in
+-- 'Dataize').
+module Atoms
+  ( Atom (..)
+  , AtomException (..)
+  , Registry
+  , Runtime (..)
+  , emptyRegistry
+  , fireAtom
+  , readRegistry
+  , registeredAtom
+  , runtimeNames
+  )
+where
+
+import AST
+import Control.Exception (Exception, bracket, catch, throwIO)
+import Control.Monad (unless)
+import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.:), (.=))
+import qualified Data.Aeson as A
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.List (find, intercalate)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8Lenient, encodeUtf8)
+import Encoding (Encoding (UNICODE))
+import Lining (LineFormat (SINGLELINE))
+import Logger (logDebug)
+import Margin (defaultMargin)
+import Parser (parseExpression)
+import Printer (printExpression')
+import Sugar (SugarType (SALTY))
+import System.Directory (getTemporaryDirectory, removePathForcibly)
+import System.Exit (ExitCode (ExitFailure, ExitSuccess))
+import System.IO (Handle, IOMode (ReadMode, WriteMode), hClose, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
+import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, waitForProcess)
+import Text.Printf (printf)
+
+-- The interpreter a script is written for. Only JavaScript for now, meaning
+-- 'node'. A registry naming any other runtime is rejected when it is read,
+-- before dataization starts, so a run never gets half-way through a program to
+-- discover that one of its atoms cannot be run at all.
+data Runtime = RtJs
+  deriving stock (Eq, Show)
+
+-- One entry of the registry: the runtime and the source of the script.
+data Atom = Atom
+  { _runtime :: Runtime
+  , _script :: T.Text
+  }
+  deriving stock (Eq, Show)
+
+-- Every λ function phino may fire, keyed by name.
+type Registry = Map T.Text Atom
+
+data AtomException
+  = -- The '--atoms' file is not a JSON registry of λ functions.
+    BrokenRegistry FilePath String
+  | -- The interpreter of a runtime is not installed, so no script of it can run.
+    NoRuntime T.Text String String
+  | -- The script exited with a non-zero status; the message carries its stderr.
+    AtomBroke T.Text Int String
+  | -- The script exited successfully but said nothing phino can use: its stdout
+    -- is not a JSON object, carries no 'n' field, or the 𝜑-expression under it
+    -- does not parse.
+    AtomMute T.Text String String
+  deriving anyclass (Exception)
+
+instance Show AtomException where
+  show (BrokenRegistry file failure) = printf "The registry of atoms '%s' cannot be read: %s" file failure
+  show (NoRuntime func runner failure) =
+    printf "Atom '%s' cannot be fired, '%s' is not runnable: %s" (T.unpack func) runner failure
+  show (AtomBroke func status complaint) =
+    printf "Atom '%s' failed with exit code %d: %s" (T.unpack func) status complaint
+  show (AtomMute func answer failure) =
+    printf "Atom '%s' returned '%s', which phino cannot use: %s" (T.unpack func) answer failure
+
+-- The name a registry spells a runtime with.
+runtimeName :: Runtime -> String
+runtimeName RtJs = "js"
+
+-- The POSIX executable the scripts of a runtime are run under.
+interpreter :: Runtime -> String
+interpreter RtJs = "node"
+
+-- The extension the script of a runtime is written to disk with, so the
+-- interpreter recognizes the file for what it is.
+extension :: Runtime -> String
+extension RtJs = "js"
+
+-- Every runtime phino can run, in the order the '--atoms' help lists them.
+runtimes :: [Runtime]
+runtimes = [RtJs]
+
+runtimeNames :: [String]
+runtimeNames = map runtimeName runtimes
+
+instance FromJSON Runtime where
+  parseJSON = withText "runtime" $ \name -> case find ((== T.unpack name) . runtimeName) runtimes of
+    Just runtime -> pure runtime
+    Nothing -> fail (printf "unknown runtime '%s', expected one of: %s" (T.unpack name) (intercalate ", " runtimeNames))
+
+instance FromJSON Atom where
+  parseJSON = withObject "atom" $ \entry -> Atom <$> entry .: "rt" <*> entry .: "script"
+
+-- What the script writes to stdout: one JSON object whose 'n' field is the
+-- 𝜑-expression the atom answers with.
+newtype Answer = Answer T.Text
+
+instance FromJSON Answer where
+  parseJSON = withObject "answer" $ \answer -> Answer <$> answer .: "n"
+
+-- No λ function at all: every atom gets stuck. This is what a run without
+-- '--atoms' fires against.
+emptyRegistry :: Registry
+emptyRegistry = Map.empty
+
+-- The λ function registered under this name, if any.
+registeredAtom :: Registry -> T.Text -> Maybe Atom
+registeredAtom registry func = Map.lookup func registry
+
+-- Read the registry of λ functions from a JSON file. An unknown runtime, a
+-- missing 'script' or malformed JSON fails here, before any dataization
+-- starts.
+readRegistry :: FilePath -> IO Registry
+readRegistry path = do
+  content <- BS.readFile path `catch` unreadable
+  case eitherDecodeStrict' content of
+    Left failure -> throwIO (BrokenRegistry path failure)
+    Right registry -> do
+      logDebug (printf "Loaded %d atom(s) from '%s'" (Map.size registry) path)
+      pure registry
+  where
+    unreadable :: IOError -> IO BS.ByteString
+    unreadable failure = throwIO (BrokenRegistry path (show failure))
+
+-- Fire the λ function 'func' by running its script as a POSIX process under
+-- the interpreter of its runtime, with the λ name as the first command-line
+-- argument — one script may be registered under several names and branch on
+-- it. The script is fed a JSON object on stdin (see 'payload') and answers
+-- with one on stdout; the 𝜑-expression under 'n' becomes the atom's raw
+-- result, which 𝔼 normalizes exactly as it normalized the answer of a built-in
+-- one. A non-zero exit, unparsable output or a missing 'n' fails the run.
+fireAtom :: T.Text -> Atom -> Expression -> Expression -> IO Expression
+fireAtom func Atom{..} form univ =
+  withTemp (printf "phino-atom-.%s" (extension _runtime)) (encodeUtf8 _script) $ \script ->
+    withTemp "phino-atom-.json" (payload form univ) $ \input ->
+      withTemp "phino-atom-.err" "" $ \errors -> do
+        logDebug (printf "Firing atom '%s' as '%s %s %s'" (T.unpack func) (interpreter _runtime) script (T.unpack func))
+        (status, answer) <- executed script input errors
+        complaint <- readErrors errors
+        unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
+        case status of
+          ExitFailure code -> throwIO (AtomBroke func code complaint)
+          ExitSuccess -> answered answer
+  where
+    -- Run the interpreter with stdin and stderr wired to files, so only stdout
+    -- is a pipe and neither side can ever block waiting for the other to drain
+    -- one. Both streams are bytes: a 𝜑 expression carries characters no
+    -- single-byte locale can spell, so nothing here is left to the locale.
+    executed :: FilePath -> FilePath -> FilePath -> IO (ExitCode, BS.ByteString)
+    executed script input errors =
+      withBinaryFile input ReadMode $ \stdin' ->
+        withBinaryFile errors WriteMode $ \stderr' -> do
+          (stdout', process) <- spawned script stdin' stderr'
+          hSetBinaryMode stdout' True
+          answer <- BS.hGetContents stdout'
+          status <- waitForProcess process
+          pure (status, answer)
+    spawned :: FilePath -> Handle -> Handle -> IO (Handle, ProcessHandle)
+    spawned script stdin' stderr' = do
+      spawn <- createProcess started `catch` missing
+      case spawn of
+        (_, Just stdout', _, process) -> pure (stdout', process)
+        _ -> throwIO (AtomMute func "" "the interpreter gave phino no stdout to read")
+      where
+        started :: CreateProcess
+        started =
+          (proc (interpreter _runtime) [script, T.unpack func])
+            { std_in = UseHandle stdin'
+            , std_out = CreatePipe
+            , std_err = UseHandle stderr'
+            }
+    missing :: IOError -> IO a
+    missing failure = throwIO (NoRuntime func (interpreter _runtime) (show failure))
+    -- Whatever the script complained about, decoded leniently: the stream is
+    -- the script's, so it may hold anything at all.
+    readErrors :: FilePath -> IO String
+    readErrors errors = T.unpack . T.strip . decodeUtf8Lenient <$> BS.readFile errors
+    -- Parse what the script said: a JSON object with the raw 𝜑-expression
+    -- under 'n'.
+    answered :: BS.ByteString -> IO Expression
+    answered answer = case eitherDecodeStrict' answer of
+      Left failure -> throwIO (AtomMute func spoken failure)
+      Right (Answer raw) -> case parseExpression (T.unpack raw) of
+        Left failure -> throwIO (AtomMute func (T.unpack raw) failure)
+        Right expr -> pure expr
+      where
+        spoken :: String
+        spoken = T.unpack (T.strip (decodeUtf8Lenient answer))
+
+-- The JSON phino feeds a script on stdin: the formation being evaluated under
+-- 'b', with its λ binding removed so the script may dispatch on it, and the
+-- universe Φ under 's'. Both are rendered as canonical 𝜑-calculus on a single
+-- line — no syntax sugar, whatever '--sweet' says about the output of the run —
+-- so a script never has to know phino's sugar to find a datum: every byte array
+-- it may need is spelled out as a Δ binding. The text is what phino's own parser
+-- reads back, so a script may hand any part of it to another phino run (see the
+-- '--inside' option).
+payload :: Expression -> Expression -> BS.ByteString
+payload form univ = BSL.toStrict (A.encode (object ["b" .= rendered form, "s" .= rendered univ]))
+  where
+    rendered :: Expression -> T.Text
+    rendered expr = T.pack (printExpression' expr (SALTY, UNICODE, SINGLELINE, defaultMargin))
+
+-- Write the content to a fresh temporary file, hand its path to the action and
+-- delete the file afterwards, whatever the action does.
+withTemp :: String -> BS.ByteString -> (FilePath -> IO a) -> IO a
+withTemp template content action = do
+  dir <- getTemporaryDirectory
+  bracket (openBinaryTempFile dir template) discarded $ \(path, handle) -> do
+    BS.hPut handle content
+    hClose handle
+    action path
+  where
+    discarded :: (FilePath, Handle) -> IO ()
+    discarded (path, handle) = hClose handle >> removePathForcibly path

--- a/src/CLI/Helpers.hs
+++ b/src/CLI/Helpers.hs
@@ -7,6 +7,7 @@
 module CLI.Helpers where
 
 import AST
+import Atoms (Registry, emptyRegistry, readRegistry)
 import CLI.Types
 import CLI.Validators (invalidCLIArguments)
 import Canonizer (canonize)
@@ -16,6 +17,7 @@ import Data.Functor ((<&>))
 import Data.IORef
 import Data.List (intercalate, nub)
 import Data.Maybe
+import Dataize (DataizeContext, insideUniverse)
 import Deps (SaveEvalFunc, SaveStepFunc, dontSaveEval, saveEval, saveStep)
 import Encoding
 import Files (ensuredFile)
@@ -83,6 +85,34 @@ withEvalFunc (Just file) ctx action = do
       protocol <- openFile file WriteMode
       hSetEncoding protocol utf8
       pure protocol
+
+-- The λ functions this run may fire. phino implements none of them, so without
+-- '--atoms' the registry is empty and every atom a program names gets stuck —
+-- which is exactly what '--partial' parks on. The file is read here, before
+-- anything is parsed or dataized, so an unknown runtime or a malformed registry
+-- fails the run up front rather than half-way through a derivation.
+registryOf :: Maybe FilePath -> IO Registry
+registryOf Nothing = do
+  logDebug "The option '--atoms' is not specified, no λ function can be fired"
+  pure emptyRegistry
+registryOf (Just file) = do
+  logDebug (printf "The option '--atoms' is specified, reading the λ functions from '%s'" file)
+  ensuredFile file >>= readRegistry
+
+-- Aim the run at the '--inside' expression instead of at '--locator': the
+-- expression is bound to a synthetic attribute prepended to the input
+-- expression, which the run takes as the universe, and the locator becomes that
+-- attribute (see 'insideUniverse'). Without the option nothing moves and the
+-- context is handed back as it came.
+aimed :: Maybe String -> Expression -> DataizeContext -> IO (Expression, DataizeContext)
+aimed Nothing expr ctx = pure (expr, ctx)
+aimed (Just src) expr@(ExFormation _) ctx = do
+  target <- parseExpressionThrows src
+  logDebug (printf "The option '--inside' is specified, reducing '%s' inside the given universe" (P.printExpression target))
+  insideUniverse target expr ctx
+aimed (Just _) expr _ =
+  invalidCLIArguments
+    (printf "The option --inside requires the input expression to be a formation, but given: %s" (P.printExpression expr))
 
 -- Read input from file or stdin
 readInput :: Maybe FilePath -> IO String

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -3,6 +3,7 @@
 
 module CLI.Parsers where
 
+import Atoms (runtimeNames)
 import CLI.Types
 import Data.Char (toLower, toUpper)
 import Data.List (intercalate)
@@ -203,7 +204,41 @@ optStepsDir :: Parser (Maybe FilePath)
 optStepsDir = optional (strOption (long "steps-dir" <> metavar "FILE" <> help "Directory to save intermediate steps during rewriting/dataizing"))
 
 optPartial :: Parser Bool
-optPartial = switch (long "partial" <> help "Partial evaluation: compute what the known inputs decide and, instead of failing on an atom that cannot fire (its λ function is unknown, or an input of it reaches such an atom), leave it in place and print the residual 𝜑-program")
+optPartial = switch (long "partial" <> help "Partial evaluation: compute what the known inputs decide and, instead of failing on an atom that cannot fire (its λ function is not in the --atoms registry), leave it in place and print the residual 𝜑-program")
+
+-- Which λ functions this run may fire. phino implements none of them itself
+-- (see 'Atoms'), so without this option every atom a program names gets stuck.
+optAtoms :: Parser (Maybe FilePath)
+optAtoms =
+  optional
+    ( strOption
+        ( long "atoms"
+            <> metavar "FILE"
+            <> help
+              ( printf
+                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script it runs"
+                  (intercalate ", " runtimeNames)
+              )
+        )
+    )
+
+-- The external face of the trick phino plays internally to reduce a
+-- sub-expression against a universe: prepend a synthetic binding holding it to
+-- that universe and aim the locator at the binding. An atom script needs it to
+-- reduce the parts of the formation it was given, so it does not have to splice
+-- them into the text of the universe by hand.
+optInside :: Parser (Maybe String)
+optInside =
+  optional
+    ( strOption
+        ( long "inside"
+            <> metavar "EXPRESSION"
+            <> help
+              "The 𝜑-expression to dataize or morph inside the input expression, which is taken as the universe \
+              \Φ: a synthetic binding holding it is prepended to the universe and the locator is aimed at that \
+              \binding. Cannot be used together with --locator"
+        )
+    )
 
 optEvaluations :: Parser (Maybe FilePath)
 optEvaluations = optional (strOption (long "evaluations" <> metavar "FILE" <> help "File to record every atom fired during dataizing, as one tab-separated line per firing: the λ function name, its argument formation and its result (requires --output=phi)"))
@@ -312,8 +347,10 @@ dataizeParser =
             <*> optExpression
             <*> optLabel
             <*> optMeetPrefix
+            <*> optInside
             <*> optStepsDir
             <*> optEvaluations
+            <*> optAtoms
             <*> argInputFile
         )
 
@@ -353,8 +390,10 @@ morphParser =
             <*> optExpression
             <*> optLabel
             <*> optMeetPrefix
+            <*> optInside
             <*> optStepsDir
             <*> optEvaluations
+            <*> optAtoms
             <*> argInputFile
         )
 

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -142,6 +142,7 @@ runRewrite OptsRewrite{..} = do
 runDataize :: OptsDataize -> IO ()
 runDataize OptsDataize{..} = do
   validateOpts
+  atoms <- registryOf _atoms
   excluded <- validatedDispatches "hide" _hide
   included <- validatedDispatches "show" _show
   [loc] <- validatedDispatches "locator" [_locator]
@@ -156,8 +157,10 @@ runDataize OptsDataize{..} = do
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
   (outcome, chain) <-
-    withEvalFunc _evaluations printCtx $
-      dataize expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial buildTerm save
+    withEvalFunc _evaluations printCtx $ \record -> do
+      let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
+      (universe, aiming) <- aimed _inside expr ctx
+      dataize universe aiming
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (printOutcome printCtx outcome >>= putStrLn)
   where
@@ -181,6 +184,9 @@ runDataize OptsDataize{..} = do
       when
         (isJust _evaluations && _outputFormat /= PHI)
         (invalidCLIArguments "The --evaluations option can stay together with --output=phi only, since one record must fit into one line")
+      when
+        (isJust _inside && _locator /= "Q")
+        (invalidCLIArguments "The options --inside and --locator cannot be used together, since --inside aims the run at the binding it mints")
     toPrintCtx :: Expression -> PrintContext
     toPrintCtx focus =
       PrintCtx
@@ -211,6 +217,7 @@ runDataize OptsDataize{..} = do
 runMorph :: OptsMorph -> IO ()
 runMorph OptsMorph{..} = do
   validateOpts
+  atoms <- registryOf _atoms
   excluded <- validatedDispatches "hide" _hide
   included <- validatedDispatches "show" _show
   [loc] <- validatedDispatches "locator" [_locator]
@@ -225,8 +232,10 @@ runMorph OptsMorph{..} = do
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
   (morphed, chain) <-
-    withEvalFunc _evaluations printCtx $
-      morph expr . DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial buildTerm save
+    withEvalFunc _evaluations printCtx $ \record -> do
+      let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
+      (universe, aiming) <- aimed _inside expr ctx
+      morph universe aiming
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (printFocused printCtx morphed >>= putStrLn)
   where
@@ -242,6 +251,9 @@ runMorph OptsMorph{..} = do
       when
         (isJust _evaluations && _outputFormat /= PHI)
         (invalidCLIArguments "The --evaluations option can stay together with --output=phi only, since one record must fit into one line")
+      when
+        (isJust _inside && _locator /= "Q")
+        (invalidCLIArguments "The options --inside and --locator cannot be used together, since --inside aims the run at the binding it mints")
     toPrintCtx :: Expression -> PrintContext
     toPrintCtx focus =
       PrintCtx

--- a/src/CLI/Types.hs
+++ b/src/CLI/Types.hs
@@ -107,8 +107,10 @@ data OptsDataize = OptsDataize
   , _expression :: Maybe String
   , _label :: Maybe String
   , _meetPrefix :: Maybe String
+  , _inside :: Maybe String
   , _stepsDir :: Maybe FilePath
   , _evaluations :: Maybe FilePath
+  , _atoms :: Maybe FilePath
   , _inputFile :: Maybe FilePath
   }
 
@@ -149,8 +151,10 @@ data OptsMorph = OptsMorph
   , _expression :: Maybe String
   , _label :: Maybe String
   , _meetPrefix :: Maybe String
+  , _inside :: Maybe String
   , _stepsDir :: Maybe FilePath
   , _evaluations :: Maybe FilePath
+  , _atoms :: Maybe FilePath
   , _inputFile :: Maybe FilePath
   }
 

--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -10,14 +10,13 @@
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
 
-module Dataize (morph, morph', dataize, dataize', DataizeContext (..), DataizeException (..), Outcome (..), Steps (..), State, emptyState, execBuildTerm) where
+module Dataize (morph, morph', dataize, dataize', insideUniverse, DataizeContext (..), DataizeException (..), Outcome (..), Steps (..), State, emptyState, execBuildTerm) where
 
 import AST
+import Atoms (Registry, fireAtom, registeredAtom)
 import Builder (buildBytesThrows, buildExpressionThrows)
-import Bytes (btsAnd, btsConcat, btsEqual, btsNot, btsOr, btsShift, btsSize, btsSlice, btsToNum, numToBts, strToBts)
 import Control.Exception (Exception, catch, throwIO, try)
 import Control.Monad (foldM, when)
-import Data.Int (Int32)
 import Data.List (find, partition)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
@@ -25,7 +24,6 @@ import qualified Data.Text as T
 import Deps (BuildTermFunc, BuildTermMethodS, Evaluation (..), SaveEvalFunc, SaveStepFunc, State, Term (..))
 import Locator (locatedExpression, withLocatedExpression)
 import Matcher (MetaValue (..), Subst (..), combine, matchExpression', substEmpty, substSingle)
-import Misc
 import Must (Must (..))
 import Random (shuffle)
 import Rewriter (RewriteContext (RewriteContext), Rewritten, rewrite)
@@ -76,6 +74,7 @@ data DataizeContext = DataizeContext
   , _depthSensitive :: Bool
   , _shuffle :: Bool
   , _partial :: Bool
+  , _atoms :: Registry
   , _buildTerm :: BuildTermFunc
   , _saveStep :: SaveStepFunc
   , _saveEval :: SaveEvalFunc
@@ -83,9 +82,10 @@ data DataizeContext = DataizeContext
 
 data DataizeException
   = OutOfSteps Int
-  | -- An atom could not fire: 'atom' does not know its λ function, or the
-    -- dataization of one of its inputs met an atom it does not know. The name
-    -- is that of the innermost unknown atom, the one 𝔼 actually failed on.
+  | -- An atom could not fire: the '--atoms' registry carries no λ function of
+    -- that name, so there is nothing to run. The name is that of the atom 𝔼
+    -- actually failed on, which for a chain of dispatches is the innermost one,
+    -- since 'ml' reduces a head before the atom above it fires.
     Stuck T.Text
   | -- A 'Stuck' caught by a frame of the 𝕄/𝔻 spine, together with the
     -- derivation that frame had reached (see 'parking'). The head of the chain
@@ -461,130 +461,43 @@ normalized expr seq ctx@DataizeContext{..} = do
     rewriteContext DataizeContext{..} =
       RewriteContext _locator _maxDepth _maxCycles _depthSensitive _buildTerm MtDisabled Nothing _saveStep
 
--- Synthetic dataize function for internal usage inside atoms. Here we modify the
--- universe by adding a new binding which refers to the expression we want to
--- dataize, building a local working expression to reduce within. As a caller of 𝔻,
--- it first reduces the expression to a normal form, since 𝔻 only accepts normal
--- forms. The universe 'univ' itself is forwarded unchanged, so morphing Φ under
--- this context still resolves to the true universe rather than to this
--- synthetic, binding-prepended formation. The chain is the synthetic one, so a
--- stuck atom met on the way leaves without it (see 'unparked').
-_dataize :: Expression -> Expression -> State -> DataizeContext -> IO (Bytes, State)
-_dataize expr univ state ctx@DataizeContext{_buildTerm = buildTerm} = case univ of
-  ExFormation bds -> unparked $ do
+-- Bind 'expr' to a synthetic attribute of the universe and reduce it to a
+-- normal form there, handing back the extended universe together with the
+-- locator that aims at the binding. This is the trick phino has always played
+-- to reduce a sub-expression that is not part of the program — an atom's
+-- operand, while the atoms still lived in the binary — and it is now the
+-- contract of the '--inside' option, so an atom script asking phino to reduce
+-- a part of the formation it was given does not have to splice it into the text
+-- of the universe by hand. 𝔻 and 𝕄 accept normal forms only and an expression
+-- handed in from outside is not necessarily one (a dispatch off a formation,
+-- '⟦ x ↦ 6, ρ ↦ 5 ⟧.x', is not), so it is normalized against the extended
+-- universe before either judgment sees it. The context comes back aimed at that
+-- binding, so the caller hands the extended universe and the context it got
+-- straight to 'dataize' or 'morph'.
+insideUniverse :: Expression -> Expression -> DataizeContext -> IO (Expression, DataizeContext)
+insideUniverse expr univ ctx@DataizeContext{_buildTerm = buildTerm} = case univ of
+  ExFormation bds -> do
     (TeAttribute attr) <- buildTerm "random-tau" [] substEmpty
-    let synthetic = ExFormation (BiTau attr expr : bds)
-    (normal, seq) <- normalized expr ((synthetic, Nothing) :| []) ctx
-    ((bts, _), state') <- dataize' (normal, seq) univ state ctx
-    pure (bts, state')
-  _ -> throwIO (userError "Can't call _dataize from atoms with non-formation universe")
+    let aiming = ctx{_locator = ExDispatch ExRoot attr}
+        synthetic = ExFormation (BiTau attr expr : bds)
+    (normal, _) <- normalized expr ((synthetic, Nothing) :| []) aiming
+    pure (ExFormation (BiTau attr normal : bds), aiming)
+  _ -> throwIO (userError "Can't reduce an expression inside a universe which is not a formation")
 
--- A number atom only operates on numeric data. Empty bytes — a genuine
--- zero-length byte array ⟦Δ ⤍ --⟧ — carry no number, so the operand is rejected
--- and the atom yields ⊥. So does any byte array whose length is not 8: 'btsToNum'
--- throws on such arrays, so the size is checked up front, exactly like 'asInt'.
-asNumber :: Bytes -> Maybe Double
-asNumber bts
-  | btsSize bts /= 8 = Nothing
-  | otherwise = Just (either toDouble id (btsToNum bts))
-
--- An operand that EO reads as a Java 'int' — a shift distance or a slice bound.
--- 'Expect.at(…).that(Integer)' turns down anything but a whole number inside the
--- 32-bit range, and so does this, leaving the atom with ⊥
-asInt :: Bytes -> Maybe Int
-asInt bts
-  | btsSize bts /= 8 = Nothing
-  | otherwise = case btsToNum bts of
-      Left num | num >= fromIntegral (minBound :: Int32) && num <= fromIntegral (maxBound :: Int32) -> Just num
-      _ -> Nothing
-
--- An atom whose EO signature ends in '/Q.bool' hands back one of the two bool
--- objects of the universe, exactly what 'Data.ToPhi(boolean)' does in the runtime
-boolean :: Bool -> Expression
-boolean True = BaseObject "true"
-boolean False = BaseObject "false"
-
--- Both bitwise atoms take ρ and 'b' and reject operands of different lengths
-bitwise :: (Bytes -> Bytes -> Maybe Bytes) -> Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
-bitwise op self univ state ctx = do
-  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
-  pure (maybe ExTermination dataBytes (op rho b), rstate)
-
--- The 12 primitive λ-atoms every EO data operation reduces to. phino mirrors
--- EO's set exactly: bytes {and, concat, eq, not, or, right, size, slice} and
--- number {div, gt, plus, times}. There is deliberately no 'L_number_eq': EO's
--- 'number.eq' (eo-runtime/src/main/eo/number/eq.eo) is pure EO — a formation
--- composing 'is-nan', 'or', 'and' and 'L_bytes_eq', with no λ of its own — so
--- nothing is left for a phino atom to implement. Names like 'L_bool_if' or
--- 'L_string_slice' must stay unimplemented too: the EO lowering declares them
--- precisely so that '--partial' parks on them and renders the call to Java.
+-- phino implements no λ function of its own. Which atoms exist is a property of
+-- the object model being dataized, not of the calculus, so they come from the
+-- '--atoms' registry and run as external scripts (see 'Atoms'). A name the
+-- registry does not carry has no λ function to fire at all, and 𝔼 gets stuck on
+-- it — the one behaviour left here. The script is handed the formation 'self'
+-- (its λ binding already removed, so it may dispatch on it) and the universe
+-- 'univ'; the state 𝑠 is not part of that contract yet, so it is threaded
+-- through untouched.
 atom :: T.Text -> Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
-atom "L_number_plus" self univ state ctx = do
-  (left, lstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (right, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
-  case (asNumber left, asNumber right) of
-    (Just first, Just second) -> pure (DataNumber (numToBts (first + second)), rstate)
-    _ -> pure (ExTermination, rstate)
-atom "L_number_times" self univ state ctx = do
-  (left, lstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (right, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
-  case (asNumber left, asNumber right) of
-    (Just first, Just second) -> pure (DataNumber (numToBts (first * second)), rstate)
-    _ -> pure (ExTermination, rstate)
-atom "L_number_div" self univ state ctx = do
-  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
-  case (asNumber x, asNumber rho) of
-    (Just divisor, Just dividend) -> pure (DataNumber (numToBts (dividend / divisor)), rstate)
-    _ -> pure (ExTermination, rstate)
-atom "L_number_gt" self univ state ctx = do
-  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
-  case (asNumber x, asNumber rho) of
-    (Just threshold, Just value) -> pure (boolean (value > threshold), rstate)
-    _ -> pure (ExTermination, rstate)
-atom "L_bytes_and" self univ state ctx = bitwise btsAnd self univ state ctx
-atom "L_bytes_or" self univ state ctx = bitwise btsOr self univ state ctx
-atom "L_bytes_not" self univ state ctx = do
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ state ctx
-  pure (dataBytes (btsNot rho), rstate)
-atom "L_bytes_concat" self univ state ctx = do
-  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
-  pure (dataBytes (btsConcat rho b), rstate)
-atom "L_bytes_eq" self univ state ctx = do
-  (b, bstate) <- _dataize (ExDispatch self (AtLabel "b")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ bstate ctx
-  pure (boolean (btsEqual rho b), rstate)
-atom "L_bytes_size" self univ state ctx = do
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ state ctx
-  pure (DataNumber (numToBts (fromIntegral (btsSize rho))), rstate)
-atom "L_bytes_right" self univ state ctx = do
-  (x, xstate) <- _dataize (ExDispatch self (AtLabel "x")) univ state ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ xstate ctx
-  case asInt x of
-    Just bits -> pure (dataBytes (btsShift bits rho), rstate)
-    Nothing -> pure (ExTermination, rstate)
-atom "L_bytes_slice" self univ state ctx = do
-  (start, sstate) <- _dataize (ExDispatch self (AtLabel "start")) univ state ctx
-  (len, lstate) <- _dataize (ExDispatch self (AtLabel "len")) univ sstate ctx
-  (rho, rstate) <- _dataize (ExDispatch self AtRho) univ lstate ctx
-  case (asInt start, asInt len) of
-    (Just from, Just count)
-      | from >= 0 && count >= 0 ->
-          pure (maybe (cantSlice from count (btsSize rho)) dataBytes (btsSlice from count rho), rstate)
-    _ -> pure (ExTermination, rstate)
-  where
-    -- A window past the end of the array does not stop EO: it copies the
-    -- 'cant-slice' fallback, applies the complaint to it and lets the caller
-    -- decide. A caller that left 'cant-slice' unbound gets ⊥ out of the dispatch
-    cantSlice :: Int -> Int -> Int -> Expression
-    cantSlice from count size =
-      ExApplication
-        (ExDispatch self (AtLabel "cant-slice"))
-        (ArAlpha (Alpha 0) (DataString (strToBts (printf "cannot slice '%d' bytes from offset '%d' of bytes of size %d" count from size))))
-atom func _ _ _ _ = throwIO (Stuck func)
+atom func self univ state ctx = case registeredAtom ctx._atoms func of
+  Nothing -> throwIO (Stuck func)
+  Just registered -> do
+    raw <- fireAtom func registered self univ
+    pure (raw, state)
 
 -- Augment the injected, context-free term builder with the dataization and
 -- morphing operations that need the universe: 'evaluate' applies an atom and
@@ -609,14 +522,12 @@ execBuildTerm _ ctx func = _buildTerm ctx func
 -- Every firing is reported to '_saveEval', which the '--evaluations' option
 -- turns into one record per line. The reported result is the normal form 𝔼
 -- returns, never the atom's raw answer, so the protocol and the caller see the
--- same term. A nested firing — an atom that dataizes its own arguments —
--- completes first, so it is reported before the firing that triggered it. A
+-- same term. Firings are reported in the order they complete, so the atom of a
+-- head reduced by 'ml' is reported before the one dispatched on its result. A
 -- firing that gets stuck is reported too, with no result, when the run is a
 -- partial evaluation rather than a failure ('_partial'): the site is what the
--- caller wants to learn then, and the nested order holds, since the unknown
--- atom is reported before the known one whose input reached it. The report is
--- made before the signal goes on to the spine, where 'parking' attaches the
--- derivation to it.
+-- caller wants to learn then. The report is made before the signal goes on to
+-- the spine, where 'parking' attaches the derivation to it.
 _evaluate :: DataizeContext -> State -> BuildTermMethodS
 _evaluate ctx state [ArgExpression expr, ArgExpression universe] subst = do
   form <- buildExpressionThrows expr subst

--- a/test-resources/atoms/primitives.js
+++ b/test-resources/atoms/primitives.js
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+// The λ functions phino's own tests fire. phino implements none of them: it
+// writes this script to a temporary file, runs it under 'node' with the name of
+// the λ function as the first argument, feeds it the formation being evaluated
+// ('b') and the universe Φ ('s') on stdin as JSON, and reads the 𝜑-expression
+// to use as the atom's raw result back from stdout, under 'n'.
+//
+// This is a fixture, not a runtime: it goes just far enough to let the specs
+// reduce arithmetic and byte comparisons. Both payloads arrive as canonical
+// 𝜑-calculus, so every datum spells its bytes out as a Δ binding and the first
+// one inside an operand is the operand's own. An operand that is not an
+// already-reduced datum is not dataized here: a real runtime would ask phino
+// for it, with 'phino dataize --inside=...'.
+
+'use strict';
+
+const fs = require('fs');
+
+const atom = process.argv[2];
+const { b } = JSON.parse(fs.readFileSync(0, 'utf8'));
+
+const OPENING = '⟦(';
+const CLOSING = '⟧)';
+
+// The 𝜑 text bound to the attribute 'name' by the formation 'b'.
+function bound(name) {
+  const head = name + ' ↦ ';
+  let depth = 0;
+  for (let index = 0; index < b.length; index += 1) {
+    const char = b[index];
+    if (OPENING.includes(char)) {
+      depth += 1;
+    } else if (CLOSING.includes(char)) {
+      depth -= 1;
+    } else if (depth === 1 && b.startsWith(head, index) && ' ,⟦'.includes(b[index - 1])) {
+      return value(index + head.length);
+    }
+  }
+  return null;
+}
+
+// The 𝜑 text of one binding's value: everything up to the comma or the closing
+// bracket that ends it.
+function value(start) {
+  let depth = 0;
+  let text = '';
+  for (let index = start; index < b.length; index += 1) {
+    const char = b[index];
+    if (OPENING.includes(char)) {
+      depth += 1;
+    } else if (CLOSING.includes(char)) {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+    } else if (char === ',' && depth === 0) {
+      break;
+    }
+    text += char;
+  }
+  return text.trim();
+}
+
+// Every shape an already-reduced datum reaches this script in: a literal
+// argument, a copy of the 'number', 'string' or 'bytes' object bound to ρ, or a
+// bare byte formation. The bytes are what follows.
+const DATA = [
+  'Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ',
+  'Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ',
+  'Φ.bytes( data ↦ ⟦ Δ ⤍ ',
+  '⟦ as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ',
+  '⟦ data ↦ ⟦ Δ ⤍ ',
+  '⟦ Δ ⤍ ',
+];
+
+// The bytes of an already-reduced datum, or nothing at all when the operand is
+// not one: this fixture never guesses at an operand that still has to be
+// dataized, since dataizing it is a phino run of its own.
+function bytes(expr) {
+  const shape = expr === null ? undefined : DATA.find((prefix) => expr.startsWith(prefix));
+  if (shape === undefined) {
+    return null;
+  }
+  const found = /^([0-9A-F-]+)/.exec(expr.slice(shape.length));
+  return found === null ? null : Buffer.from(found[1].replace(/-/g, ''), 'hex');
+}
+
+// The double a datum carries. A byte array of any other length carries no
+// number at all, exactly as 'Expect.at(…).that(Number)' insists in EO.
+function number(expr) {
+  const raw = bytes(expr);
+  return raw !== null && raw.length === 8 ? raw.readDoubleBE(0) : NaN;
+}
+
+// A byte array the way 𝜑-calculus spells one: '--' when it is empty, 'FF-'
+// when it holds a single octet, '20-1F' when it holds more.
+function hex(raw) {
+  if (raw.length === 0) {
+    return '--';
+  }
+  const octets = [...raw].map((octet) => octet.toString(16).toUpperCase().padStart(2, '0'));
+  return octets.length === 1 ? `${octets[0]}-` : octets.join('-');
+}
+
+function asBytes(raw) {
+  return `Φ.bytes( data ↦ ⟦ Δ ⤍ ${hex(raw)} ⟧ )`;
+}
+
+function asNumber(value_) {
+  const raw = Buffer.alloc(8);
+  raw.writeDoubleBE(value_, 0);
+  return `Φ.number( as-bytes ↦ ${asBytes(raw)} )`;
+}
+
+function asBool(yes) {
+  return yes ? 'Φ.true' : 'Φ.false';
+}
+
+// A number atom with an operand carrying no number yields the terminator ⊥,
+// the way every EO number atom does.
+function arithmetic(operation) {
+  const left = number(bound('x'));
+  const right = number(bound('ρ'));
+  return Number.isNaN(left) || Number.isNaN(right) ? '⊥' : asNumber(operation(left, right));
+}
+
+function answer() {
+  switch (atom) {
+    case 'L_number_plus':
+      return arithmetic((x, rho) => rho + x);
+    case 'L_number_times':
+      return arithmetic((x, rho) => rho * x);
+    case 'L_number_div':
+      return arithmetic((x, rho) => rho / x);
+    case 'L_number_gt': {
+      const left = number(bound('x'));
+      const right = number(bound('ρ'));
+      return Number.isNaN(left) || Number.isNaN(right) ? '⊥' : asBool(right > left);
+    }
+    case 'L_bytes_eq': {
+      const left = bytes(bound('b'));
+      const right = bytes(bound('ρ'));
+      return left === null || right === null ? '⊥' : asBool(left.equals(right));
+    }
+    case 'L_bytes_not': {
+      const raw = bytes(bound('ρ'));
+      return raw === null ? '⊥' : asBytes(Buffer.from([...raw].map((octet) => ~octet & 0xff)));
+    }
+    default:
+      throw new Error(`the fixture implements no atom named '${atom}'`);
+  }
+}
+
+process.stdout.write(JSON.stringify({ n: answer() }));

--- a/test-resources/atoms/primitives.js
+++ b/test-resources/atoms/primitives.js
@@ -35,7 +35,7 @@ function bound(name) {
     } else if (CLOSING.includes(char)) {
       depth -= 1;
     } else if (depth === 1 && b.startsWith(head, index) && ' ,⟦'.includes(b[index - 1])) {
-      return value(index + head.length);
+      return bindingValue(index + head.length);
     }
   }
   return null;
@@ -43,7 +43,7 @@ function bound(name) {
 
 // The 𝜑 text of one binding's value: everything up to the comma or the closing
 // bracket that ends it.
-function value(start) {
+function bindingValue(start) {
   let depth = 0;
   let text = '';
   for (let index = start; index < b.length; index += 1) {
@@ -108,9 +108,9 @@ function asBytes(raw) {
   return `Φ.bytes( data ↦ ⟦ Δ ⤍ ${hex(raw)} ⟧ )`;
 }
 
-function asNumber(value_) {
+function asNumber(value) {
   const raw = Buffer.alloc(8);
-  raw.writeDoubleBE(value_, 0);
+  raw.writeDoubleBE(value, 0);
   return `Φ.number( as-bytes ↦ ${asBytes(raw)} )`;
 }
 

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+module AtomsSpec (spec) where
+
+import AST
+import Atoms (Atom (..), Runtime (RtJs), emptyRegistry, fireAtom, readRegistry, registeredAtom)
+import Control.Exception (SomeException, bracket)
+import qualified Data.ByteString as BS
+import Control.Monad (forM_)
+import Data.List (isInfixOf)
+import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
+import Fixtures (withNode)
+import Parser (parseExpressionThrows)
+import System.Directory (getTemporaryDirectory, removePathForcibly)
+import System.IO (Handle, hClose, openBinaryTempFile)
+import Test.Hspec
+
+-- A registry file holding the given content, removed afterwards
+withRegistry :: T.Text -> (FilePath -> IO a) -> IO a
+withRegistry content action = do
+  dir <- getTemporaryDirectory
+  bracket (openBinaryTempFile dir "phino-registry-.json") discarded $ \(path, handle) -> do
+    BS.hPut handle (encodeUtf8 content)
+    hClose handle
+    action path
+  where
+    discarded :: (FilePath, Handle) -> IO ()
+    discarded (path, handle) = hClose handle >> removePathForcibly path
+
+-- Fire the λ function 'L_answer' out of the given script, against a formation
+-- binding 'x' inside a universe binding 'y'
+fired :: T.Text -> IO Expression
+fired script = do
+  form <- parseExpressionThrows "⟦ x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧"
+  univ <- parseExpressionThrows "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+  fireAtom "L_answer" (Atom RtJs script) form univ
+
+-- What the script wrote under 'n' has to come back parsed, so a case asserting
+-- on it says which expression it expects in 𝜑 rather than in constructors
+answers :: T.Text -> String -> Expectation
+answers script expected = withNode $ do
+  answer <- fired script
+  wanted <- parseExpressionThrows expected
+  answer `shouldBe` wanted
+
+-- A firing that has to fail, with the reason naming the given fragments
+fails :: T.Text -> [String] -> Expectation
+fails script fragments =
+  withNode $
+    fired script
+      `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
+
+spec :: Spec
+spec = do
+  -- phino implements no λ function, so an empty registry is what a run without
+  -- '--atoms' fires against: every name is unknown there
+  describe "emptyRegistry" $
+    it "registers no λ function at all" $
+      registeredAtom emptyRegistry "L_bytes_eq" `shouldBe` Nothing
+
+  describe "readRegistry" $ do
+    it "reads a λ function together with its runtime and script" $
+      withRegistry "{\"L_answer\": {\"rt\": \"js\", \"script\": \"say(1)\"}}" $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_answer" `shouldBe` Just (Atom RtJs "say(1)")
+
+    it "leaves a name the file does not carry unregistered" $
+      withRegistry "{\"L_answer\": {\"rt\": \"js\", \"script\": \"say(1)\"}}" $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_bytes_eq" `shouldBe` Nothing
+
+    -- An unknown runtime is refused where the file is read, which is before any
+    -- dataization starts, rather than at the moment an atom of it would fire
+    forM_
+      [
+        ( "the runtime is not one phino can run"
+        , "{\"L_answer\": {\"rt\": \"ruby\", \"script\": \"say(1)\"}}"
+        , ["unknown runtime 'ruby'", "js"]
+        )
+      ,
+        ( "an entry carries no script"
+        , "{\"L_answer\": {\"rt\": \"js\"}}"
+        , ["script"]
+        )
+      ,
+        ( "an entry carries no runtime"
+        , "{\"L_answer\": {\"script\": \"say(1)\"}}"
+        , ["rt"]
+        )
+      ,
+        ( "the file is not JSON at all"
+        , "L_answer: js"
+        , ["cannot be read"]
+        )
+      ]
+      ( \(desc, content, fragments) ->
+          it ("fails when " ++ desc) $
+            withRegistry content $ \path ->
+              readRegistry path
+                `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
+      )
+
+    it "fails when the file is not there" $
+      readRegistry "no-such-registry.json"
+        `shouldThrow` (\failure -> "cannot be read" `isInfixOf` show (failure :: SomeException))
+
+  describe "fireAtom" $ do
+    it "hands back the 𝜑-expression the script wrote under 'n'" $
+      answers "process.stdout.write(JSON.stringify({n: '⟦ Δ ⤍ 2A- ⟧'}))" "⟦ Δ ⤍ 2A- ⟧"
+
+    -- One script may stand for several λ functions, so the name of the one
+    -- being fired is its first command-line argument — where node puts it
+    it "names the λ function being fired as the first command-line argument" $
+      answers
+        "process.stdout.write(JSON.stringify({n: process.argv[2] === 'L_answer' ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        "⟦ Δ ⤍ FF- ⟧"
+
+    -- The formation being evaluated arrives under 'b' and the universe Φ under
+    -- 's', both as 𝜑 text on stdin
+    it "feeds the formation and the universe to the script on stdin" $
+      answers
+        "const {b, s} = JSON.parse(require('fs').readFileSync(0, 'utf8'));\
+        \process.stdout.write(JSON.stringify({n: b.includes('x ↦') && s.includes('y ↦') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        "⟦ Δ ⤍ FF- ⟧"
+
+    -- Neither payload carries syntax sugar, whatever '--sweet' says about the
+    -- output of the run, so a script finds every datum spelled as a Δ binding
+    it "spells the payloads as canonical 𝜑-calculus" $
+      answers
+        "const {b} = JSON.parse(require('fs').readFileSync(0, 'utf8'));\
+        \process.stdout.write(JSON.stringify({n: b.includes('Δ ⤍ 01-') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        "⟦ Δ ⤍ FF- ⟧"
+
+    it "reads a script that says nothing to stdin without waiting for it" $
+      answers "process.stdout.write(JSON.stringify({n: '⟦ Δ ⤍ 01- ⟧'}))" "⟦ Δ ⤍ 01- ⟧"
+
+    it "fails with the script's own complaint when it exits non-zero" $
+      fails
+        "process.stderr.write('no idea what to do');process.exit(4)"
+        ["L_answer", "exit code 4", "no idea what to do"]
+
+    it "fails when the script writes something other than JSON" $
+      fails "process.stdout.write('almost')" ["L_answer", "almost"]
+
+    it "fails when the script writes JSON with no 'n' in it" $
+      fails "process.stdout.write(JSON.stringify({m: '⟦ ⟧'}))" ["L_answer", "n"]
+
+    it "fails when what the script put under 'n' is not a 𝜑-expression" $
+      fails "process.stdout.write(JSON.stringify({n: '⟦ ⟧⟧'}))" ["L_answer"]

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -7,7 +7,7 @@
 module AtomsSpec (spec) where
 
 import AST
-import Atoms (Atom (..), Runtime (RtJs), emptyRegistry, fireAtom, readRegistry, registeredAtom)
+import Atoms (Atom (..), Runtime (RtNode), emptyRegistry, fireAtom, readRegistry, registeredAtom)
 import Control.Exception (SomeException, bracket)
 import Control.Monad (forM_)
 import Data.ByteString qualified as BS
@@ -38,7 +38,7 @@ fired :: T.Text -> IO Expression
 fired script = do
   form <- parseExpressionThrows "⟦ x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧"
   univ <- parseExpressionThrows "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
-  fireAtom "L_answer" (Atom RtJs script) form univ
+  fireAtom "L_answer" (Atom RtNode script) form univ
 
 -- What the script wrote under 'n' has to come back parsed, so a case asserting
 -- on it says which expression it expects in 𝜑 rather than in constructors
@@ -65,12 +65,12 @@ spec = do
 
   describe "readRegistry" $ do
     it "reads a λ function together with its runtime and script" $
-      withRegistry "{\"L_answer\": {\"rt\": \"js\", \"script\": \"say(1)\"}}" $ \path -> do
+      withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
         registry <- readRegistry path
-        registeredAtom registry "L_answer" `shouldBe` Just (Atom RtJs "say(1)")
+        registeredAtom registry "L_answer" `shouldBe` Just (Atom RtNode "say(1)")
 
     it "leaves a name the file does not carry unregistered" $
-      withRegistry "{\"L_answer\": {\"rt\": \"js\", \"script\": \"say(1)\"}}" $ \path -> do
+      withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
         registry <- readRegistry path
         registeredAtom registry "L_bytes_eq" `shouldBe` Nothing
 
@@ -80,11 +80,11 @@ spec = do
       [
         ( "the runtime is not one phino can run"
         , "{\"L_answer\": {\"rt\": \"ruby\", \"script\": \"say(1)\"}}"
-        , ["unknown runtime 'ruby'", "js"]
+        , ["unknown runtime 'ruby'", "node"]
         )
       ,
         ( "an entry carries no script"
-        , "{\"L_answer\": {\"rt\": \"js\"}}"
+        , "{\"L_answer\": {\"rt\": \"node\"}}"
         , ["script"]
         )
       ,

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -9,10 +9,10 @@ module AtomsSpec (spec) where
 import AST
 import Atoms (Atom (..), Runtime (RtJs), emptyRegistry, fireAtom, readRegistry, registeredAtom)
 import Control.Exception (SomeException, bracket)
-import qualified Data.ByteString as BS
 import Control.Monad (forM_)
+import Data.ByteString qualified as BS
 import Data.List (isInfixOf)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Fixtures (withNode)
 import Parser (parseExpressionThrows)

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -15,6 +15,7 @@ import Data.List (intercalate, isInfixOf, isPrefixOf, sort)
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
+import Fixtures (withFixtureRegistry, withNode)
 import GHC.IO.Handle
 import Paths_phino (version)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, removeFile, removePathForcibly, setModificationTime)
@@ -118,6 +119,13 @@ testCLI' args outputs exit = do
 
 testCLISucceeded :: [String] -> [String] -> Expectation
 testCLISucceeded args outputs = testCLI' args outputs (Right ())
+
+-- phino implements no λ function of its own, so a case that needs an atom to
+-- fire brings the fixture registry in and hands its path to the command as
+-- '--atoms' (see 'Fixtures'). Every such atom runs under 'node', so the case is
+-- pending where 'node' is not installed.
+withAtoms :: (String -> Expectation) -> Expectation
+withAtoms action = withNode (withFixtureRegistry (action . ("--atoms=" ++)))
 
 testCLIFailed :: [String] -> [String] -> Expectation
 testCLIFailed args outputs = testCLI' args outputs (Left (ExitFailure 1))
@@ -392,20 +400,21 @@ spec = do
           doesFileExist (dir ++ "/00003.phi") `shouldReturn` True
 
     it "saves dataize steps to dir with --steps-dir" $
-      withTempDirectory "phino-steps-dataize" $ \dir ->
-        withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $ do
-          testCLISucceeded
-            ["dataize", "--steps-dir=" ++ dir, "--sweet"]
-            ["40-26"]
-          doesDirectoryExist dir `shouldReturn` True
-          files <- listDirectory dir
-          let steps = sort files
-          -- The fix is about numbering, not about a specific rule set: the file
-          -- names must be distinct and contiguous from 00001, and there must be
-          -- more of them than a single normalization pass produces (this input
-          -- runs several normalizations, so a global counter yields more steps).
-          steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
-          length steps `shouldSatisfy` (> 18)
+      withAtoms $ \atoms ->
+        withTempDirectory "phino-steps-dataize" $ \dir ->
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $ do
+            testCLISucceeded
+              ["dataize", atoms, "--steps-dir=" ++ dir, "--sweet"]
+              ["40-32"]
+            doesDirectoryExist dir `shouldReturn` True
+            files <- listDirectory dir
+            let steps = sort files
+            -- The fix is about numbering, not about a specific rule set: the file
+            -- names must be distinct and contiguous from 00001, and there must be
+            -- more of them than a single normalization pass produces (this input
+            -- runs several normalizations, so a global counter yields more steps).
+            steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
+            length steps `shouldSatisfy` (> 18)
 
     it "saves steps with a .tex extension when --output=latex is used with --steps-dir" $
       withTempDirectory "phino-steps-latex" $ \dir ->
@@ -1070,10 +1079,11 @@ spec = do
     -- The 𝕄/𝔻 recursion used to be unbounded, so this division kept morphing
     -- forever and no option could stop it (#1052)
     it "fails on --max-steps instead of morphing forever" $
-      withStdin "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧" $
-        testCLIFailed
-          ["dataize", "--max-steps=40"]
-          ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=40"]
+      withAtoms $ \atoms ->
+        withStdin "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧" $
+          testCLIFailed
+            ["dataize", atoms, "--max-steps=40"]
+            ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=40"]
 
     it "dataizes with --sequence" $
       withStdin "[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]]" $
@@ -1112,16 +1122,18 @@ spec = do
           ["⟦ Δ ⤍ 01- ⟧\n01-"]
 
     it "focuses a compressed sequence whose meet replaces a step root" $
-      withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
-        testCLISucceeded
-          ["dataize", "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--hide=Q.bytes", "--hide=Q.number", "--locator=Q.@", "--focus=Q.@", "--meet-length=5", "--meet-popularity=1"]
-          ["\\phinoMeet{dataization:1}{ [[ @ -> |c| . |plus| ( 32 ), |c| -> 25 ]] } \\leadsto_{\\nameref{r:contextualize}}"]
+      withAtoms $ \atoms ->
+        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
+          testCLISucceeded
+            ["dataize", atoms, "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--hide=Q.bytes", "--hide=Q.number", "--locator=Q.@", "--focus=Q.@", "--meet-length=5", "--meet-popularity=1"]
+            ["\\phinoMeet{dataization:1}{ [[ @ -> |c| . |plus| ( 32 ), |c| -> 25 ]] } \\leadsto_{\\nameref{r:contextualize}}"]
 
     it "compresses a canonized whole-expression sequence into a meet" $
-      withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
-        testCLISucceeded
-          ["dataize", "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--meet-length=5", "--meet-popularity=1"]
-          ["\\phinoMeet{dataization:1}"]
+      withAtoms $ \atoms ->
+        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
+          testCLISucceeded
+            ["dataize", atoms, "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--meet-length=5", "--meet-popularity=1"]
+            ["\\phinoMeet{dataization:1}"]
 
     it "dataizes with --locator" $
       withStdin "[[ ex -> [[ @ -> Q.x ]], x -> [[ D> 42- ]] ]]" $
@@ -1133,38 +1145,42 @@ spec = do
 
     describe "--evaluations" $ do
       it "writes one tab-separated record per fired atom" $
-        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-          hClose stream
-          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
-            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
-          records <- readUtf8 path
-          records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
+        withAtoms $ \atoms ->
+          withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+            hClose stream
+            withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+              testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+            records <- readUtf8 path
+            records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
 
       it "writes a record for every firing" $
-        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-          hClose stream
-          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $
-            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
-          records <- readUtf8 path
-          lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11", "L_number_plus\t⟦ x ↦ 7 ⟧\t18"]
+        withAtoms $ \atoms ->
+          withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+            hClose stream
+            withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $
+              testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+            records <- readUtf8 path
+            lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11", "L_number_plus\t⟦ x ↦ 7 ⟧\t18"]
 
       it "writes records in canonical syntax without --sweet" $
-        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-          hClose stream
-          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
-            testCLISucceeded ["dataize", "--evaluations=" ++ path, "--quiet", "--hide-rho"] []
-          records <- readUtf8 path
-          records `shouldEndWith` "\tΦ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
+        withAtoms $ \atoms ->
+          withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+            hClose stream
+            withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+              testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--hide-rho"] []
+            records <- readUtf8 path
+            records `shouldEndWith` "\tΦ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
 
       it "keeps the records of a run that fails" $
-        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-          hClose stream
-          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], nope -> [[ L> L_number_nope ]] ]], @ -> 5.plus(6).nope ]]" $
-            testCLIFailed
-              ["dataize", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"]
-              ["Atom 'L_number_nope' does not exist"]
-          records <- readUtf8 path
-          records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
+        withAtoms $ \atoms ->
+          withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+            hClose stream
+            withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], nope -> [[ L> L_number_nope ]] ]], @ -> 5.plus(6).nope ]]" $
+              testCLIFailed
+                ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"]
+                ["Atom 'L_number_nope' does not exist"]
+            records <- readUtf8 path
+            records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
 
       it "truncates the records left over from the previous run" $
         withTempFileContent "evaluationsXXXXXX.txt" "L_number_gt\t[[ ]]\t01-\n" $ \path -> do
@@ -1185,52 +1201,116 @@ spec = do
             ["dataize", "--evaluations=evaluations.txt", "--output=latex"]
             ["The --evaluations option can stay together with --output=phi only"]
 
-    -- A placeholder formation ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input
-    -- names an atom phino cannot fire; the run used to die on it, discarding
-    -- what it had already evaluated (#1060)
+    -- A λ function the '--atoms' registry does not carry cannot fire — a
+    -- placeholder such as ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input, or
+    -- an operation the caller left out of its registry on purpose. The run used
+    -- to die on it, discarding what it had already evaluated (#1060)
     describe "--partial" $ do
-      let stuck = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], times(x) -> [[ L> L_number_times ]] ]], @ -> 2.times(3).plus([[ L> Sym_arg_0 ]]) ]]"
+      let stuck = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, times(x) -> [[ L> L_number_times ]], nope -> [[ L> L_number_nope ]] ]], @ -> 2.times(3).nope ]]"
       it "fails on an atom that cannot fire without the flag" $
-        withStdin stuck $
-          testCLIFailed ["dataize", "--sweet", "--hide-rho"] ["Atom 'Sym_arg_0' does not exist"]
+        withAtoms $ \atoms ->
+          withStdin stuck $
+            testCLIFailed ["dataize", atoms, "--sweet", "--hide-rho"] ["Atom 'L_number_nope' does not exist"]
 
       it "prints the residue with the stuck application intact and exits successfully" $
-        withStdin stuck $
-          testCLISucceeded
-            ["dataize", "--partial", "--sweet", "--hide-rho"]
-            ["⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
+        withAtoms $ \atoms ->
+          withStdin stuck $
+            testCLISucceeded
+              ["dataize", atoms, "--partial", "--sweet", "--hide-rho"]
+              ["⟦ λ ⤍ L_number_nope ⟧"]
 
       it "keeps what was evaluated before the stuck site in the residue" $
-        withStdin stuck $
-          testCLISucceeded
-            ["dataize", "--partial", "--sweet"]
-            ["as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
+        withAtoms $ \atoms ->
+          withStdin stuck $
+            testCLISucceeded
+              ["dataize", atoms, "--partial", "--sweet"]
+              ["as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
 
       it "records every stuck site in --evaluations with no result" $
-        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-          hClose stream
-          withStdin stuck $
-            testCLISucceeded ["dataize", "--partial", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
-          records <- readUtf8 path
-          lines records
-            `shouldBe` [ "L_number_times\t⟦ x ↦ 3 ⟧\t6"
-                       , "Sym_arg_0\t⟦⟧"
-                       , "L_number_plus\t⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧ ⟧"
-                       ]
+        withAtoms $ \atoms ->
+          withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+            hClose stream
+            withStdin stuck $
+              testCLISucceeded ["dataize", atoms, "--partial", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+            records <- readUtf8 path
+            lines records
+              `shouldBe` [ "L_number_times\t⟦ x ↦ 3 ⟧\t6"
+                         , "L_number_nope\t⟦⟧"
+                         ]
 
       it "still prints bytes when nothing gets stuck" $
-        withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
-          testCLISucceeded ["dataize", "--partial"] ["40-26-00-00-00-00-00-00"]
+        withAtoms $ \atoms ->
+          withStdin "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+            testCLISucceeded ["dataize", atoms, "--partial"] ["40-26-00-00-00-00-00-00"]
 
       it "prints the chain of steps ending in the residue with --sequence" $
-        withStdin stuck $
-          testCLISucceeded
-            ["dataize", "--partial", "--sequence", "--sweet", "--hide-rho", "--flat"]
-            ["2.times( 3 ).plus( ⟦ λ ⤍ Sym_arg_0 ⟧ )", "⟦ x ↦ ⟦ λ ⤍ Sym_arg_0 ⟧, λ ⤍ L_number_plus ⟧"]
+        withAtoms $ \atoms ->
+          withStdin stuck $
+            testCLISucceeded
+              ["dataize", atoms, "--partial", "--sequence", "--sweet", "--hide-rho", "--flat"]
+              ["2.times( 3 ).nope", "⟦ λ ⤍ L_number_nope ⟧"]
 
       it "still stops on the terminator ⊥, since a wrong operand is not a stuck atom" $
         withStdin "[[ ]]" $
           testCLIFailed ["dataize", "--partial"] ["terminator ⊥"]
+
+    -- Which λ functions exist is not phino's business any more: the registry
+    -- given with '--atoms' decides, and phino carries none of its own
+    describe "--atoms" $ do
+      let sum' = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
+      it "fires the λ function the registry carries" $
+        withAtoms $ \atoms ->
+          withStdin sum' $
+            testCLISucceeded ["dataize", atoms] ["40-26-00-00-00-00-00-00"]
+
+      it "gets stuck on every atom when it is not given" $
+        withStdin sum' $
+          testCLIFailed ["dataize"] ["Atom 'L_number_plus' does not exist"]
+
+      it "fails when the registry file is not there" $
+        withStdin sum' $
+          testCLIFailed ["dataize", "--atoms=no-such-registry.json"] ["no-such-registry.json"]
+
+      -- An unknown runtime is refused where the registry is read, which is
+      -- before the input is even parsed, rather than when an atom of it fires
+      it "fails on a runtime phino cannot run, before dataizing anything" $
+        withTempFileContent "atomsXXXXXX.json" "{\"L_number_plus\": {\"rt\": \"ruby\", \"script\": \"puts 1\"}}" $ \path ->
+          withStdin sum' $
+            testCLIFailed ["dataize", "--atoms=" ++ path] ["unknown runtime 'ruby'"]
+
+      it "fails on a registry that is not JSON" $
+        withTempFileContent "atomsXXXXXX.json" "L_number_plus: js" $ \path ->
+          withStdin sum' $
+            testCLIFailed ["dataize", "--atoms=" ++ path] ["cannot be read"]
+
+    -- An atom script cannot reduce the operands it was handed by itself, so it
+    -- asks phino for them: '--inside' binds an expression to a synthetic
+    -- attribute of the universe and aims the run at it
+    describe "--inside" $ do
+      let universe = "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> [[ D> 01- ]] ]]"
+      it "dataizes an expression the input does not contain" $
+        withAtoms $ \atoms ->
+          withStdin universe $
+            testCLISucceeded ["dataize", atoms, "--inside=5.plus( 6 )"] ["40-26-00-00-00-00-00-00"]
+
+      -- The expression is normalized first, so a dispatch off a formation — the
+      -- very shape a script asks about, '⟦ x ↦ 6, ρ ↦ 5 ⟧.x' — reduces too
+      it "normalizes what it is handed before dataizing it" $
+        withStdin universe $
+          testCLISucceeded ["dataize", "--inside=[[ x -> [[ D> 2A- ]] ]].x"] ["2A-"]
+
+      it "morphs inside the universe just as it dataizes inside it" $
+        withAtoms $ \atoms ->
+          withStdin universe $
+            testCLISucceeded ["morph", atoms, "--inside=5.plus( 6 )", "--sweet", "--hide-rho", "--flat"] ["⟦ x ↦ 6, λ ⤍ L_number_plus ⟧"]
+
+      it "cannot be used together with --locator" $
+        withStdin universe $
+          testCLIFailed ["dataize", "--inside=Q.@", "--locator=Q.@"] ["--inside and --locator cannot be used together"]
+
+      it "fails when the input expression is not a formation" $
+        withStdin "Q.x" $
+          testCLIFailed ["dataize", "--inside=Q.x"] ["--inside requires the input expression to be a formation"]
 
     describe "fails" $ do
       it "with --output != latex and --nonumber" $
@@ -1307,15 +1387,17 @@ spec = do
         testCLISucceeded ["morph", "--flat", "--hide-rho"] ["⟦ Δ ⤍ 01- ⟧"]
 
     it "stops at the bare saturated λ-formation" $
-      withStdin chained $
-        testCLISucceeded
-          ["morph", "--locator=Q.@", "--sweet", "--hide-rho", "--flat"]
-          ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+      withAtoms $ \atoms ->
+        withStdin chained $
+          testCLISucceeded
+            ["morph", atoms, "--locator=Q.@", "--sweet", "--hide-rho", "--flat"]
+            ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
 
     -- The same term under 𝔻, which insists on bytes and fires what 𝕄 left bare
     it "leaves to dataize the firing that takes the same term to bytes" $
-      withStdin chained $
-        testCLISucceeded ["dataize"] ["40-32-00-00-00-00-00-00"]
+      withAtoms $ \atoms ->
+        withStdin chained $
+          testCLISucceeded ["dataize", atoms] ["40-32-00-00-00-00-00-00"]
 
     -- 'mf' hands a formation back as it is, so '--locator' is how one aims 𝕄 at
     -- a subterm worth navigating: here it resolves Φ against the universe and
@@ -1340,37 +1422,40 @@ spec = do
     -- design — it happens in a side premise, which reduces on a chain of its
     -- own and discards it
     it "prints the chain of morphing steps with --sequence" $
-      withStdin chained $
-        testCLISucceeded
-          ["morph", "--locator=Q.@", "--sequence", "--headers", "--sweet", "--hide-rho", "--flat"]
-          [ "Rule 'maa'"
-          , "Rule 'alpha'"
-          , "Rule 'copy'"
-          , "Rule 'mf'"
-          , "⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"
-          ]
+      withAtoms $ \atoms ->
+        withStdin chained $
+          testCLISucceeded
+            ["morph", atoms, "--locator=Q.@", "--sequence", "--headers", "--sweet", "--hide-rho", "--flat"]
+            [ "Rule 'maa'"
+            , "Rule 'alpha'"
+            , "Rule 'copy'"
+            , "Rule 'mf'"
+            , "⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"
+            ]
 
     it "does not print the result with --quiet" $
       withStdin "[[ D> 01- ]]" $
         testCLISucceeded ["morph", "--quiet"] []
 
     it "records the atoms it fires with --evaluations" $
-      withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
-        hClose stream
-        withStdin chained $
-          testCLISucceeded ["morph", "--locator=Q.@", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
-        records <- readUtf8 path
-        lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11"]
+      withAtoms $ \atoms ->
+        withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
+          hClose stream
+          withStdin chained $
+            testCLISucceeded ["morph", atoms, "--locator=Q.@", "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
+          records <- readUtf8 path
+          lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11"]
 
     it "saves morphing steps to dir with --steps-dir" $
-      withTempDirectory "phino-steps-morph" $ \dir ->
-        withStdin chained $ do
-          testCLISucceeded
-            ["morph", "--locator=Q.@", "--steps-dir=" ++ dir, "--sweet", "--hide-rho", "--flat"]
-            ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
-          steps <- sort <$> listDirectory dir
-          steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
-          length steps `shouldSatisfy` (> 0)
+      withAtoms $ \atoms ->
+        withTempDirectory "phino-steps-morph" $ \dir ->
+          withStdin chained $ do
+            testCLISucceeded
+              ["morph", atoms, "--locator=Q.@", "--steps-dir=" ++ dir, "--sweet", "--hide-rho", "--flat"]
+              ["⟦ x ↦ 7, λ ⤍ L_number_plus ⟧"]
+            steps <- sort <$> listDirectory dir
+            steps `shouldBe` map (\n -> printf "%05d.phi" (n :: Int)) [1 .. length steps]
+            length steps `shouldSatisfy` (> 0)
 
     it "accepts --seed, --shuffle and --depth-sensitive" $
       withStdin "[[ D> 01- ]]" $

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -7,14 +7,16 @@
 module DataizeSpec (spec) where
 
 import AST
+import Atoms (Registry, emptyRegistry)
 import Control.Exception (SomeException)
 import Control.Monad
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List (find, isInfixOf, nub)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe, isJust)
-import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, morph, morph')
+import Dataize (DataizeContext (..), Outcome (..), Steps (..), dataize, dataize', emptyState, execBuildTerm, insideUniverse, morph, morph')
 import Deps (Evaluation (..), Term (TeExpression), dontSaveEval, dontSaveStep)
+import Fixtures (fixtureRegistry, withNode)
 import Functions (buildTerm)
 import Matcher (substEmpty)
 import Parser (parseExpressionThrows)
@@ -26,9 +28,15 @@ import Yaml qualified
 
 -- Shuffle is enabled so the suite exercises the order-independence of the
 -- dataization rules (#909): a hidden overlap surfaces as a nondeterministic
--- failure instead of staying silently green.
+-- failure instead of staying silently green. The registry of λ functions is
+-- empty, since phino implements none of them: a case that needs an atom to
+-- answer brings the fixture registry in through 'withAtoms'.
 defaultDataizeContext :: Expression -> DataizeContext
-defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval
+defaultDataizeContext loc = DataizeContext loc 25 25 (Steps 250 0) False True False emptyRegistry buildTerm dontSaveStep dontSaveEval
+
+-- The same context with the fixture λ functions registered (see 'Fixtures').
+withAtoms :: Registry -> DataizeContext -> DataizeContext
+withAtoms registry ctx = ctx{_atoms = registry}
 
 test :: (Eq a, Show a) => ((Expression, NonEmpty Rewritten) -> Expression -> String -> DataizeContext -> IO ((a, [Rewritten]), String)) -> [(String, Expression, Expression, a)] -> Spec
 test func useCases =
@@ -63,18 +71,18 @@ testMorph useCases =
       (morphed, _) <- morph expr (defaultDataizeContext loc')
       morphed `shouldBe` expected
 
--- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
--- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
--- The 12 primitive λ-atoms every EO data operation reduces to, declared the way
--- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell the
--- expression under φ. 'number.eq' is the one operation with no atom of its own:
--- EO spells it out of 'L_bytes_eq' (eq.eo), so the fixture composes it the same
--- way. Alongside them stand the objects the atoms hand results to: 'string'
--- carries the 'cant-slice' complaint, while 'true' and 'false' fill in for the
--- real bool objects, since the single byte an EO bool dataizes to is all these
--- cases assert. Those bytes are EO's own: 'true.eo' asserts
+-- The EO objects the fixture λ functions answer for, declared the way
+-- 'number.eo' and 'bytes.eo' declare them, so a case below only has to spell
+-- the expression under φ. 'number.eq' is the one operation with no atom of its
+-- own: EO spells it out of 'L_bytes_eq' (eq.eo), so the fixture composes it the
+-- same way. Alongside them stand the objects the atoms hand results to: 'string'
+-- carries what a byte-array complaint would say, while 'true' and 'false' fill
+-- in for the real bool objects, since the single byte an EO bool dataizes to is
+-- all these cases assert. Those bytes are EO's own: 'true.eo' asserts
 -- 'true.as-bytes.eq FF-' and 'bool.eo' branches 'if' over 'FF-' and '00-', so a
 -- universe copied from here starts with a bool an EO program recognizes.
+-- 'number.nope' is declared and left out of the registry on purpose: it is the
+-- λ function that cannot fire, the one '--partial' parks on.
 primitives :: String -> String
 primitives src =
   unlines
@@ -82,14 +90,8 @@ primitives src =
     , "  bytes -> [["
     , "    data -> ?,"
     , "    @ -> $.data,"
-    , "    and -> [[ b -> ?, L> L_bytes_and ]],"
-    , "    or -> [[ b -> ?, L> L_bytes_or ]],"
     , "    not -> [[ L> L_bytes_not ]],"
-    , "    concat -> [[ b -> ?, L> L_bytes_concat ]],"
-    , "    eq -> [[ b -> ?, L> L_bytes_eq ]],"
-    , "    size -> [[ L> L_bytes_size ]],"
-    , "    right -> [[ x -> ?, L> L_bytes_right ]],"
-    , "    slice -> [[ start -> ?, len -> ?, cant-slice -> ?, L> L_bytes_slice ]]"
+    , "    eq -> [[ b -> ?, L> L_bytes_eq ]]"
     , "  ]],"
     , "  number -> [["
     , "    as-bytes -> ?,"
@@ -98,7 +100,8 @@ primitives src =
     , "    times -> [[ x -> ?, L> L_number_times ]],"
     , "    div -> [[ x -> ?, L> L_number_div ]],"
     , "    gt -> [[ x -> ?, L> L_number_gt ]],"
-    , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]]"
+    , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]],"
+    , "    nope -> [[ L> L_number_nope ]]"
     , "  ]],"
     , "  string -> [[ as-bytes -> ?, @ -> $.as-bytes ]],"
     , "  true -> [[ @ -> [[ D> FF- ]] ]],"
@@ -111,38 +114,51 @@ primitives src =
 raw :: String -> String
 raw bts = "Q.bytes( data -> [[ D> " ++ bts ++ " ]] )"
 
-testAtom :: [(String, String, Bytes)] -> Spec
-testAtom useCases =
+-- Dataize an expression against the fixture universe, with the fixture λ
+-- functions registered. Every such case runs an external script, so it is
+-- pending where 'node' is not installed.
+testAtom :: Registry -> [(String, String, Bytes)] -> Spec
+testAtom registry useCases =
   forM_ useCases $ \(name, src, res) ->
-    it name $ do
-      expr <- parseExpressionThrows (primitives src)
-      loc <- parseExpressionThrows "Q"
-      (value, _) <- dataize expr (defaultDataizeContext loc)
-      value `shouldBe` Dataized res
+    it name $
+      withNode $ do
+        expr <- parseExpressionThrows (primitives src)
+        loc <- parseExpressionThrows "Q"
+        (value, _) <- dataize expr (withAtoms registry (defaultDataizeContext loc))
+        value `shouldBe` Dataized res
 
 -- Dataize under '--partial', collecting every report 𝔼 makes on the way, in
 -- the order it makes them
-partially :: String -> IO ((Outcome, [Rewritten]), [Evaluation])
-partially src = do
+partially :: Registry -> String -> IO ((Outcome, [Rewritten]), [Evaluation])
+partially registry src = do
   expr <- parseExpressionThrows (primitives src)
   reports <- newIORef []
-  let ctx = (defaultDataizeContext ExRoot){_partial = True, _saveEval = \report -> modifyIORef' reports (report :)}
+  let ctx =
+        (withAtoms registry (defaultDataizeContext ExRoot))
+          { _partial = True
+          , _saveEval = \report -> modifyIORef' reports (report :)
+          }
   result <- dataize expr ctx
   collected <- readIORef reports
   pure (result, reverse collected)
 
 -- An atom with no answer yields ⊥, which stops the whole dataization
-testStuckAtom :: [(String, String)] -> Spec
-testStuckAtom useCases =
+testStuckAtom :: Registry -> [(String, String)] -> Spec
+testStuckAtom registry useCases =
   forM_ useCases $ \(name, src) ->
-    it name $ do
-      expr <- parseExpressionThrows (primitives src)
-      loc <- parseExpressionThrows "Q"
-      dataize expr (defaultDataizeContext loc)
-        `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
+    it name $
+      withNode $ do
+        expr <- parseExpressionThrows (primitives src)
+        loc <- parseExpressionThrows "Q"
+        dataize expr (withAtoms registry (defaultDataizeContext loc))
+          `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
 spec :: Spec
 spec = do
+  -- Every λ function a case may fire comes from the fixture registry, read
+  -- once here: phino carries none of its own (see 'Fixtures').
+  registry <- runIO fixtureRegistry
+
   -- The top-level 𝕄 entry point, the one the 'morph' command runs: it locates
   -- the subterm, threads the whole input expression as the universe and hands
   -- back the morphed expression together with the chain that led to it (#1114).
@@ -253,7 +269,7 @@ spec = do
   -- 'execBuildTerm', the same way the matcher would call it.
   describe "execBuildTerm 'evaluate'" $ do
     let univ = ExFormation []
-        ctx = defaultDataizeContext ExRoot
+        ctx = withAtoms registry (defaultDataizeContext ExRoot)
         runEvaluate args = execBuildTerm univ ctx "evaluate" args substEmpty
     forM_
       [
@@ -281,12 +297,13 @@ spec = do
           it ("throws when " ++ desc) $
             runEvaluate args `shouldThrow` (\e -> message `isInfixOf` show (e :: SomeException))
       )
-    it "evaluates a λ-bearing formation to the atom's normalized result" $ do
-      let form = ExFormation [BiLambda (Function "L_bytes_not"), BiTau AtRho (ExFormation [BiDelta (BtOne "00")])]
-      result <- runEvaluate [ArgExpression form, ArgExpression univ]
-      case result of
-        TeExpression expr -> expr `shouldBe` dataBytes (BtOne "FF")
-        _ -> expectationFailure "expected TeExpression"
+    it "evaluates a λ-bearing formation to the atom's normalized result" $
+      withNode $ do
+        let form = ExFormation [BiLambda (Function "L_bytes_not"), BiTau AtRho (ExFormation [BiDelta (BtOne "00")])]
+        result <- runEvaluate [ArgExpression form, ArgExpression univ]
+        case result of
+          TeExpression expr -> expr `shouldBe` dataBytes (BtOne "FF")
+          _ -> expectationFailure "expected TeExpression"
 
   describe "execBuildTerm 'morph'" $ do
     let univ = ExFormation []
@@ -300,18 +317,32 @@ spec = do
         TeExpression expr -> expr `shouldBe` ExFormation [BiDelta (BtOne "00")]
         _ -> expectationFailure "expected TeExpression"
 
-  -- Every atom's operand is fetched through the synthetic '_dataize', which
-  -- rebuilds the universe as a formation to bind the operand into before
-  -- reducing it. A universe that is not itself a formation can never arise
-  -- from the public 'dataize' entry point (its own universe argument doubles
-  -- as the located root of a real program, always a formation), but 'dataize''
-  -- lets a test drive an atom-bearing term against one directly, proving the
-  -- guard fires instead of the atom looping or crashing some other way.
-  describe "atoms refuse to run under a non-formation universe" $
-    it "fails fast instead of dispatching against a non-formation universe" $ do
-      let form = ExFormation [BiLambda (Function "L_bytes_not"), BiVoid AtRho]
-      dataize' (form, (ExRoot, Nothing) :| []) ExRoot emptyState (defaultDataizeContext ExRoot)
-        `shouldThrow` (\e -> "non-formation universe" `isInfixOf` show (e :: SomeException))
+  -- An expression that is not part of the program — the operand an atom script
+  -- asks phino to reduce — is bound to a synthetic attribute of the universe and
+  -- that attribute is what 𝔻 is aimed at. This is what the '--inside' option
+  -- runs, and what phino did internally while the atoms still lived in the
+  -- binary.
+  describe "insideUniverse" $ do
+    let universe = "[[ y -> [[ D> 02- ]] ]]"
+        reduced src = do
+          univ <- parseExpressionThrows universe
+          target <- parseExpressionThrows src
+          (extended, ctx) <- insideUniverse target univ (defaultDataizeContext ExRoot)
+          fst <$> dataize extended ctx
+    it "reduces an expression the program does not contain" $ do
+      value <- reduced "Q.y"
+      value `shouldBe` Dataized (BtOne "02")
+    -- 𝔻 accepts normal forms only, and a dispatch off a formation is not one:
+    -- 'dot' still applies to it. So the expression is normalized first, which
+    -- is the whole reason an atom script cannot simply splice it into the
+    -- universe itself.
+    it "normalizes what it is handed before 𝔻 sees it" $ do
+      value <- reduced "[[ x -> [[ D> 01- ]] ]].x"
+      value `shouldBe` Dataized (BtOne "01")
+    it "refuses a universe which is not a formation" $ do
+      target <- parseExpressionThrows "Q.y"
+      insideUniverse target ExRoot (defaultDataizeContext ExRoot)
+        `shouldThrow` (\e -> "not a formation" `isInfixOf` show (e :: SomeException))
 
   -- 'defaultDataizeContext' runs with '_shuffle' on, so 'morph'' walks the
   -- morphing rules in a random order on every step. Every clause is
@@ -453,76 +484,79 @@ spec = do
   -- stop it (#1052). '--max-steps' bounds that recursion and fails once the
   -- budget is gone.
   describe "stops a dataization that never reaches bytes" $
-    it "fails on the step limit instead of morphing forever" $ do
-      expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
-      dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True False buildTerm dontSaveStep dontSaveEval)
-        `shouldThrow` (\e -> "--max-steps=40" `isInfixOf` show (e :: SomeException))
+    it "fails on the step limit instead of morphing forever" $
+      withNode $ do
+        expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
+        dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True False registry buildTerm dontSaveStep dontSaveEval)
+          `shouldThrow` (\e -> "--max-steps=40" `isInfixOf` show (e :: SomeException))
 
-  -- An atom phino does not know — a placeholder such as ⟦ λ ⤍ Sym_arg_0 ⟧
-  -- standing in for a data input (#1060) — fails the run, and so does a known
-  -- atom whose input reaches one. Under '_partial' the run ends on the residue
+  -- An atom phino does not know — a name the '--atoms' registry does not carry,
+  -- such as the placeholder ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input
+  -- (#1060) — fails the run. Under '_partial' the run ends on the residue
   -- instead: the working expression the spine had reached, with the stuck
   -- application intact and everything the calculus demanded before it already
-  -- evaluated, while 𝔼 reports each parked site with no result.
+  -- evaluated, while 𝔼 reports each parked site with no result. Since the atoms
+  -- moved out of the binary, an operand that cannot be reduced is the script's
+  -- own business, so what parks here is the unregistered λ function alone.
   describe "partially evaluates around an atom that cannot fire (--partial)" $ do
     -- the parser gives every formation its void ρ
     let placeholder = ExFormation [BiLambda (Function "Sym_arg_0"), BiVoid AtRho]
-    it "fails on it without the flag, naming the unknown atom" $ do
-      expr <- parseExpressionThrows (primitives "2.times(3).plus([[ L> Sym_arg_0 ]])")
-      dataize expr (defaultDataizeContext ExRoot)
-        `shouldThrow` (\e -> "Atom 'Sym_arg_0' does not exist" `isInfixOf` show (e :: SomeException))
-    it "leaves the saturated application of the known atom in place, the placeholder inside it" $ do
-      ((outcome, _), _) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
-      case outcome of
-        Residual (ExFormation bds) -> do
-          bds `shouldContain` [BiLambda (Function "L_number_plus")]
-          bds `shouldContain` [BiTau (AtLabel "x") placeholder]
-        other -> expectationFailure ("expected a residual formation, got " ++ show other)
-    it "keeps what was evaluated before the stuck site in the residue" $ do
-      ((outcome, _), _) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
-      case outcome of
-        Residual (ExFormation bds) -> do
-          let rho = [value | BiTau AtRho value <- bds]
-          length rho `shouldBe` 1
-          -- 2 × 3 = 6.0, whose IEEE 754 bytes are 40-18-00-00-00-00-00-00
-          show rho `shouldContain` show (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
-          -- the times application is gone: ρ is the number it produced, its 'as-bytes' bound
-          [() | ExFormation inner <- rho, BiTau (AtLabel "as-bytes") _ <- inner] `shouldBe` [()]
-        other -> expectationFailure ("expected a residual formation, got " ++ show other)
-    it "reports the firing that succeeded with its result and every stuck site without one" $ do
-      (_, reports) <- partially "2.times(3).plus([[ L> Sym_arg_0 ]])"
-      map (._function) reports `shouldBe` ["L_number_times", "Sym_arg_0", "L_number_plus"]
-      map (isJust . (._result)) reports `shouldBe` [True, False, False]
-    it "leaves an unknown atom dataized directly as the whole residue" $ do
-      ((outcome, chain), reports) <- partially "[[ L> Sym_arg_0 ]]"
-      outcome `shouldBe` Residual placeholder
-      map (._function) reports `shouldBe` ["Sym_arg_0"]
-      map fst chain `shouldEndWith` [placeholder]
-    it "still reaches bytes when nothing is stuck" $ do
-      ((outcome, _), reports) <- partially "2.times(3)"
-      outcome `shouldBe` Dataized (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
-      map (._function) reports `shouldBe` ["L_number_times"]
-    it "stops on the terminator ⊥ as before, since a wrong operand is not a stuck atom" $ do
-      expr <- parseExpressionThrows (primitives (raw "20-1F" ++ ".and( " ++ raw "CA-FE-BE" ++ " )"))
-      dataize expr ((defaultDataizeContext ExRoot){_partial = True})
-        `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
+    it "fails on it without the flag, naming the unknown atom" $
+      withNode $ do
+        expr <- parseExpressionThrows (primitives "2.times(3).nope")
+        dataize expr (withAtoms registry (defaultDataizeContext ExRoot))
+          `shouldThrow` (\e -> "Atom 'L_number_nope' does not exist" `isInfixOf` show (e :: SomeException))
+    it "leaves the application of the unregistered atom in place" $
+      withNode $ do
+        ((outcome, _), _) <- partially registry "2.times(3).nope"
+        case outcome of
+          Residual (ExFormation bds) -> bds `shouldContain` [BiLambda (Function "L_number_nope")]
+          other -> expectationFailure ("expected a residual formation, got " ++ show other)
+    it "keeps what was evaluated before the stuck site in the residue" $
+      withNode $ do
+        ((outcome, _), _) <- partially registry "2.times(3).nope"
+        case outcome of
+          Residual (ExFormation bds) -> do
+            let rho = [value | BiTau AtRho value <- bds]
+            length rho `shouldBe` 1
+            -- 2 × 3 = 6.0, whose IEEE 754 bytes are 40-18-00-00-00-00-00-00
+            show rho `shouldContain` show (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
+            -- the times application is gone: ρ is the number it produced, its 'as-bytes' bound
+            [() | ExFormation inner <- rho, BiTau (AtLabel "as-bytes") _ <- inner] `shouldBe` [()]
+          other -> expectationFailure ("expected a residual formation, got " ++ show other)
+    it "reports the firing that succeeded with its result and the stuck site without one" $
+      withNode $ do
+        (_, reports) <- partially registry "2.times(3).nope"
+        map (._function) reports `shouldBe` ["L_number_times", "L_number_nope"]
+        map (isJust . (._result)) reports `shouldBe` [True, False]
+    it "leaves an unknown atom dataized directly as the whole residue" $
+      withNode $ do
+        ((outcome, chain), reports) <- partially registry "[[ L> Sym_arg_0 ]]"
+        outcome `shouldBe` Residual placeholder
+        map (._function) reports `shouldBe` ["Sym_arg_0"]
+        map fst chain `shouldEndWith` [placeholder]
+    it "still reaches bytes when nothing is stuck" $
+      withNode $ do
+        ((outcome, _), reports) <- partially registry "2.times(3)"
+        outcome `shouldBe` Dataized (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
+        map (._function) reports `shouldBe` ["L_number_times"]
+    it "stops on the terminator ⊥ as before, since a wrong operand is not a stuck atom" $
+      withNode $ do
+        expr <- parseExpressionThrows (primitives ("5.plus( " ++ raw "--" ++ " )"))
+        dataize expr ((withAtoms registry (defaultDataizeContext ExRoot)){_partial = True})
+          `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
-  -- '_maxDepth'/'_maxCycles' bound the normalization rewriter that a 'box' or
-  -- 'norm' dataization step splices in (see 'normalized'); with
-  -- '_depthSensitive' on, exhausting either one propagates the very same
-  -- exception the rewriter itself throws, and with it off the limit is
-  -- absorbed silently, so dataization still reaches an answer.
   describe "DataizeContext's --max-depth/--max-cycles reach into the normalization it splices in" $ do
     let boxed = "[[ @ -> [[ D> 00- ]] ]]"
     forM_
       [
         ( "--max-cycles"
-        , DataizeContext ExRoot 25 0 (Steps 250 0) True True False buildTerm dontSaveStep dontSaveEval
+        , DataizeContext ExRoot 25 0 (Steps 250 0) True True False emptyRegistry buildTerm dontSaveStep dontSaveEval
         , "--max-cycles=0"
         )
       ,
         ( "--max-depth"
-        , DataizeContext ExRoot 0 25 (Steps 250 0) True True False buildTerm dontSaveStep dontSaveEval
+        , DataizeContext ExRoot 0 25 (Steps 250 0) True True False emptyRegistry buildTerm dontSaveStep dontSaveEval
         , "--max-depth=0"
         )
       ]
@@ -532,8 +566,8 @@ spec = do
             dataize expr ctx `shouldThrow` (\e -> message `isInfixOf` show (e :: SomeException))
       )
     forM_
-      [ ("--max-cycles", DataizeContext ExRoot 25 0 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval)
-      , ("--max-depth", DataizeContext ExRoot 0 25 (Steps 250 0) False True False buildTerm dontSaveStep dontSaveEval)
+      [ ("--max-cycles", DataizeContext ExRoot 25 0 (Steps 250 0) False True False emptyRegistry buildTerm dontSaveStep dontSaveEval)
+      , ("--max-depth", DataizeContext ExRoot 0 25 (Steps 250 0) False True False emptyRegistry buildTerm dontSaveStep dontSaveEval)
       ]
       ( \(flag, ctx) ->
           it ("does not throw without --depth-sensitive even once " ++ flag ++ " is exhausted") $ do
@@ -555,23 +589,15 @@ spec = do
             ++ map (.name) Yaml.normalizationRules
             ++ concatMap (map (verb . (.operation)) . (.premises)) Yaml.morphingRules
             ++ concatMap (map (verb . (.operation)) . (.premises)) Yaml.dataizationRules
-    it "uses no step label without a defining rule or operation" $ do
-      expr <-
-        parseExpressionThrows
-          ( unlines
-              [ "[["
-              , "  bytes(data) -> [[ @ -> $.data ]],"
-              , "  number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]],"
-              , "  @ -> 5.plus(6)"
-              , "]]"
-              ]
-          )
-      loc <- parseExpressionThrows "Q"
-      (_, chain) <- dataize expr (defaultDataizeContext loc)
-      let orphans = nub [label | (_, Just label) <- chain, label `notElem` allowed]
-      unless
-        (null orphans)
-        (expectationFailure ("Dataization emitted step labels with no defining rule or operation: " ++ show orphans))
+    it "uses no step label without a defining rule or operation" $
+      withNode $ do
+        expr <- parseExpressionThrows (primitives "5.plus(6)")
+        loc <- parseExpressionThrows "Q"
+        (_, chain) <- dataize expr (withAtoms registry (defaultDataizeContext loc))
+        let orphans = nub [label | (_, Just label) <- chain, label `notElem` allowed]
+        unless
+          (null orphans)
+          (expectationFailure ("Dataization emitted step labels with no defining rule or operation: " ++ show orphans))
 
   describe "names every rule uniquely across rule sets" $
     it "shares no rule name between morphing, dataization, normalization and contextualization" $ do
@@ -587,33 +613,34 @@ spec = do
     let labelsOf loc src = do
           expr <- parseExpressionThrows src
           loc' <- parseExpressionThrows loc
-          (_, chain) <- dataize expr (defaultDataizeContext loc')
+          (_, chain) <- dataize expr (withAtoms registry (defaultDataizeContext loc'))
           pure [label | (_, Just label) <- chain]
-    it "dataizes 5.plus(6) through the expected rules" $ do
-      labels <-
-        labelsOf
-          "Q"
-          "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
-      labels
-        `shouldBe` [ "contextualize"
-                   , "maa"
-                   , "alpha"
-                   , "copy"
-                   , "mf"
-                   , "evaluate"
-                   , "ma"
-                   , "copy"
-                   , "mf"
-                   , "contextualize"
-                   , "dot"
-                   , "ma"
-                   , "stay"
-                   , "mf"
-                   , "contextualize"
-                   , "dot"
-                   , "copy"
-                   , "delta"
-                   ]
+    it "dataizes 5.plus(6) through the expected rules" $
+      withNode $ do
+        labels <-
+          labelsOf
+            "Q"
+            "[[ bytes(data) -> [[ @ -> $.data ]], number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
+        labels
+          `shouldBe` [ "contextualize"
+                     , "maa"
+                     , "alpha"
+                     , "copy"
+                     , "mf"
+                     , "evaluate"
+                     , "ma"
+                     , "copy"
+                     , "mf"
+                     , "contextualize"
+                     , "dot"
+                     , "ma"
+                     , "stay"
+                     , "mf"
+                     , "contextualize"
+                     , "dot"
+                     , "copy"
+                     , "delta"
+                     ]
     it "dataizes a located reference through the expected rules" $ do
       labels <- labelsOf "Q.foo.bar" "[[ foo -> [[ bar -> [[ @ -> Q.x ]] ]], x -> [[ D> 42- ]] ]]"
       labels `shouldBe` ["contextualize", "md", "dot", "copy", "mf", "delta"]
@@ -626,77 +653,10 @@ spec = do
       dataize expr (defaultDataizeContext loc)
         `shouldThrow` (\e -> "terminator" `isInfixOf` show (e :: SomeException))
 
+  -- Every case below reaches its bytes without firing an atom, so none of them
+  -- needs the registry: what they exercise is the calculus itself.
   testDataize
     [
-      ( "5.plus(6)"
-      , "Q"
-      , unlines
-          [ "[["
-          , "  bytes(data) -> [["
-          , "    @ -> $.data"
-          , "  ]],"
-          , "  number(as-bytes) -> [["
-          , "    @ -> $.as-bytes,"
-          , "    plus(x) -> [[ L> L_number_plus ]]"
-          , "  ]],"
-          , "  @ -> 5.plus(6)"
-          , "]]"
-          ]
-      , BtMany ["40", "26", "00", "00", "00", "00", "00", "00"]
-      )
-    ,
-      ( "Fahrenheit"
-      , "Q"
-      , unlines
-          [ "[["
-          , "  bytes -> [["
-          , "    data -> ?,"
-          , "    @ -> $.data"
-          , "  ]],"
-          , "  number -> [["
-          , "    as-bytes -> ?,"
-          , "    @ -> $.as-bytes,"
-          , "    plus -> [[ x -> ?, L> L_number_plus ]],"
-          , "    times -> [[ x -> ?, L> L_number_times ]]"
-          , "  ]],"
-          , "  @ -> $.c.times(1.8).plus(32),"
-          , "  c -> 25"
-          , "]]"
-          ]
-      , BtMany ["40", "53", "40", "00", "00", "00", "00", "00"]
-      )
-    ,
-      ( "Factorial"
-      , "Q"
-      , unlines
-          [ "[["
-          , "  bytes -> [["
-          , "    data -> ?,"
-          , "    eq -> [[ b -> ?, L> L_bytes_eq ]],"
-          , "    @ -> $.data"
-          , "  ]],"
-          , "  number -> [["
-          , "    as-bytes -> ?,"
-          , "    @ -> $.as-bytes,"
-          , "    times -> [[ x -> ?, L> L_number_times ]],"
-          , "    plus -> [[ x -> ?, L> L_number_plus ]],"
-          , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]]"
-          , "  ]],"
-          , "  true -> [[ if -> [[ t -> ?, f -> ?, @ -> t ]] ]],"
-          , "  false -> [[ if -> [[ t -> ?, f -> ?, @ -> f ]] ]],"
-          , "  fac -> [["
-          , "    x -> ?,"
-          , "    @ -> $.x.eq( 1 ).if("
-          , "      1,"
-          , "      $.x.times($.^.fac($.x.plus(-1)))"
-          , "    )"
-          , "  ]],"
-          , "  @ -> $.fac(3)"
-          , "]]"
-          ]
-      , BtMany ["40", "18", "00", "00", "00", "00", "00", "00"]
-      )
-    ,
       ( "Located"
       , "Q.foo.bar"
       , unlines
@@ -737,88 +697,81 @@ spec = do
       )
     ]
 
-  describe "atoms" $ do
+  -- Which λ functions exist is no longer phino's business: the registry given
+  -- with '--atoms' decides, and each one runs as an external script (see
+  -- 'Atoms'). What the cases below assert is that the answer of such a script
+  -- lands in the derivation exactly where a built-in atom's answer used to: 𝔼
+  -- normalizes it and 𝔻 carries on. The λ functions themselves are the fixture
+  -- ones (see 'Fixtures'), and 'number.eq' is composed out of 'L_bytes_eq' the
+  -- way 'eq.eo' composes it, so the EO-level composition is exercised too.
+  describe "atoms come from the registry" $ do
     testAtom
-      [ ("divides a positive dividend", "256.div( 16 )", BtMany ["40", "30", "00", "00", "00", "00", "00", "00"])
+      registry
+      [ ("adds two numbers", "5.plus( 6 )", BtMany ["40", "26", "00", "00", "00", "00", "00", "00"])
+      , ("multiplies two numbers", "5.times( 6 )", BtMany ["40", "3E", "00", "00", "00", "00", "00", "00"])
+      , -- Two firings in a row: 'ml' reduces the head of the second dispatch,
+        -- which fires the first atom, before the second one is handed its own
+        -- formation to fire against
+        ("fires twice down a chain of dispatches", "5.plus( 6 ).plus( 7 )", BtMany ["40", "32", "00", "00", "00", "00", "00", "00"])
+      , ("divides a positive dividend", "256.div( 16 )", BtMany ["40", "30", "00", "00", "00", "00", "00", "00"])
       , ("divides by zero into infinity", "2.div( 0 )", BtMany ["7F", "F0", "00", "00", "00", "00", "00", "00"])
       , ("tells 1000 is greater than 200", "1000.gt( 200 )", BtOne "FF")
       , ("tells 42 is not greater than 42.5", "42.gt( 42.5 )", BtOne "00")
       , ("tells zero is greater than a negative", "0.gt( -5 )", BtOne "FF")
       , ("tells 5 equals 5", "5.eq( 5 )", BtOne "FF")
       , ("tells 5 is not equal to 6", "5.eq( 6 )", BtOne "00")
-      , ("adds two numbers", "5.plus( 6 )", BtMany ["40", "26", "00", "00", "00", "00", "00", "00"])
-      , ("multiplies two numbers", "5.times( 6 )", BtMany ["40", "3E", "00", "00", "00", "00", "00", "00"])
-      ,
-        ( "conjoins two long bytes"
-        , raw "02-EF-D4-05-5E-78-3A" ++ ".and( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
-        , BtMany ["02", "23", "C0", "05", "5E", "70", "10"]
-        )
-      ,
-        ( "disjoins negative bytes with one"
-        , raw "FF-FF-FF-FF-00-00-00-00" ++ ".or( " ++ raw "00-00-00-00-00-00-00-01" ++ " )"
-        , BtMany ["FF", "FF", "FF", "FF", "00", "00", "00", "01"]
-        )
       , ("inverts bytes", raw "CA-FE-BE-BE" ++ ".not", BtMany ["35", "01", "41", "41"])
-      ,
-        ( "concats two long bytes"
-        , raw "02-EF-D4-05-5E-78-3A" ++ ".concat( " ++ raw "12-33-C1-B5-5E-71-55" ++ " )"
-        , BtMany ["02", "EF", "D4", "05", "5E", "78", "3A", "12", "33", "C1", "B5", "5E", "71", "55"]
-        )
-      ,
-        ( "concats bytes with empty ones"
-        , raw "05-5E-78" ++ ".concat( " ++ raw "--" ++ " )"
-        , BtMany ["05", "5E", "78"]
-        )
-      , ("counts the size of bytes", raw "F1-20-5F-EC-B5-90-32" ++ ".size", BtMany ["40", "1C", "00", "00", "00", "00", "00", "00"])
       , ("tells equal bytes are equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FE" ++ " )", BtOne "FF")
       , ("tells different bytes are not equal", raw "CA-FE" ++ ".eq( " ++ raw "CA-FF" ++ " )", BtOne "00")
-      , ("takes a part of bytes", raw "20-1F-EE-B5-90" ++ ".slice( 1, 3 )", BtMany ["1F", "EE", "B5"])
-      ,
-        ( "shifts right an even negative"
-        , raw "C0-43-00-00-00-00-00-00" ++ ".right( 1 )"
-        , BtMany ["60", "21", "80", "00", "00", "00", "00", "00"]
-        )
-      ,
-        ( "shifts right minus one"
-        , raw "BF-F0-00-00-00-00-00-00" ++ ".right( 4 )"
-        , BtMany ["0B", "FF", "00", "00", "00", "00", "00", "00"]
-        )
-      ,
-        ( "shifts right by the integer minimum"
-        , raw "BF-F0-00-00-00-00-00-00" ++ ".right( -2147483648 )"
-        , BtMany ["00", "00", "00", "00", "00", "00", "00", "00"]
-        )
-      ,
-        ( "recovers from an out-of-bounds slice"
-        , raw "20-1F-EE-B5-90" ++ ".slice( 3, 10, [[ message -> ?, @ -> \"recovered\" ]] )"
-        , BtMany ["72", "65", "63", "6F", "76", "65", "72", "65", "64"]
-        )
-      ,
-        ( "recovers from a slice whose start plus length overflows"
-        , raw "20-1F-EE-B5-90" ++ ".slice( 2000000000, 2000000000, [[ message -> ?, @ -> \"recovered\" ]] )"
-        , BtMany ["72", "65", "63", "6F", "76", "65", "72", "65", "64"]
-        )
       ]
+
+    -- A whole program, not a single operation: every atom on the way is an
+    -- external script and the run still lands on the bytes EO's own
+    -- 'Fahrenheit' example lands on
+    it "dataizes a program whose every operation is an external atom" $
+      withNode $ do
+        expr <-
+          parseExpressionThrows
+            ( unlines
+                [ "[["
+                , "  bytes -> [["
+                , "    data -> ?,"
+                , "    @ -> $.data"
+                , "  ]],"
+                , "  number -> [["
+                , "    as-bytes -> ?,"
+                , "    @ -> $.as-bytes,"
+                , "    plus -> [[ x -> ?, L> L_number_plus ]],"
+                , "    times -> [[ x -> ?, L> L_number_times ]]"
+                , "  ]],"
+                , "  @ -> $.c.times(1.8).plus(32),"
+                , "  c -> 25"
+                , "]]"
+                ]
+            )
+        loc <- parseExpressionThrows "Q"
+        (value, _) <- dataize expr (withAtoms registry (defaultDataizeContext loc))
+        value `shouldBe` Dataized (BtMany ["40", "53", "40", "00", "00", "00", "00", "00"])
+
+    -- A name the registry does not carry has no λ function at all: 𝔼 gets
+    -- stuck on it, which is the only behaviour phino itself is left with
+    it "gets stuck on a λ function the registry does not carry" $ do
+      expr <- parseExpressionThrows (primitives "5.nope")
+      loc <- parseExpressionThrows "Q"
+      dataize expr (withAtoms registry (defaultDataizeContext loc))
+        `shouldThrow` (\e -> "Atom 'L_number_nope' does not exist" `isInfixOf` show (e :: SomeException))
+
+    -- An operand carrying no number is what an EO number atom answers ⊥ to, and
+    -- dataizing ⊥ fails through the terminator path. The judgment is the
+    -- script's now, so what these cases prove is that a ⊥ coming back from a
+    -- script stops 𝔻 exactly as a built-in ⊥ used to.
     testStuckAtom
-      [ ("cannot conjoin bytes of different lengths", raw "20-1F" ++ ".and( " ++ raw "CA-FE-BE" ++ " )")
-      , ("cannot disjoin bytes of different lengths", raw "20-1F" ++ ".or( " ++ raw "CA-FE-BE" ++ " )")
-      , ("cannot slice from an offset beyond the int range", raw "20-1F-EE-B5-90" ++ ".slice( 3000000000, 1 )")
-      , ("cannot slice a negative length", raw "20-1F-EE-B5-90" ++ ".slice( 1, -1 )")
-      , -- A number atom rejects an operand that carries no number (empty bytes),
-        -- yielding ⊥ rather than a result; dataizing ⊥ then fails through the
-        -- terminator path, exactly like the bytes-atom cases above.
-        ("cannot add a non-numeric operand", "5.plus( " ++ raw "--" ++ " )")
+      registry
+      [ ("cannot add a non-numeric operand", "5.plus( " ++ raw "--" ++ " )")
       , ("cannot multiply by a non-numeric operand", "5.times( " ++ raw "--" ++ " )")
       , ("cannot divide by a non-numeric divisor", "5.div( " ++ raw "--" ++ " )")
       , ("cannot compare against a non-numeric threshold", "5.gt( " ++ raw "--" ++ " )")
-      , -- A number atom also rejects a non-empty operand whose byte array is not
-        -- 8 bytes long (e.g. 2 or 5 bytes): such an array carries no number, and
-        -- the atom must yield ⊥ instead of crashing on 'btsToNum' (issue #1072).
+      , -- A byte array whose length is not 8 carries no number either (#1072)
         ("cannot add a 5-byte operand", "5.plus( " ++ raw "68-65-6C-6C-6F" ++ " )")
       , ("cannot multiply by a 2-byte operand", "5.times( " ++ raw "20-1F" ++ " )")
-      , ("cannot divide by a 3-byte divisor", "5.div( " ++ raw "CA-FE-BE" ++ " )")
-      , ("cannot compare against a 4-byte threshold", "5.gt( " ++ raw "FF-FF-FF-FF" ++ " )")
-      , -- 'right' rejects a shift distance that is not a plain 8-byte integer;
-        -- empty bytes carry no such integer, so the shift atom is stuck too.
-        ("cannot shift right by a non-integer distance", raw "C0-43-00-00-00-00-00-00" ++ ".right( " ++ raw "--" ++ " )")
       ]

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -10,7 +10,7 @@
 -- command-line argument.
 module Fixtures (fixtureAtoms, fixtureRegistry, withFixtureRegistry, withNode) where
 
-import Atoms (Atom (..), Registry, Runtime (RtJs))
+import Atoms (Atom (..), Registry, Runtime (RtNode))
 import Control.Exception (bracket)
 import Data.Aeson (encode, object, (.=))
 import Data.Aeson.Key qualified as Key
@@ -45,7 +45,7 @@ fixtureScript = decodeUtf8 <$> BS.readFile "test-resources/atoms/primitives.js"
 fixtureRegistry :: IO Registry
 fixtureRegistry = do
   script <- fixtureScript
-  pure (Map.fromList [(name, Atom RtJs script) | name <- fixtureAtoms])
+  pure (Map.fromList [(name, Atom RtNode script) | name <- fixtureAtoms])
 
 -- The same registry as the JSON file '--atoms' reads, in a temporary file
 -- removed afterwards, for the specs that go through the command line.
@@ -58,7 +58,7 @@ withFixtureRegistry action = do
     hClose handle
     action path
   where
-    entry script = object ["rt" .= ("js" :: T.Text), "script" .= script]
+    entry script = object ["rt" .= ("node" :: T.Text), "script" .= script]
     discarded :: (FilePath, Handle) -> IO ()
     discarded (path, handle) = hClose handle >> removePathForcibly path
 

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+-- SPDX-License-Identifier: MIT
+
+-- The λ functions the specs fire. phino implements none of them, so a spec that
+-- needs an atom to answer brings its own: one JavaScript fixture,
+-- 'test-resources/atoms/primitives.js', registered under every name in
+-- 'fixtureAtoms' and branching on the one it is handed as its first
+-- command-line argument.
+module Fixtures (fixtureAtoms, fixtureRegistry, withFixtureRegistry, withNode) where
+
+import Atoms (Atom (..), Registry, Runtime (RtJs))
+import Control.Exception (bracket)
+import Data.Aeson (encode, object, (.=))
+import qualified Data.Aeson.Key as Key
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map.Strict as Map
+import Data.Maybe (isNothing)
+import qualified Data.Text as T
+import Data.Text.Encoding (decodeUtf8)
+import System.Directory (findExecutable, getTemporaryDirectory, removePathForcibly)
+import System.IO (Handle, hClose, openBinaryTempFile)
+import Test.Hspec (Expectation, pendingWith)
+
+-- Every λ function the fixture answers for. A name outside this list is
+-- unregistered, which is how a spec asks for an atom that cannot fire.
+fixtureAtoms :: [T.Text]
+fixtureAtoms =
+  [ "L_number_plus"
+  , "L_number_times"
+  , "L_number_div"
+  , "L_number_gt"
+  , "L_bytes_eq"
+  , "L_bytes_not"
+  ]
+
+-- The fixture script itself, read as UTF-8 rather than through the locale,
+-- since it spells 𝜑 expressions.
+fixtureScript :: IO T.Text
+fixtureScript = decodeUtf8 <$> BS.readFile "test-resources/atoms/primitives.js"
+
+-- The registry the specs that drive 'Dataize' directly run against.
+fixtureRegistry :: IO Registry
+fixtureRegistry = do
+  script <- fixtureScript
+  pure (Map.fromList [(name, Atom RtJs script) | name <- fixtureAtoms])
+
+-- The same registry as the JSON file '--atoms' reads, in a temporary file
+-- removed afterwards, for the specs that go through the command line.
+withFixtureRegistry :: (FilePath -> IO a) -> IO a
+withFixtureRegistry action = do
+  script <- fixtureScript
+  dir <- getTemporaryDirectory
+  bracket (openBinaryTempFile dir "phino-atoms-.json") discarded $ \(path, handle) -> do
+    BSL.hPut handle (encode (object [Key.fromText name .= entry script | name <- fixtureAtoms]))
+    hClose handle
+    action path
+  where
+    entry script = object ["rt" .= ("js" :: T.Text), "script" .= script]
+    discarded :: (FilePath, Handle) -> IO ()
+    discarded (path, handle) = hClose handle >> removePathForcibly path
+
+-- Every atom the fixture provides runs under 'node', so a machine without it
+-- cannot fire one at all: such an expectation is pending rather than red.
+withNode :: Expectation -> Expectation
+withNode expectation = do
+  node <- findExecutable "node"
+  if isNothing node
+    then pendingWith "'node' is not installed, so no λ function can be fired"
+    else expectation

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -13,12 +13,12 @@ module Fixtures (fixtureAtoms, fixtureRegistry, withFixtureRegistry, withNode) w
 import Atoms (Atom (..), Registry, Runtime (RtJs))
 import Control.Exception (bracket)
 import Data.Aeson (encode, object, (.=))
-import qualified Data.Aeson.Key as Key
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.Map.Strict as Map
+import Data.Aeson.Key qualified as Key
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
+import Data.Map.Strict qualified as Map
 import Data.Maybe (isNothing)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
 import System.Directory (findExecutable, getTemporaryDirectory, removePathForcibly)
 import System.IO (Handle, hClose, openBinaryTempFile)


### PR DESCRIPTION
Closes #1113.

`atom` in `src/Dataize.hs` pattern-matched eleven fixed λ names and fell
through to `Stuck` for everything else, so which atoms exist was pinned to
one snapshot of EO's primitives. It is now read from outside the binary.

## What changed

- **`src/Atoms.hs`** (new) — reads the JSON registry given with
  `--atoms=FILE`, keyed by λ name:

  ```json
  { "L_number_plus": { "rt": "node", "script": "const fs = require('fs'); ..." } }
  ```

  and fires an entry as a POSIX process under the executable its `rt` names
  (`node` is the only one for now), with the λ name as the first command-line
  argument so one script may stand for several names and branch on
  `process.argv[2]`. The script is fed `{"b": …, "s": …}` on stdin — the
  formation being evaluated and the universe Φ — and answers with `{"n": …}`
  on stdout, whose 𝜑-expression becomes the atom's raw result, normalized by 𝔼
  exactly as a built-in answer used to be, so `--evaluations`, `--partial` and
  `--max-steps` keep working unchanged.
- **Every `atom` clause is gone**, and with it `_dataize`, `asNumber`,
  `asInt`, `boolean` and `bitwise`. A name the registry does not carry leaves
  `Stuck` as the only behaviour.
- **`--inside=EXPRESSION`** on `dataize` and `morph` — the decided convention
  the issue asked for. `insideUniverse` binds the expression to a fresh
  synthetic attribute of the universe, normalizes it there and aims the run at
  it: the very trick `_dataize` played internally, now the way a script asks
  phino to reduce a part of the `b` it was handed, instead of splicing it into
  the text of `s` by hand. It cannot be combined with `--locator`.
- **Failure modes** — a non-zero exit (message carries the script's stderr),
  output that is not JSON, a missing `n`, an `n` that does not parse: each
  fails the run. An unknown `rt`, a malformed registry or a missing registry
  file fails when the file is read, before the input is even parsed.
- **`README.md`** documents the registry, the wire protocol, `--inside` (with
  a worked `L_number_plus` that reduces its own operands) and the reshaped
  `--partial` story.
- **Tests** — `test-resources/atoms/primitives.js` is a fixture registry
  (number `plus`/`times`/`div`/`gt`, `bytes` `eq`/`not`, with `number.eq`
  composed out of `L_bytes_eq` the way `eq.eo` composes it), wired in through
  `test/Fixtures.hs`; `test/AtomsSpec.hs` covers registry parsing and the
  firing protocol including every failure path; `DataizeSpec` and `CLISpec`
  drive that registry instead of the built-in names, and `CLISpec` gains
  `--atoms` and `--inside` blocks.

## Consequences worth naming

- **An atom no longer reduces its own operands.** `fire`/`ml` hand 𝔼 the
  formation with its arguments unreduced, and the built-ins used to dataize
  them internally. An external script has to ask phino instead, which is what
  `--inside` is for — the README's `L_number_plus` does exactly that, and it
  takes EO's `Factorial` to `6` through recursive `phino` invocations. It
  costs a process per operand, so a registry that wants speed will want a
  longer-lived protocol one day.
- **`--partial` now parks unregistered names only.** "A known atom whose
  input reaches an unknown atom" is no longer a phino-side case, since inputs
  are the script's business; the placeholder story (`⟦ λ ⤍ Sym_arg_0 ⟧`, an
  operation deliberately left out of the registry) is unchanged and still
  parks. There is currently no way for a script to report "I am stuck" — worth
  a follow-up if the EO lowering needs it.
- **The primitive-semantics cases are gone** from `DataizeSpec` (byte
  `and`/`or`/`concat`/`size`/`slice`/`right`, the int32 and non-8-byte
  rejections): they asserted behaviour phino no longer owns, and keeping them
  would mean maintaining an EO runtime inside phino's test resources. What
  replaces them tests the mechanism, plus the end-to-end cases the fixture can
  still answer for.
- **`Bytes.hs` is left as it is, on purpose.** `btsAnd`, `btsOr`, `btsNot`,
  `btsConcat`, `btsSlice` and `btsShift` existed only to implement the byte
  atoms this PR deletes, so nothing in `src/` calls them any more (their
  `BytesSpec` cases still do). Stripping them is a cleanup the issue does not
  ask for and it touches a module unrelated to the change, so it is left for
  you to call — say the word and I will take them out.
- **The atom-firing specs need `node`.** They are marked pending, not red,
  where it is missing; every GitHub runner has it.

## How it was checked

`cabal test --ghc-options=-Werror` on GHC 9.6.7: 2310 examples, 0 failures
(and the same suite pending-not-failing with `node` off the `PATH`).
`fourmolu 0.17.0.0 --mode check src app test`, `hlint src app test` and
`markdownlint-cli2` clean; `make coverage` reports 81% against the 80%
threshold. The binary was also driven by hand: the registry protocol,
`--inside`, `--partial`, `--evaluations`, a payload well past a pipe's buffer,
and EO's `Fahrenheit` and `Factorial` examples through recursive scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmCGnQHJyTAw6whNeZpSuV
