### PR TITLE
Let the `--atoms` registry name an executable, not only a script

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ registry given with `--atoms`, keyed by λ name:
 }
 ```
 
-The `rt` field names the executable the `script` is run under. Only `node` is
-supported for now; a registry naming any other runtime is refused when the file
-is read, before dataization starts.
+The `rt` field names the interpreter the `script` is run under. Only `node` is
+supported for now; a registry naming any other interpreter is refused when the
+file is read, before dataization starts.
 
 When 𝔼 reaches a λ function the registry carries, `phino` writes its `script`
 to a temporary file and runs it as a POSIX process under that interpreter, with
@@ -127,9 +127,31 @@ the λ name as the first command-line argument:
 node /tmp/phino-atom-4f2a.js L_number_plus
 ```
 
-The name matters: one script may be registered under several λ names and branch
-on it, which is where `node` puts it — `process.argv[2]`. The script is then
-fed one JSON object on `stdin`:
+An atom that is already a program needs no interpreter and no staging. Such an
+entry says `exec` and gives a `path` instead of a `script`:
+
+```json
+{
+  "L_number_plus": {
+    "rt": "exec",
+    "path": "/opt/eo/atoms/number-plus"
+  }
+}
+```
+
+`phino` spawns that file directly, as the executable binary it is, with the λ
+name as its first command-line argument:
+
+```text
+/opt/eo/atoms/number-plus L_number_plus
+```
+
+A `path` that names no file, or a file nobody may run, is refused where the
+registry is read, together with the unknown runtimes.
+
+The name matters: one program may be registered under several λ names and
+branch on it, which is where `node` puts it — `process.argv[2]`. The program is
+then fed one JSON object on `stdin`:
 
 ```json
 {
@@ -156,7 +178,7 @@ The `n` field is the 𝜑-expression the atom answers with, in any syntax
 and hands it to 𝔼 as the atom's raw result, normalizing it exactly as it
 normalizes anything else, so `--evaluations`, `--partial` and `--max-steps`
 keep working unchanged. A non-zero exit, output that is not JSON, a missing
-`n` or an `n` that does not parse fails the run, with the script's own
+`n` or an `n` that does not parse fails the run, with the program's own
 `stderr` in the message.
 
 A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
@@ -9,13 +8,17 @@
 -- Which λ functions exist is a property of the object model being dataized,
 -- not of the calculus. phino therefore implements none of them: it reads a
 -- registry of them from a JSON file given with '--atoms' and fires each one as
--- a POSIX process. The registry maps a λ name to the runtime that runs it and
--- the script it runs:
+-- a POSIX process. The registry maps a λ name either to the runtime that runs
+-- its script or to 'exec' and the path of a file that runs on its own:
 --
 -- > {
 -- >   "L_bytes_eq": {
 -- >     "rt": "node",
 -- >     "script": "const fs = require('fs'); ..."
+-- >   },
+-- >   "L_number_plus": {
+-- >     "rt": "exec",
+-- >     "path": "/opt/eo/atoms/number-plus"
 -- >   }
 -- > }
 --
@@ -54,7 +57,7 @@ import Margin (defaultMargin)
 import Parser (parseExpression)
 import Printer (printExpression')
 import Sugar (SugarType (SALTY))
-import System.Directory (getTemporaryDirectory, removePathForcibly)
+import System.Directory (doesFileExist, executable, getPermissions, getTemporaryDirectory, removePathForcibly)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
 import System.IO (Handle, IOMode (WriteMode), hClose, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
 import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, waitForProcess)
@@ -67,11 +70,14 @@ import Text.Printf (printf)
 data Runtime = RtNode
   deriving stock (Eq, Show)
 
--- One entry of the registry: the runtime and the source of the script.
-data Atom = Atom
-  { _runtime :: Runtime
-  , _script :: T.Text
-  }
+-- One entry of the registry: the λ function phino runs as a POSIX process.
+-- Either a script, which phino stages in a temporary file and hands to the
+-- interpreter of its runtime, or an executable file, which phino runs as it
+-- is, since the object model brought its own binary and there is nothing to
+-- stage.
+data Atom
+  = Scripted Runtime T.Text
+  | Executable FilePath
   deriving stock (Eq, Show)
 
 -- Every λ function phino may fire, keyed by name.
@@ -80,7 +86,8 @@ type Registry = Map T.Text Atom
 data AtomException
   = -- The '--atoms' file is not a JSON registry of λ functions.
     BrokenRegistry FilePath String
-  | -- The interpreter of a runtime is not installed, so no script of it can run.
+  | -- The program of an atom cannot be run: the interpreter of its runtime is
+    -- not installed, or its executable file is missing or not executable.
     NoRuntime T.Text String String
   | -- The script exited with a non-zero status; the message carries its stderr.
     AtomBroke T.Text Int String
@@ -117,8 +124,14 @@ extension RtNode = "js"
 runtimes :: [Runtime]
 runtimes = [RtNode]
 
+-- The 'rt' of an atom that is a file rather than a script: it names no
+-- interpreter, because the file runs on its own.
+execName :: String
+execName = "exec"
+
+-- Every name the 'rt' field of a registry entry may take.
 runtimeNames :: [String]
-runtimeNames = map runtimeName runtimes
+runtimeNames = map runtimeName runtimes ++ [execName]
 
 instance FromJSON Runtime where
   parseJSON = withText "runtime" $ \name -> case find ((== T.unpack name) . runtimeName) runtimes of
@@ -126,7 +139,11 @@ instance FromJSON Runtime where
     Nothing -> fail (printf "unknown runtime '%s', expected one of: %s" (T.unpack name) (intercalate ", " runtimeNames))
 
 instance FromJSON Atom where
-  parseJSON = withObject "atom" $ \entry -> Atom <$> entry .: "rt" <*> entry .: "script"
+  parseJSON = withObject "atom" $ \entry -> do
+    named <- entry .: "rt"
+    if named == T.pack execName
+      then Executable . T.unpack <$> entry .: "path"
+      else Scripted <$> parseJSON (A.String named) <*> entry .: "script"
 
 -- What the script writes to stdout: one JSON object whose 'n' field is the
 -- 𝜑-expression the atom answers with.
@@ -145,83 +162,104 @@ registeredAtom :: Registry -> T.Text -> Maybe Atom
 registeredAtom registry func = Map.lookup func registry
 
 -- Read the registry of λ functions from a JSON file. An unknown runtime, a
--- missing 'script' or malformed JSON fails here, before any dataization
--- starts.
+-- missing 'script', a 'path' that names no executable file or malformed JSON
+-- fails here, before any dataization starts.
 readRegistry :: FilePath -> IO Registry
 readRegistry path = do
   content <- BS.readFile path `catch` unreadable
   case eitherDecodeStrict' content of
     Left failure -> throwIO (BrokenRegistry path failure)
     Right registry -> do
+      mapM_ (uncurry runnable) (Map.toList registry)
       logDebug (printf "Loaded %d atom(s) from '%s'" (Map.size registry) path)
       pure registry
   where
     unreadable :: IOError -> IO BS.ByteString
     unreadable failure = throwIO (BrokenRegistry path (show failure))
+    -- The file of an executable atom is the only thing phino knows about it,
+    -- and it staged none of it, so the file is looked at here, while the
+    -- registry is being read, rather than half-way through a program that
+    -- turns out to name that atom.
+    runnable :: T.Text -> Atom -> IO ()
+    runnable _ (Scripted _ _) = pure ()
+    runnable func (Executable file) = do
+      there <- doesFileExist file
+      unless there (throwIO (NoRuntime func file "there is no such file"))
+      allowed <- executable <$> getPermissions file
+      unless allowed (throwIO (NoRuntime func file "the file is not executable"))
 
--- Fire the λ function 'func' by running its script as a POSIX process under
--- the interpreter of its runtime, with the λ name as the first command-line
--- argument — one script may be registered under several names and branch on
--- it. The script is fed a JSON object on stdin (see 'payload') and answers
--- with one on stdout; the 𝜑-expression under 'n' becomes the atom's raw
--- result, which 𝔼 normalizes exactly as it normalized the answer of a built-in
--- one. A non-zero exit, unparsable output or a missing 'n' fails the run.
+-- Fire the λ function 'func' by running its program as a POSIX process, with
+-- the λ name as its last command-line argument — one program may be registered
+-- under several names and branch on it. A scripted atom is staged in a
+-- temporary file and handed to the interpreter of its runtime; an executable
+-- one is run straight off its path, under no interpreter at all. The program
+-- is fed a JSON object on stdin (see 'payload') and answers with one on
+-- stdout; the 𝜑-expression under 'n' becomes the atom's raw result, which 𝔼
+-- normalizes exactly as it normalized the answer of a built-in one. A non-zero
+-- exit, unparsable output or a missing 'n' fails the run.
 fireAtom :: T.Text -> Atom -> Expression -> Expression -> IO Expression
-fireAtom func Atom{..} form univ =
-  withTemp (printf "phino-atom-.%s" (extension _runtime)) (encodeUtf8 _script) $ \script ->
-    withTemp "phino-atom-.err" "" $ \errors -> do
-      logDebug (printf "Firing atom '%s' as '%s %s %s'" (T.unpack func) (interpreter _runtime) script (T.unpack func))
-      (status, answer) <- executed script errors
-      complaint <- readErrors errors
-      unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
-      case status of
-        ExitFailure code -> throwIO (AtomBroke func code complaint)
-        ExitSuccess -> answered answer
+fireAtom func atom form univ = commanded atom $ \program arguments ->
+  withTemp "phino-atom-.err" "" $ \errors -> do
+    logDebug (printf "Firing atom '%s' as '%s %s'" (T.unpack func) program (unwords arguments))
+    (status, answer) <- executed program arguments errors
+    complaint <- readErrors errors
+    unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
+    case status of
+      ExitFailure code -> throwIO (AtomBroke func code complaint)
+      ExitSuccess -> answered answer
   where
-    -- Run the interpreter with its input and its output on pipes and its
+    -- What to spawn and what to hand it: the interpreter of the runtime, with
+    -- the script staged in a temporary file that outlives nothing but the
+    -- action, or the executable file itself, which phino only points at.
+    commanded :: Atom -> (String -> [String] -> IO a) -> IO a
+    commanded (Scripted runtime script) action =
+      withTemp (printf "phino-atom-.%s" (extension runtime)) (encodeUtf8 script) $ \staged ->
+        action (interpreter runtime) [staged, T.unpack func]
+    commanded (Executable file) action = action file [T.unpack func]
+    -- Run the program with its input and its output on pipes and its
     -- complaints in a file. The input is written and closed before the output is
     -- read, so the parent never has two streams to drain at once — which would
-    -- need threads to be safe — and the script's own stderr, which may be
+    -- need threads to be safe — and the program's own stderr, which may be
     -- anything at all, cannot fill a pipe nobody is reading. Every stream is
     -- bytes: a 𝜑 expression carries characters no single-byte locale can spell,
     -- so nothing is left to the locale.
-    executed :: FilePath -> FilePath -> IO (ExitCode, BS.ByteString)
-    executed script errors =
+    executed :: String -> [String] -> FilePath -> IO (ExitCode, BS.ByteString)
+    executed program arguments errors =
       withBinaryFile errors WriteMode $ \stderr' -> do
-        (stdin', stdout', process) <- spawned script stderr'
+        (stdin', stdout', process) <- spawned program arguments stderr'
         hSetBinaryMode stdin' True
         hSetBinaryMode stdout' True
-        -- A script that dies before reading its input leaves this write with
-        -- nobody to drain it. The failure worth reporting is the one the script
+        -- A program that dies before reading its input leaves this write with
+        -- nobody to drain it. The failure worth reporting is the one the program
         -- made, so a broken pipe is swallowed here and the exit status decides.
         BS.hPut stdin' (payload form univ) `catch` unheard
         hClose stdin' `catch` unheard
         answer <- BS.hGetContents stdout'
         status <- waitForProcess process
         pure (status, answer)
-    spawned :: FilePath -> Handle -> IO (Handle, Handle, ProcessHandle)
-    spawned script stderr' = do
-      spawn <- createProcess started `catch` missing
+    spawned :: String -> [String] -> Handle -> IO (Handle, Handle, ProcessHandle)
+    spawned program arguments stderr' = do
+      spawn <- createProcess started `catch` missing program
       case spawn of
         (Just stdin', Just stdout', _, process) -> pure (stdin', stdout', process)
-        _ -> throwIO (AtomMute func "" "the interpreter gave phino no streams to talk over")
+        _ -> throwIO (AtomMute func "" "the program gave phino no streams to talk over")
       where
         started :: CreateProcess
         started =
-          (proc (interpreter _runtime) [script, T.unpack func])
+          (proc program arguments)
             { std_in = CreatePipe
             , std_out = CreatePipe
             , std_err = UseHandle stderr'
             }
-    missing :: IOError -> IO a
-    missing failure = throwIO (NoRuntime func (interpreter _runtime) (show failure))
+    missing :: String -> IOError -> IO a
+    missing program failure = throwIO (NoRuntime func program (show failure))
     unheard :: IOError -> IO ()
     unheard _ = pure ()
-    -- Whatever the script complained about, decoded leniently: the stream is
-    -- the script's, so it may hold anything at all.
+    -- Whatever the program complained about, decoded leniently: the stream is
+    -- the program's, so it may hold anything at all.
     readErrors :: FilePath -> IO String
     readErrors errors = T.unpack . T.strip . decodeUtf8Lenient <$> BS.readFile errors
-    -- Parse what the script said: a JSON object with the raw 𝜑-expression
+    -- Parse what the program said: a JSON object with the raw 𝜑-expression
     -- under 'n'.
     answered :: BS.ByteString -> IO Expression
     answered answer = case eitherDecodeStrict' answer of

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -216,7 +216,7 @@ optAtoms =
             <> metavar "FILE"
             <> help
               ( printf
-                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script it runs"
+                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script or the executable it runs"
                   (intercalate ", " runtimeNames)
               )
         )

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -10,17 +10,18 @@ import AST
 import Atoms (Atom (..), Runtime (RtNode), emptyRegistry, fireAtom, readRegistry, registeredAtom)
 import Control.Exception (SomeException, bracket)
 import Control.Monad (forM_)
+import Data.Aeson (encode, object, (.=))
 import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BSL
 import Data.List (isInfixOf)
 import Data.Text qualified as T
-import Data.Text.Encoding (encodeUtf8)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Fixtures (withNode)
 import Parser (parseExpressionThrows)
 import System.Directory (getPermissions, getTemporaryDirectory, removePathForcibly, setOwnerExecutable, setPermissions)
 import System.IO (Handle, hClose, openBinaryTempFile)
 import System.Info (os)
 import Test.Hspec
-import Text.Printf (printf)
 
 -- A registry file holding the given content, removed afterwards
 withRegistry :: T.Text -> (FilePath -> IO a) -> IO a
@@ -62,9 +63,12 @@ withShell expectation
   | os == "mingw32" = pendingWith "no POSIX shell script is executable on Windows"
   | otherwise = expectation
 
--- The registry of one executable λ function, naming the given file
+-- The registry of one executable λ function, naming the given file. The path
+-- goes through JSON encoding rather than into the text by hand, since a
+-- Windows one spells its separators with the escape character of JSON
 executing :: FilePath -> T.Text
-executing file = T.pack (printf "{\"L_answer\": {\"rt\": \"exec\", \"path\": \"%s\"}}" file)
+executing file =
+  decodeUtf8 (BSL.toStrict (encode (object ["L_answer" .= object ["rt" .= ("exec" :: T.Text), "path" .= file]])))
 
 -- Fire the λ function 'L_answer' out of the given atom, against a formation
 -- binding 'x' inside a universe binding 'y'

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -16,9 +16,11 @@ import Data.Text qualified as T
 import Data.Text.Encoding (encodeUtf8)
 import Fixtures (withNode)
 import Parser (parseExpressionThrows)
-import System.Directory (getTemporaryDirectory, removePathForcibly)
+import System.Directory (getPermissions, getTemporaryDirectory, removePathForcibly, setOwnerExecutable, setPermissions)
 import System.IO (Handle, hClose, openBinaryTempFile)
+import System.Info (os)
 import Test.Hspec
+import Text.Printf (printf)
 
 -- A registry file holding the given content, removed afterwards
 withRegistry :: T.Text -> (FilePath -> IO a) -> IO a
@@ -32,27 +34,67 @@ withRegistry content action = do
     discarded :: (FilePath, Handle) -> IO ()
     discarded (path, handle) = hClose handle >> removePathForcibly path
 
--- Fire the λ function 'L_answer' out of the given script, against a formation
+-- A file in the temporary directory holding the given POSIX shell script,
+-- removed afterwards
+withScript :: T.Text -> (FilePath -> IO a) -> IO a
+withScript script action = do
+  dir <- getTemporaryDirectory
+  bracket (openBinaryTempFile dir "phino-exec-.sh") discarded $ \(path, handle) -> do
+    BS.hPut handle (encodeUtf8 (T.unlines ["#!/bin/sh", script]))
+    hClose handle
+    action path
+  where
+    discarded :: (FilePath, Handle) -> IO ()
+    discarded (path, handle) = hClose handle >> removePathForcibly path
+
+-- The same file, executable, which is what an 'exec' atom names and phino
+-- never stages itself
+withExecutable :: T.Text -> (FilePath -> IO a) -> IO a
+withExecutable script action = withScript script $ \path -> do
+  permissions <- getPermissions path
+  setPermissions path (setOwnerExecutable True permissions)
+  action path
+
+-- A POSIX shell script is executable nowhere on Windows, so a case that needs
+-- one is pending there rather than red
+withShell :: Expectation -> Expectation
+withShell expectation
+  | os == "mingw32" = pendingWith "no POSIX shell script is executable on Windows"
+  | otherwise = expectation
+
+-- The registry of one executable λ function, naming the given file
+executing :: FilePath -> T.Text
+executing file = T.pack (printf "{\"L_answer\": {\"rt\": \"exec\", \"path\": \"%s\"}}" file)
+
+-- Fire the λ function 'L_answer' out of the given atom, against a formation
 -- binding 'x' inside a universe binding 'y'
-fired :: T.Text -> IO Expression
-fired script = do
+fired :: Atom -> IO Expression
+fired atom = do
   form <- parseExpressionThrows "⟦ x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧"
   univ <- parseExpressionThrows "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
-  fireAtom "L_answer" (Atom RtNode script) form univ
+  fireAtom "L_answer" atom form univ
 
 -- What the script wrote under 'n' has to come back parsed, so a case asserting
 -- on it says which expression it expects in 𝜑 rather than in constructors
 answers :: T.Text -> String -> Expectation
 answers script expected = withNode $ do
-  answer <- fired script
+  answer <- fired (Scripted RtNode script)
   wanted <- parseExpressionThrows expected
   answer `shouldBe` wanted
+
+-- The same, for an atom phino runs off its path instead of staging it
+executes :: T.Text -> String -> Expectation
+executes script expected = withShell $
+  withExecutable script $ \file -> do
+    answer <- fired (Executable file)
+    wanted <- parseExpressionThrows expected
+    answer `shouldBe` wanted
 
 -- A firing that has to fail, with the reason naming the given fragments
 fails :: T.Text -> [String] -> Expectation
 fails script fragments =
   withNode $
-    fired script
+    fired (Scripted RtNode script)
       `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
 
 spec :: Spec
@@ -67,7 +109,16 @@ spec = do
     it "reads a λ function together with its runtime and script" $
       withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
         registry <- readRegistry path
-        registeredAtom registry "L_answer" `shouldBe` Just (Atom RtNode "say(1)")
+        registeredAtom registry "L_answer" `shouldBe` Just (Scripted RtNode "say(1)")
+
+    -- An atom the object model brought as a binary of its own names no
+    -- interpreter at all, only the file phino is to run
+    it "reads an executable λ function as the file it runs" $
+      withShell $
+        withExecutable "" $ \file ->
+          withRegistry (executing file) $ \path -> do
+            registry <- readRegistry path
+            registeredAtom registry "L_answer" `shouldBe` Just (Executable file)
 
     it "leaves a name the file does not carry unregistered" $
       withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
@@ -93,6 +144,16 @@ spec = do
         , ["rt"]
         )
       ,
+        ( "an executable entry carries no path"
+        , "{\"L_answer\": {\"rt\": \"exec\"}}"
+        , ["path"]
+        )
+      ,
+        ( "the executable file is not there"
+        , "{\"L_answer\": {\"rt\": \"exec\", \"path\": \"no-such-atom\"}}"
+        , ["L_answer", "no-such-atom", "there is no such file"]
+        )
+      ,
         ( "the file is not JSON at all"
         , "L_answer: js"
         , ["cannot be read"]
@@ -108,6 +169,14 @@ spec = do
     it "fails when the file is not there" $
       readRegistry "no-such-registry.json"
         `shouldThrow` (\failure -> "cannot be read" `isInfixOf` show (failure :: SomeException))
+
+    -- A file nobody may run is refused where the registry is read, not where
+    -- the atom would fire
+    it "fails when the file of an executable λ function cannot be run" $
+      withScript "" $ \file ->
+        withRegistry (executing file) $ \path ->
+          readRegistry path
+            `shouldThrow` (\failure -> "not executable" `isInfixOf` show (failure :: SomeException))
 
   describe "fireAtom" $ do
     it "hands back the 𝜑-expression the script wrote under 'n'" $
@@ -152,3 +221,18 @@ spec = do
 
     it "fails when what the script put under 'n' is not a 𝜑-expression" $
       fails "process.stdout.write(JSON.stringify({n: '⟦ ⟧⟧'}))" ["L_answer"]
+
+    -- An executable atom is spawned as it is, under no interpreter, so phino
+    -- stages nothing of it and the file speaks the same protocol a script does
+    it "runs an executable λ function straight off its path" $
+      executes "echo '{\"n\": \"⟦ Δ ⤍ 2A- ⟧\"}'" "⟦ Δ ⤍ 2A- ⟧"
+
+    it "names the λ function being fired as the first argument of an executable" $
+      executes
+        "if [ \"$1\" = L_answer ]; then echo '{\"n\": \"⟦ Δ ⤍ FF- ⟧\"}'; else echo '{\"n\": \"⟦ Δ ⤍ 00- ⟧\"}'; fi"
+        "⟦ Δ ⤍ FF- ⟧"
+
+    it "feeds the formation and the universe to an executable on stdin" $
+      executes
+        "case \"$(cat)\" in *'x ↦'*) echo '{\"n\": \"⟦ Δ ⤍ FF- ⟧\"}';; *) echo '{\"n\": \"⟦ Δ ⤍ 00- ⟧\"}';; esac"
+        "⟦ Δ ⤍ FF- ⟧"

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -45,7 +45,7 @@ fixtureScript = decodeUtf8 <$> BS.readFile "test-resources/atoms/primitives.js"
 fixtureRegistry :: IO Registry
 fixtureRegistry = do
   script <- fixtureScript
-  pure (Map.fromList [(name, Atom RtNode script) | name <- fixtureAtoms])
+  pure (Map.fromList [(name, Scripted RtNode script) | name <- fixtureAtoms])
 
 -- The same registry as the JSON file '--atoms' reads, in a temporary file
 -- removed afterwards, for the specs that go through the command line.


### PR DESCRIPTION
The `--atoms` registry now takes a second kind of entry. Next to
`{"rt": "node", "script": "..."}` an entry may say
`{"rt": "exec", "path": "/opt/eo/atoms/number-plus"}`, and phino spawns
that file directly, as the executable it is: no interpreter, no
temporary file, no staging. Everything else stays the same — the λ name
arrives as the first argument, the formation and the universe arrive as
JSON on stdin, and the answer comes back under `n` on stdout.

The reason is that an atom which is already a program had nowhere to go.
A Go or Rust binary, a `chmod +x` script, a wrapper someone keeps in
their own tree — none of those has an interpreter to name or source to
inline, and pasting a whole program into a JSON string is not a way to
ship one.

`Atom` grew two shapes instead of a record, so `path` and `script` can
no longer both be given or both be missing, and a `path` that names no
file (or a file nobody may run) is refused where the registry is read,
next to the unknown runtimes, rather than half-way through a run. The
new spec cases run a small shell script as the atom, so they are pending
on Windows, where no shebang runs.

Closes #1120
