### PR TITLE
Speak the paper's letters to every atom and make `serve` a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ phino dataize hello.phi
 
 Which λ functions exist is a property of the object model being dataized, not
 of the calculus, so `phino` implements none of them. They come from a JSON
-registry given with `--atoms`, keyed by λ name:
+registry given with `--atoms`, keyed by regular expressions over λ names:
 
 ```json
 {
@@ -177,22 +177,31 @@ the run. So does a reply that is not JSON, carries no `𝑛`, answers another
 `id`, or an `𝑛` that does not parse, or a program that quits without
 answering — always with the program's own `stderr` in the message.
 
-A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck
-on it. Without `--atoms` the registry is empty and every atom gets stuck.
+Each key of the registry is a regular expression, and it must match the whole
+λ name, so a plain name such as `L_number_plus` means that one atom and nothing
+else, while `L_number_.*` stands for every atom of `number`. When 𝔼 reaches a
+λ function, the keys are tried top to bottom, in the order the file lists them,
+and the first one that matches is the entry fired, so a key placed above
+another hides whatever the two have in common. A key that is not a regular
+expression is refused where the registry is read.
+
+A λ name no key matches has no λ function at all, so 𝔼 gets stuck on it.
+Without `--atoms` the registry is empty and every atom gets stuck.
 
 One process per fire is where a program that is slow to start — a JVM, say —
 spends most of the run. An entry saying `serve` has `phino` start its program
 once, on the first fire, and keep it for the rest of the run, whether it is a
-`script` or a `path`:
+`script` or a `path`. Together with a key that matches many names, this is how
+one program stands for a whole object model without being spelled once per
+atom:
 
 ```json
 {
-  "L_number_plus": {
-    "rt": "exec",
-    "path": "/opt/eo/atoms/resident",
-    "serve": true
+  "L_bytes_eq": {
+    "rt": "node",
+    "script": "const readline = require('readline'); ..."
   },
-  "L_number_times": {
+  ".*": {
     "rt": "exec",
     "path": "/opt/eo/atoms/resident",
     "serve": true
@@ -200,8 +209,9 @@ once, on the first fire, and keep it for the rest of the run, whether it is a
 }
 ```
 
-Every λ name registered on the same program is served by the same process, so
-there is one of it, however many atoms it stands for. The lines are the same:
+Every λ name registered on the same program, under one key or under several,
+is served by the same process, so there is one of it, however many atoms it
+stands for. The lines are the same:
 the program reads request after request off its `stdin`, each with the next
 `id`, and answers each in turn. The universe is told again only when a fire
 comes with a different one; the program keeps the last one it was told. When

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ registry given with `--atoms`, keyed by λ name:
 {
   "L_number_plus": {
     "rt": "node",
-    "script": "const fs = require('fs'); ..."
+    "script": "const readline = require('readline'); ..."
   }
 }
 ```
@@ -120,11 +120,10 @@ supported for now; a registry naming any other interpreter is refused when the
 file is read, before dataization starts.
 
 When 𝔼 reaches a λ function the registry carries, `phino` writes its `script`
-to a temporary file and runs it as a POSIX process under that interpreter, with
-the λ name as the first command-line argument:
+to a temporary file and runs it as a POSIX process under that interpreter:
 
 ```text
-node /tmp/phino-atom-4f2a.js L_number_plus
+node /tmp/phino-atom-4f2a.js
 ```
 
 An atom that is already a program needs no interpreter and no staging. Such an
@@ -139,105 +138,84 @@ entry says `exec` and gives a `path` instead of a `script`:
 }
 ```
 
-`phino` spawns that file directly, as the executable binary it is, with the λ
-name as its first command-line argument:
+`phino` spawns that file directly, as the executable binary it is, with no
+arguments. A `path` that names no file, or a file nobody may run, is refused
+where the registry is read, together with the unknown runtimes.
 
-```text
-/opt/eo/atoms/number-plus L_number_plus
-```
-
-A `path` that names no file, or a file nobody may run, is refused where the
-registry is read, together with the unknown runtimes.
-
-The name matters: one program may be registered under several λ names and
-branch on it, which is where `node` puts it — `process.argv[2]`. The program is
-then fed one JSON object on `stdin`:
-
-```json
-{
-  "b": "⟦ x ↦ Φ.number( as-bytes ↦ … ), ρ ↦ ⟦ … ⟧ ⟧",
-  "s": "⟦ bytes ↦ ⟦ … ⟧, number ↦ ⟦ … ⟧, φ ↦ … ⟧"
-}
-```
-
-Here `b` is the formation being evaluated, with its λ binding removed so that
-the script may dispatch on it, and `s` is the universe Φ. Both are canonical
-𝜑-calculus on a single line — no syntax sugar, whatever `--sweet` says about
-the output of the run — so a script never has to know about `phino`'s sugar in
-order to find a datum: every byte array is spelled out as a Δ binding.
-
-The script writes one JSON object to `stdout`:
-
-```json
-{ "n": "11" }
-```
-
-The `n` field is the 𝜑-expression the atom answers with, in any syntax
-`phino`'s parser reads — syntax sugar included, so the `11` above and the
-`Φ.number( … )` it stands for are the same answer. `phino` parses it back
-and hands it to 𝔼 as the atom's raw result, normalizing it exactly as it
-normalizes anything else, so `--evaluations`, `--partial` and `--max-steps`
-keep working unchanged. A non-zero exit, output that is not JSON, a missing
-`n` or an `n` that does not parse fails the run, with the program's own
-`stderr` in the message.
-
-A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck
-on it. Without `--atoms` the registry is empty and every atom gets stuck.
-
-Both `node` and `exec` spawn one process per fire, which is where a program
-that is slow to start — a JVM, say — spends most of the run. Such a program
-is registered with `serve` instead, and `phino` starts it once, on the first
-fire, and keeps it for the rest of the run:
-
-```json
-{
-  "L_number_plus": {
-    "rt": "serve",
-    "path": "/opt/eo/atoms/resident"
-  },
-  "L_number_times": {
-    "rt": "serve",
-    "path": "/opt/eo/atoms/resident"
-  }
-}
-```
-
-Every λ name registered on the same `path` is served by the same process, so
-there is one of it, however many atoms it stands for. Its `path` is checked
-where the registry is read, like the one of an `exec` entry. The program is
-started with no arguments and talked to over `stdin` and `stdout`, one JSON
-object per line, in the letters of the evaluation rule of the
+Whichever way it is run, the program is talked to over `stdin` and `stdout`,
+one JSON object per line, in the letters of the evaluation rule of the
 [𝜑-calculus paper](https://github.com/objectionary/calculus-paper),
 𝔼(𝑏, 𝑒, 𝑠) = 𝑛, where 𝑏 is the formation, 𝑒 the universe and 𝑛 the normal
 form the atom answers with:
 
 ```text
-{"𝑒": "⟦ bytes ↦ … ⟧"}
-{"id": 1, "λ": "L_number_plus", "𝑏": "⟦ x ↦ …, ρ ↦ … ⟧"}
-{"id": 1, "𝑛": "Φ.number( … )"}
+{"𝑒": "⟦ bytes ↦ ⟦ … ⟧, number ↦ ⟦ … ⟧, φ ↦ … ⟧"}
+{"id": 1, "λ": "L_number_plus", "𝑏": "⟦ x ↦ Φ.number( … ), ρ ↦ ⟦ … ⟧ ⟧"}
+{"id": 1, "𝑛": "11"}
 ```
 
 The first two lines are `phino`'s, the third is the program's. The universe Φ
-goes under `𝑒`, in a line of its own, before the first request and again only
-when a fire comes with a different universe; the program keeps the last one it
-was told. Every fire is then one request with an `id`, the λ name under `λ` —
-one program serves several names, so it is told which one fires — and the
-formation under `𝑏`, and one reply carrying the same `id` and the
-𝜑-expression under `𝑛`. Both payloads are the same canonical 𝜑-calculus a
-one-shot program gets, and the answer is parsed the same way. A reply that is
-not JSON, carries no `𝑛`, answers another `id`, or a program that closes its
-`stdout` fails the run, with the program's `stderr` in the message. When the
-run is over, whatever it ended with, `phino` closes the program's `stdin`,
+goes under `𝑒`, in a line of its own, before the first request. Then comes the
+request: an `id`, the λ name under `λ` — one program may be registered under
+several names and branch on it — and, under `𝑏`, the formation being
+evaluated, with its λ binding removed. Both payloads are canonical 𝜑-calculus
+on a single line — no syntax sugar, whatever `--sweet` says about the output of
+the run — so a program never has to know about `phino`'s sugar in order to find
+a datum: every byte array is spelled out as a Δ binding.
+
+The program answers with one line carrying the same `id` and, under `𝑛`, the
+𝜑-expression the atom answers with, in any syntax `phino`'s parser reads —
+syntax sugar included, so the `11` above and the `Φ.number( … )` it stands for
+are the same answer. `phino` parses it back and hands it to 𝔼 as the atom's
+raw result, normalizing it exactly as it normalizes anything else, so
+`--evaluations`, `--partial` and `--max-steps` keep working unchanged.
+
+A program started for the fire is asked one request, always `id` 1, and its
+`stdin` is closed behind it, so it may read its input whole or line by line, as
+it pleases. It is waited for once it has answered, and a non-zero exit fails
+the run. So does a reply that is not JSON, carries no `𝑛`, answers another
+`id`, or an `𝑛` that does not parse, or a program that quits without
+answering — always with the program's own `stderr` in the message.
+
+A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck
+on it. Without `--atoms` the registry is empty and every atom gets stuck.
+
+One process per fire is where a program that is slow to start — a JVM, say —
+spends most of the run. An entry saying `serve` has `phino` start its program
+once, on the first fire, and keep it for the rest of the run, whether it is a
+`script` or a `path`:
+
+```json
+{
+  "L_number_plus": {
+    "rt": "exec",
+    "path": "/opt/eo/atoms/resident",
+    "serve": true
+  },
+  "L_number_times": {
+    "rt": "exec",
+    "path": "/opt/eo/atoms/resident",
+    "serve": true
+  }
+}
+```
+
+Every λ name registered on the same program is served by the same process, so
+there is one of it, however many atoms it stands for. The lines are the same:
+the program reads request after request off its `stdin`, each with the next
+`id`, and answers each in turn. The universe is told again only when a fire
+comes with a different one; the program keeps the last one it was told. When
+the run is over, whatever it ended with, `phino` closes the program's `stdin`,
 which is its cue to quit, and terminates it if it has not quit within a second.
 
 ### Reducing the operands of an atom
 
-A script gets at the parts of `b` by calling `phino` again, so no API has to be
-exposed for it. The `--inside` option is how it asks: the expression it names
-is bound to a fresh synthetic attribute of the input expression, which the run
-takes as the universe, normalized there, and then dataized. This is the same
-trick `phino` plays internally whenever it has to reduce a sub-expression the
-program does not contain:
+A program gets at the parts of `𝑏` by calling `phino` again, so no API has to
+be exposed for it. The `--inside` option is how it asks: the expression it
+names is bound to a fresh synthetic attribute of the input expression, which
+the run takes as the universe, normalized there, and then dataized. This is the
+same trick `phino` plays internally whenever it has to reduce a sub-expression
+the program does not contain:
 
 ```bash
 $ phino dataize --atoms=atoms.json --inside='5.plus( 6 )' universe.phi
@@ -245,33 +223,49 @@ $ phino dataize --atoms=atoms.json --inside='5.plus( 6 )' universe.phi
 ```
 
 Here `universe.phi` is the 𝜑-program the atom is being fired inside — the very
-text the script was handed as `s`, which it feeds back on `stdin`.
+text the program was told under `𝑒`, which it feeds back on `stdin`.
 
 So a `L_number_plus` that reduces its own operands reads like this:
 
 ```js
-const fs = require('fs');
+const readline = require('readline');
 const { execFileSync } = require('child_process');
-const atom = process.argv[2];
-if (atom !== 'L_number_plus') {
-  throw new Error(`unsupported atom ${atom}`);
-}
-const { b, s } = JSON.parse(fs.readFileSync(0, 'utf8'));
+let universe;
 const dataized = (expr) => execFileSync(
   'phino',
   ['dataize', '--atoms=atoms.json', `--inside=${expr}`],
-  { input: s, encoding: 'utf8' }
+  { input: universe, encoding: 'utf8' }
 ).trim();
-const number = (expr) => Buffer.from(dataized(expr).replace(/-/g, ''), 'hex').readDoubleBE(0);
-const sum = Buffer.alloc(8);
-sum.writeDoubleBE(number(`${b}.ρ`) + number(`${b}.x`));
-const hex = [...sum]
-  .map((octet) => octet.toString(16).toUpperCase().padStart(2, '0'))
-  .join('-');
-process.stdout.write(JSON.stringify({
-  n: `Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ${hex} ⟧ ) )`
-}));
+const number = (expr) => Buffer
+  .from(dataized(expr).replace(/-/g, ''), 'hex')
+  .readDoubleBE(0);
+const hex = (value) => {
+  const bytes = Buffer.alloc(8);
+  bytes.writeDoubleBE(value);
+  return [...bytes]
+    .map((octet) => octet.toString(16).toUpperCase().padStart(2, '0'))
+    .join('-');
+};
+readline.createInterface({ input: process.stdin }).on('line', (line) => {
+  const message = JSON.parse(line);
+  if ('𝑒' in message) {
+    universe = message['𝑒'];
+    return;
+  }
+  if (message['λ'] !== 'L_number_plus') {
+    throw new Error(`unsupported atom ${message['λ']}`);
+  }
+  const b = message['𝑏'];
+  const sum = hex(number(`${b}.ρ`) + number(`${b}.x`));
+  process.stdout.write(`${JSON.stringify({
+    id: message.id,
+    '𝑛': `Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ ${sum} ⟧ ) )`,
+  })}\n`);
+});
 ```
+
+Written this way, reading until its `stdin` closes, the same program runs once
+per fire and serves the whole run alike; only the registry entry decides.
 
 The `--inside` option cannot be combined with `--locator`, since it aims the
 run at the binding it mints itself. Both `dataize` and `morph` take `--atoms`

--- a/README.md
+++ b/README.md
@@ -184,6 +184,52 @@ keep working unchanged. A non-zero exit, output that is not JSON, a missing
 A λ name the registry does not carry has no λ function at all, so 𝔼 gets stuck
 on it. Without `--atoms` the registry is empty and every atom gets stuck.
 
+Both `node` and `exec` spawn one process per fire, which is where a program
+that is slow to start — a JVM, say — spends most of the run. Such a program
+is registered with `serve` instead, and `phino` starts it once, on the first
+fire, and keeps it for the rest of the run:
+
+```json
+{
+  "L_number_plus": {
+    "rt": "serve",
+    "path": "/opt/eo/atoms/resident"
+  },
+  "L_number_times": {
+    "rt": "serve",
+    "path": "/opt/eo/atoms/resident"
+  }
+}
+```
+
+Every λ name registered on the same `path` is served by the same process, so
+there is one of it, however many atoms it stands for. Its `path` is checked
+where the registry is read, like the one of an `exec` entry. The program is
+started with no arguments and talked to over `stdin` and `stdout`, one JSON
+object per line, in the letters of the evaluation rule of the
+[𝜑-calculus paper](https://github.com/objectionary/calculus-paper),
+𝔼(𝑏, 𝑒, 𝑠) = 𝑛, where 𝑏 is the formation, 𝑒 the universe and 𝑛 the normal
+form the atom answers with:
+
+```text
+{"𝑒": "⟦ bytes ↦ … ⟧"}
+{"id": 1, "λ": "L_number_plus", "𝑏": "⟦ x ↦ …, ρ ↦ … ⟧"}
+{"id": 1, "𝑛": "Φ.number( … )"}
+```
+
+The first two lines are `phino`'s, the third is the program's. The universe Φ
+goes under `𝑒`, in a line of its own, before the first request and again only
+when a fire comes with a different universe; the program keeps the last one it
+was told. Every fire is then one request with an `id`, the λ name under `λ` —
+one program serves several names, so it is told which one fires — and the
+formation under `𝑏`, and one reply carrying the same `id` and the
+𝜑-expression under `𝑛`. Both payloads are the same canonical 𝜑-calculus a
+one-shot program gets, and the answer is parsed the same way. A reply that is
+not JSON, carries no `𝑛`, answers another `id`, or a program that closes its
+`stdout` fails the run, with the program's `stderr` in the message. When the
+run is over, whatever it ended with, `phino` closes the program's `stdin`,
+which is its cue to quit, and terminates it if it has not quit within a second.
+
 ### Reducing the operands of an atom
 
 A script gets at the parts of `b` by calling `phino` again, so no API has to be

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -67,6 +67,7 @@ import Data.Aeson.Decoding.Tokens (TkRecord (TkPair, TkRecordEnd, TkRecordErr), 
 import qualified Data.Aeson.Key as Key
 import Data.Aeson.Types (JSONPathElement (Key), parseEither, (<?>))
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate)
 import Data.Map.Strict (Map)
@@ -395,7 +396,7 @@ asked func running@Running{..} form univ pushed = do
       request = lined (object ["id" .= number, "λ" .= func, "𝑏" .= rendered form])
   logDebug (printf "Asking atom '%s' as request %d" (T.unpack func) number)
   said (if _told == Just univ then request else universe <> request)
-  reply <- BS.hGetLine _output `catch` hungUp
+  reply <- BC.hGetLine _output `catch` hungUp
   answer <- replied number reply
   pure (running{_told = Just univ, _requests = number}, answer)
   where

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -9,20 +9,22 @@
 -- Which λ functions exist is a property of the object model being dataized,
 -- not of the calculus. phino therefore implements none of them: it reads a
 -- registry of them from a JSON file given with '--atoms' and fires each one as
--- a POSIX process. The registry maps a λ name to the runtime that runs its
--- script, or to 'exec' and the path of a file that runs on its own, and says
--- with 'serve' whether the program is to be started once and kept for the run:
+-- a POSIX process. Each key of the registry is a regular expression over λ
+-- names, tried top to bottom, and the first one matching the whole name of the
+-- atom being fired wins; its entry names the runtime that runs a script, or
+-- 'exec' and the path of a file that runs on its own, and says with 'serve'
+-- whether the program is to be started once and kept for the run:
 --
 -- > {
 -- >   "L_bytes_eq": {
 -- >     "rt": "node",
--- >     "script": "const fs = require('fs'); ..."
+-- >     "script": "const readline = require('readline'); ..."
 -- >   },
 -- >   "L_number_plus": {
 -- >     "rt": "exec",
 -- >     "path": "/opt/eo/atoms/number-plus"
 -- >   },
--- >   "L_number_times": {
+-- >   ".*": {
 -- >     "rt": "exec",
 -- >     "path": "/opt/eo/atoms/resident",
 -- >     "serve": true
@@ -35,9 +37,8 @@
 -- 'λ' and the formation under '𝑏', answered by a line with the same 'id' and
 -- the 𝜑-expression under '𝑛'.
 --
--- A name absent from the registry has no λ function at all: 𝔼 gets stuck on
--- it, exactly as it does for a name no one ever declared (see 'Stuck' in
--- 'Dataize').
+-- A name no key matches has no λ function at all: 𝔼 gets stuck on it, exactly
+-- as it does for a name no one ever declared (see 'Stuck' in 'Dataize').
 module Atoms
   ( Atom (..)
   , AtomException (..)
@@ -60,6 +61,11 @@ import Control.Exception (Exception, SomeException, catch, onException, throwIO,
 import Control.Monad (foldM, unless)
 import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
+import Data.Aeson.Decoding (toEitherValue)
+import Data.Aeson.Decoding.ByteString (bsToTokens)
+import Data.Aeson.Decoding.Tokens (TkRecord (TkPair, TkRecordEnd, TkRecordErr), Tokens (TkErr, TkRecordOpen))
+import qualified Data.Aeson.Key as Key
+import Data.Aeson.Types (JSONPathElement (Key), parseEither, (<?>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate)
@@ -80,6 +86,8 @@ import System.IO (Handle, hClose, hFlush, hSetBinaryMode, openBinaryTempFile)
 import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, terminateProcess, waitForProcess)
 import System.Timeout (timeout)
 import Text.Printf (printf)
+import Text.Regex.PCRE (matchTest)
+import Text.Regex.PCRE.ByteString (Regex, compUTF8, compile, execBlank)
 
 -- The interpreter a script is run under, named after the executable itself:
 -- only 'node' for now. A registry naming any other runtime is rejected when it
@@ -142,8 +150,13 @@ data Running = Running
 -- it is to be kept for the run.
 data Entry = Entry Program Bool
 
--- Every λ function phino may fire, keyed by name.
-type Registry = Map T.Text Atom
+-- Every λ function phino may fire, in the order the registry file lists them:
+-- each key of the file, a regular expression over λ names, paired with the
+-- atom its entry describes. A lookup tries them top to bottom and the first
+-- key matching the whole name wins, so one entry may stand for many atoms,
+-- while a plain name, being a regular expression matching itself, keeps
+-- meaning that one atom.
+newtype Registry = Registry [(Regex, Atom)]
 
 data AtomException
   = -- The '--atoms' file is not a JSON registry of λ functions.
@@ -225,30 +238,54 @@ instance FromJSON Reply where
 -- No λ function at all: every atom gets stuck. This is what a run without
 -- '--atoms' fires against.
 emptyRegistry :: Registry
-emptyRegistry = Map.empty
+emptyRegistry = Registry []
 
--- The λ function registered under this name, if any.
+-- The λ function of the first key that matches the whole name, if any.
 registeredAtom :: Registry -> T.Text -> Maybe Atom
-registeredAtom registry func = Map.lookup func registry
+registeredAtom (Registry rules) func = snd <$> find (\(pattern, _) -> matchTest pattern (encodeUtf8 func)) rules
 
--- Read the registry of λ functions from a JSON file. An unknown runtime, a
--- missing 'script', a 'path' that names no executable file or malformed JSON
--- fails here, before any dataization starts. The entries that are to keep the
--- same program are given one session between them, so that one resident
--- process answers for every λ name it is registered under.
+-- Read the registry of λ functions from a JSON file. A key that is no regular
+-- expression, an unknown runtime, a missing 'script', a 'path' that names no
+-- executable file or malformed JSON fails here, before any dataization starts.
+-- The entries that are to keep the same program are given one session between
+-- them, so that one resident process answers for every key it is registered
+-- under.
 readRegistry :: FilePath -> IO Registry
 readRegistry path = do
   content <- BS.readFile path `catch` unreadable
-  case eitherDecodeStrict' content of
-    Left failure -> throwIO (BrokenRegistry path failure)
-    Right entries -> do
-      mapM_ (uncurry runnable) (Map.toList entries)
-      (registry, _) <- foldM admitted (Map.empty, Map.empty) (Map.toList entries)
-      logDebug (printf "Loaded %d atom(s) from '%s'" (Map.size registry) path)
-      pure registry
+  entries <- either (throwIO . BrokenRegistry path) pure (listed content)
+  mapM_ (uncurry runnable) entries
+  (rules, _) <- foldM admitted ([], Map.empty) entries
+  logDebug (printf "Loaded %d atom(s) from '%s'" (length rules) path)
+  pure (Registry (reverse rules))
   where
     unreadable :: IOError -> IO BS.ByteString
     unreadable failure = throwIO (BrokenRegistry path (show failure))
+    -- The entries of the file in the order it lists them, which is the order
+    -- the keys are tried in and which the object aeson would decode the file
+    -- to forgets, so the file is walked token by token instead.
+    listed :: BS.ByteString -> Either String [(T.Text, Entry)]
+    listed content = case bsToTokens content of
+      TkRecordOpen record -> paired record
+      TkErr failure -> Left failure
+      _ -> Left "the file is not a JSON object"
+    paired :: TkRecord BS.ByteString String -> Either String [(T.Text, Entry)]
+    paired (TkPair key tokens) = do
+      (value, rest) <- toEitherValue tokens
+      entry <- parseEither (\raw -> parseJSON raw <?> Key key) value
+      ((Key.toText key, entry) :) <$> paired rest
+    paired (TkRecordEnd rest)
+      | BS.all (`BS.elem` " \t\r\n") rest = Right []
+      | otherwise = Left "there is more in the file than the JSON object"
+    paired (TkRecordErr failure) = Left failure
+    -- The key as the regular expression it is, made to match the whole name,
+    -- so that a plain name means that one atom and not every name it is a
+    -- part of.
+    compiled :: T.Text -> IO Regex
+    compiled key = compile compUTF8 execBlank (encodeUtf8 ("^(?:" <> key <> ")$")) >>= either broken pure
+      where
+        broken :: (a, String) -> IO Regex
+        broken (_, failure) = throwIO (BrokenRegistry path (printf "the key '%s' is not a regular expression: %s" (T.unpack key) failure))
     -- The file of an executable atom is the only thing phino knows about it,
     -- and it staged none of it, so the file is looked at here, while the
     -- registry is being read, rather than half-way through a program that
@@ -260,20 +297,25 @@ readRegistry path = do
       allowed <- executable <$> getPermissions file
       unless allowed (throwIO (NoRuntime func file "the file is not executable"))
     runnable _ _ = pure ()
-    -- Turn an entry into the atom phino fires, sharing a session between the
-    -- entries that are to keep the same program.
-    admitted :: (Registry, Map Program Session) -> (T.Text, Entry) -> IO (Registry, Map Program Session)
-    admitted (registry, sessions) (func, Entry program False) = pure (Map.insert func (Transient program) registry, sessions)
-    admitted (registry, sessions) (func, Entry program True) = do
+    -- Turn an entry into the atom phino fires, keyed by its pattern and, when
+    -- it is to keep its program, sharing a session with the entries keeping
+    -- the same one; the rules come out newest first.
+    admitted :: ([(Regex, Atom)], Map Program Session) -> (T.Text, Entry) -> IO ([(Regex, Atom)], Map Program Session)
+    admitted (rules, sessions) (key, Entry program serve) = do
+      pattern <- compiled key
+      (atom, kept) <- if serve then resident program sessions else pure (Transient program, sessions)
+      pure ((pattern, atom) : rules, kept)
+    resident :: Program -> Map Program Session -> IO (Atom, Map Program Session)
+    resident program sessions = do
       session <- maybe (Session program <$> newMVar Nothing) pure (Map.lookup program sessions)
-      pure (Map.insert func (Resident session) registry, Map.insert program session sessions)
+      pure (Resident session, Map.insert program session sessions)
 
 -- Stop every resident program the registry has started: its stdin is closed,
 -- which is its cue to quit, and a program that has not quit within a second is
 -- terminated. The runners call this when the run is over, whatever it ended
 -- with, so that no process outlives the phino that started it.
 closeRegistry :: Registry -> IO ()
-closeRegistry registry = mapM_ dismissed (Map.elems registry)
+closeRegistry (Registry rules) = mapM_ (dismissed . snd) rules
   where
     dismissed :: Atom -> IO ()
     dismissed (Resident Session{..}) = modifyMVar_ _running (maybe (pure Nothing) (\running -> Nothing <$ stopped briefly running))

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 -- SPDX-License-Identifier: MIT
@@ -8,8 +9,10 @@
 -- Which λ functions exist is a property of the object model being dataized,
 -- not of the calculus. phino therefore implements none of them: it reads a
 -- registry of them from a JSON file given with '--atoms' and fires each one as
--- a POSIX process. The registry maps a λ name either to the runtime that runs
--- its script or to 'exec' and the path of a file that runs on its own:
+-- a POSIX process. The registry maps a λ name to the runtime that runs its
+-- script, to 'exec' and the path of a file that runs on its own once per fire,
+-- or to 'serve' and the path of a file that stays for the whole run and is
+-- asked over its streams, one line per fire:
 --
 -- > {
 -- >   "L_bytes_eq": {
@@ -19,6 +22,10 @@
 -- >   "L_number_plus": {
 -- >     "rt": "exec",
 -- >     "path": "/opt/eo/atoms/number-plus"
+-- >   },
+-- >   "L_number_times": {
+-- >     "rt": "serve",
+-- >     "path": "/opt/eo/atoms/resident"
 -- >   }
 -- > }
 --
@@ -30,6 +37,8 @@ module Atoms
   , AtomException (..)
   , Registry
   , Runtime (..)
+  , Session (_program)
+  , closeRegistry
   , emptyRegistry
   , fireAtom
   , readRegistry
@@ -39,15 +48,18 @@ module Atoms
 where
 
 import AST
-import Control.Exception (Exception, bracket, catch, throwIO)
-import Control.Monad (unless)
-import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.:), (.=))
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar)
+import Control.Exception (Exception, SomeException, bracket, catch, throwIO, try)
+import Control.Monad (foldM, unless, void)
+import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.:), (.:?), (.=))
 import qualified Data.Aeson as A
+import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isJust)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8Lenient, encodeUtf8)
 import Encoding (Encoding (UNICODE))
@@ -59,8 +71,9 @@ import Printer (printExpression')
 import Sugar (SugarType (SALTY))
 import System.Directory (doesFileExist, executable, getPermissions, getTemporaryDirectory, removePathForcibly)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
-import System.IO (Handle, IOMode (WriteMode), hClose, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
-import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, waitForProcess)
+import System.IO (Handle, IOMode (WriteMode), hClose, hFlush, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
+import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, terminateProcess, waitForProcess)
+import System.Timeout (timeout)
 import Text.Printf (printf)
 
 -- The interpreter a script is run under, named after the executable itself:
@@ -70,15 +83,56 @@ import Text.Printf (printf)
 data Runtime = RtNode
   deriving stock (Eq, Show)
 
--- One entry of the registry: the λ function phino runs as a POSIX process.
--- Either a script, which phino stages in a temporary file and hands to the
--- interpreter of its runtime, or an executable file, which phino runs as it
--- is, since the object model brought its own binary and there is nothing to
--- stage.
+-- One entry of the registry, as the file spells it: a script under the runtime
+-- that interprets it, a file that runs on its own once per fire, or a file
+-- that is started once and serves every fire of the run. This is what the JSON
+-- says; what phino fires is an 'Atom', which 'readRegistry' makes of it.
+data Entry
+  = EnScripted Runtime T.Text
+  | EnExecutable FilePath
+  | EnServed FilePath
+
+-- One λ function phino may fire. Either a script, which phino stages in a
+-- temporary file and hands to the interpreter of its runtime, or an executable
+-- file, which phino runs as it is, since the object model brought its own
+-- binary and there is nothing to stage, or a session with a program that stays
+-- resident for the run and is asked over its streams, so that a run of many
+-- fires spawns it once instead of once per fire.
 data Atom
   = Scripted Runtime T.Text
   | Executable FilePath
+  | Served Session
   deriving stock (Eq, Show)
+
+-- The program a 'serve' entry names, together with the process phino has
+-- started of it, if it has: none until the first fire, since a run that never
+-- reaches the atom should not pay for it. Every entry naming the same file
+-- shares one session, so one process serves all the λ names it is registered
+-- under.
+data Session = Session
+  { _program :: FilePath
+  , _resident :: MVar (Maybe Resident)
+  }
+
+-- Two sessions are the same when they serve from the same file, whatever
+-- their processes are up to.
+instance Eq Session where
+  Session left _ == Session right _ = left == right
+
+instance Show Session where
+  show (Session program _) = show program
+
+-- A resident program while it runs: its streams, the file its complaints go to,
+-- the universe it was told last, so it is told again only when the universe
+-- changes, and how many requests it has been asked, which numbers the next one.
+data Resident = Resident
+  { _input :: Handle
+  , _output :: Handle
+  , _process :: ProcessHandle
+  , _complaints :: FilePath
+  , _told :: Maybe Expression
+  , _asked :: Int
+  }
 
 -- Every λ function phino may fire, keyed by name.
 type Registry = Map T.Text Atom
@@ -89,10 +143,10 @@ data AtomException
   | -- The program of an atom cannot be run: the interpreter of its runtime is
     -- not installed, or its executable file is missing or not executable.
     NoRuntime T.Text String String
-  | -- The script exited with a non-zero status; the message carries its stderr.
+  | -- The program exited with a non-zero status; the message carries its stderr.
     AtomBroke T.Text Int String
-  | -- The script exited successfully but said nothing phino can use: its stdout
-    -- is not a JSON object, carries no 'n' field, or the 𝜑-expression under it
+  | -- The program said nothing phino can use: its answer is not a JSON object,
+    -- carries no 𝜑-expression, answers another request, or the 𝜑-expression
     -- does not parse.
     AtomMute T.Text String String
   deriving anyclass (Exception)
@@ -129,28 +183,44 @@ runtimes = [RtNode]
 execName :: String
 execName = "exec"
 
+-- The 'rt' of an atom that is a file started once and kept for the run.
+serveName :: String
+serveName = "serve"
+
 -- Every name the 'rt' field of a registry entry may take.
 runtimeNames :: [String]
-runtimeNames = map runtimeName runtimes ++ [execName]
+runtimeNames = map runtimeName runtimes ++ [execName, serveName]
 
 instance FromJSON Runtime where
   parseJSON = withText "runtime" $ \name -> case find ((== T.unpack name) . runtimeName) runtimes of
     Just runtime -> pure runtime
     Nothing -> fail (printf "unknown runtime '%s', expected one of: %s" (T.unpack name) (intercalate ", " runtimeNames))
 
-instance FromJSON Atom where
-  parseJSON = withObject "atom" $ \entry -> do
-    named <- entry .: "rt"
-    if named == T.pack execName
-      then Executable . T.unpack <$> entry .: "path"
-      else Scripted <$> parseJSON (A.String named) <*> entry .: "script"
+instance FromJSON Entry where
+  parseJSON = withObject "atom" $ \entry -> entry .: "rt" >>= shaped entry
+    where
+      shaped :: A.Object -> String -> Parser Entry
+      shaped entry named
+        | named == execName = EnExecutable <$> entry .: "path"
+        | named == serveName = EnServed <$> entry .: "path"
+        | otherwise = EnScripted <$> parseJSON (A.String (T.pack named)) <*> entry .: "script"
 
--- What the script writes to stdout: one JSON object whose 'n' field is the
--- 𝜑-expression the atom answers with.
+-- What a one-shot program writes to stdout: one JSON object whose 'n' field is
+-- the 𝜑-expression the atom answers with.
 newtype Answer = Answer T.Text
 
 instance FromJSON Answer where
   parseJSON = withObject "answer" $ \answer -> Answer <$> answer .: "n"
+
+-- What a resident program writes back for one request: the 'id' of the request
+-- it answers and, under '𝑛', the 𝜑-expression the atom answers with.
+data Reply = Reply Int T.Text
+
+instance FromJSON Reply where
+  parseJSON = withObject "reply" $ \reply -> do
+    number <- reply .: "id"
+    raw <- reply .:? "𝑛"
+    maybe (fail "there is no '𝑛' in it") (pure . Reply number) raw
 
 -- No λ function at all: every atom gets stuck. This is what a run without
 -- '--atoms' fires against.
@@ -163,59 +233,96 @@ registeredAtom registry func = Map.lookup func registry
 
 -- Read the registry of λ functions from a JSON file. An unknown runtime, a
 -- missing 'script', a 'path' that names no executable file or malformed JSON
--- fails here, before any dataization starts.
+-- fails here, before any dataization starts. The entries naming the same file
+-- to serve from are given one session between them, so that one resident
+-- process answers for every λ name it is registered under.
 readRegistry :: FilePath -> IO Registry
 readRegistry path = do
   content <- BS.readFile path `catch` unreadable
   case eitherDecodeStrict' content of
     Left failure -> throwIO (BrokenRegistry path failure)
-    Right registry -> do
-      mapM_ (uncurry runnable) (Map.toList registry)
+    Right entries -> do
+      mapM_ (uncurry runnable) (Map.toList entries)
+      (registry, _) <- foldM admitted (Map.empty, Map.empty) (Map.toList entries)
       logDebug (printf "Loaded %d atom(s) from '%s'" (Map.size registry) path)
       pure registry
   where
     unreadable :: IOError -> IO BS.ByteString
     unreadable failure = throwIO (BrokenRegistry path (show failure))
-    -- The file of an executable atom is the only thing phino knows about it,
-    -- and it staged none of it, so the file is looked at here, while the
-    -- registry is being read, rather than half-way through a program that
-    -- turns out to name that atom.
-    runnable :: T.Text -> Atom -> IO ()
-    runnable _ (Scripted _ _) = pure ()
-    runnable func (Executable file) = do
+    -- The file of an executable or a resident atom is the only thing phino
+    -- knows about it, and it staged none of it, so the file is looked at here,
+    -- while the registry is being read, rather than half-way through a program
+    -- that turns out to name that atom.
+    runnable :: T.Text -> Entry -> IO ()
+    runnable _ (EnScripted _ _) = pure ()
+    runnable func (EnExecutable file) = runs func file
+    runnable func (EnServed file) = runs func file
+    runs :: T.Text -> FilePath -> IO ()
+    runs func file = do
       there <- doesFileExist file
       unless there (throwIO (NoRuntime func file "there is no such file"))
       allowed <- executable <$> getPermissions file
       unless allowed (throwIO (NoRuntime func file "the file is not executable"))
+    -- Turn an entry into the atom phino fires, sharing a session between the
+    -- entries that serve from the same file.
+    admitted :: (Registry, Map FilePath Session) -> (T.Text, Entry) -> IO (Registry, Map FilePath Session)
+    admitted (registry, sessions) (func, EnScripted runtime script) = pure (Map.insert func (Scripted runtime script) registry, sessions)
+    admitted (registry, sessions) (func, EnExecutable file) = pure (Map.insert func (Executable file) registry, sessions)
+    admitted (registry, sessions) (func, EnServed file) = do
+      session <- maybe (Session file <$> newMVar Nothing) pure (Map.lookup file sessions)
+      pure (Map.insert func (Served session) registry, Map.insert file session sessions)
 
--- Fire the λ function 'func' by running its program as a POSIX process, with
--- the λ name as its last command-line argument — one program may be registered
--- under several names and branch on it. A scripted atom is staged in a
--- temporary file and handed to the interpreter of its runtime; an executable
--- one is run straight off its path, under no interpreter at all. The program
--- is fed a JSON object on stdin (see 'payload') and answers with one on
--- stdout; the 𝜑-expression under 'n' becomes the atom's raw result, which 𝔼
--- normalizes exactly as it normalized the answer of a built-in one. A non-zero
--- exit, unparsable output or a missing 'n' fails the run.
+-- Stop every resident program the registry has started: its stdin is closed,
+-- which is its cue to quit, and a program that has not quit within a second is
+-- terminated. The runners call this when the run is over, whatever it ended
+-- with, so that no process outlives the phino that started it.
+closeRegistry :: Registry -> IO ()
+closeRegistry registry = mapM_ dismissed (Map.elems registry)
+  where
+    dismissed :: Atom -> IO ()
+    dismissed (Served Session{..}) = modifyMVar_ _resident (maybe (pure Nothing) stopped)
+    dismissed _ = pure ()
+    stopped :: Resident -> IO (Maybe Resident)
+    stopped Resident{..} = do
+      hClose _input `catch` unheard
+      quit <- timeout 1000000 (waitForProcess _process)
+      unless (isJust quit) (terminateProcess _process >> void (waitForProcess _process))
+      hClose _output `catch` unheard
+      removePathForcibly _complaints
+      pure Nothing
+
+-- Fire the λ function 'func' by running its program. A scripted atom is staged
+-- in a temporary file and handed to the interpreter of its runtime; an
+-- executable one is run straight off its path, under no interpreter at all;
+-- both get the λ name as their last command-line argument — one program may be
+-- registered under several names and branch on it — and answer once, over
+-- stdin and stdout, before they exit. A served atom is asked instead: its
+-- program is started on the first fire and stays for the run, and every fire
+-- is one line to it and one line back. Whichever way, the 𝜑-expression the
+-- program answers with becomes the atom's raw result, which 𝔼 normalizes
+-- exactly as it normalized the answer of a built-in one.
 fireAtom :: T.Text -> Atom -> Expression -> Expression -> IO Expression
-fireAtom func atom form univ = commanded atom $ \program arguments ->
+fireAtom func (Scripted runtime script) form univ =
+  withTemp (printf "phino-atom-.%s" (extension runtime)) (encodeUtf8 script) $ \staged ->
+    fireOnce func (interpreter runtime) [staged, T.unpack func] form univ
+fireAtom func (Executable file) form univ = fireOnce func file [T.unpack func] form univ
+fireAtom func (Served session) form univ = askResident func session form univ
+
+-- Run the program as a POSIX process that answers once: it is fed a JSON
+-- object on stdin (see 'payload') and answers with one on stdout, whose 'n'
+-- field is the 𝜑-expression. A non-zero exit, unparsable output or a missing
+-- 'n' fails the run.
+fireOnce :: T.Text -> String -> [String] -> Expression -> Expression -> IO Expression
+fireOnce func program arguments form univ =
   withTemp "phino-atom-.err" "" $ \errors -> do
     logDebug (printf "Firing atom '%s' as '%s %s'" (T.unpack func) program (unwords arguments))
-    (status, answer) <- executed program arguments errors
+    (status, answer) <- executed errors
     complaint <- readErrors errors
     unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
     case status of
       ExitFailure code -> throwIO (AtomBroke func code complaint)
       ExitSuccess -> answered answer
   where
-    -- What to spawn and what to hand it: the interpreter of the runtime, with
-    -- the script staged in a temporary file that outlives nothing but the
-    -- action, or the executable file itself, which phino only points at.
-    commanded :: Atom -> (String -> [String] -> IO a) -> IO a
-    commanded (Scripted runtime script) action =
-      withTemp (printf "phino-atom-.%s" (extension runtime)) (encodeUtf8 script) $ \staged ->
-        action (interpreter runtime) [staged, T.unpack func]
-    commanded (Executable file) action = action file [T.unpack func]
     -- Run the program with its input and its output on pipes and its
     -- complaints in a file. The input is written and closed before the output is
     -- read, so the parent never has two streams to drain at once — which would
@@ -223,12 +330,10 @@ fireAtom func atom form univ = commanded atom $ \program arguments ->
     -- anything at all, cannot fill a pipe nobody is reading. Every stream is
     -- bytes: a 𝜑 expression carries characters no single-byte locale can spell,
     -- so nothing is left to the locale.
-    executed :: String -> [String] -> FilePath -> IO (ExitCode, BS.ByteString)
-    executed program arguments errors =
+    executed :: FilePath -> IO (ExitCode, BS.ByteString)
+    executed errors =
       withBinaryFile errors WriteMode $ \stderr' -> do
-        (stdin', stdout', process) <- spawned program arguments stderr'
-        hSetBinaryMode stdin' True
-        hSetBinaryMode stdout' True
+        (stdin', stdout', process) <- spawned func program arguments stderr'
         -- A program that dies before reading its input leaves this write with
         -- nobody to drain it. The failure worth reporting is the one the program
         -- made, so a broken pipe is swallowed here and the exit status decides.
@@ -237,53 +342,149 @@ fireAtom func atom form univ = commanded atom $ \program arguments ->
         answer <- BS.hGetContents stdout'
         status <- waitForProcess process
         pure (status, answer)
-    spawned :: String -> [String] -> Handle -> IO (Handle, Handle, ProcessHandle)
-    spawned program arguments stderr' = do
-      spawn <- createProcess started `catch` missing program
-      case spawn of
-        (Just stdin', Just stdout', _, process) -> pure (stdin', stdout', process)
-        _ -> throwIO (AtomMute func "" "the program gave phino no streams to talk over")
-      where
-        started :: CreateProcess
-        started =
-          (proc program arguments)
-            { std_in = CreatePipe
-            , std_out = CreatePipe
-            , std_err = UseHandle stderr'
-            }
-    missing :: String -> IOError -> IO a
-    missing program failure = throwIO (NoRuntime func program (show failure))
-    unheard :: IOError -> IO ()
-    unheard _ = pure ()
-    -- Whatever the program complained about, decoded leniently: the stream is
-    -- the program's, so it may hold anything at all.
-    readErrors :: FilePath -> IO String
-    readErrors errors = T.unpack . T.strip . decodeUtf8Lenient <$> BS.readFile errors
     -- Parse what the program said: a JSON object with the raw 𝜑-expression
     -- under 'n'.
     answered :: BS.ByteString -> IO Expression
     answered answer = case eitherDecodeStrict' answer of
-      Left failure -> throwIO (AtomMute func spoken failure)
-      Right (Answer raw) -> case parseExpression (T.unpack raw) of
-        Left failure -> throwIO (AtomMute func (T.unpack raw) failure)
-        Right expr -> pure expr
-      where
-        spoken :: String
-        spoken = T.unpack (T.strip (decodeUtf8Lenient answer))
+      Left failure -> throwIO (AtomMute func (spoken answer) failure)
+      Right (Answer raw) -> parsedAnswer func raw
 
--- The JSON phino feeds a script on stdin: the formation being evaluated under
--- 'b', with its λ binding removed so the script may dispatch on it, and the
--- universe Φ under 's'. Both are rendered as canonical 𝜑-calculus on a single
--- line — no syntax sugar, whatever '--sweet' says about the output of the run —
--- so a script never has to know phino's sugar to find a datum: every byte array
--- it may need is spelled out as a Δ binding. The text is what phino's own parser
--- reads back, so a script may hand any part of it to another phino run (see the
--- '--inside' option).
+-- Ask the resident program of the session, starting it if this is the first
+-- fire. The program is told the universe Φ first, as one line holding it under
+-- '𝑒', and again only when a fire comes with a different universe; every fire
+-- is then one line holding the λ name under 'λ', the formation under '𝑏' and
+-- an 'id', and one line back holding the 𝜑-expression under '𝑛' and the same
+-- 'id'. The letters are those of the evaluation rule of the calculus, 𝔼(𝑏, 𝑒,
+-- 𝑠) = 𝑛. A reply that is not JSON, carries no '𝑛', answers another request,
+-- or a program that hangs up fails the run, with the program's stderr in the
+-- message. The process is kept whatever the fire ended with, so that
+-- 'closeRegistry' finds it.
+askResident :: T.Text -> Session -> Expression -> Expression -> IO Expression
+askResident func Session{..} form univ = do
+  outcome <- modifyMVar _resident $ \current -> do
+    resident <- maybe started pure current
+    attempt <- try (asked resident) :: IO (Either SomeException (Resident, Expression))
+    pure (Just (either (const resident) fst attempt), snd <$> attempt)
+  either throwIO pure outcome
+  where
+    -- Start the program with its input and its output on pipes and its
+    -- complaints in a file that lives as long as the process does.
+    started :: IO Resident
+    started = do
+      dir <- getTemporaryDirectory
+      (complaints, handle) <- openBinaryTempFile dir "phino-atom-.err"
+      logDebug (printf "Starting the resident program '%s' to serve atom '%s'" _program (T.unpack func))
+      (input, output, process) <- spawned func _program [] handle
+      pure (Resident input output process complaints Nothing 0)
+    asked :: Resident -> IO (Resident, Expression)
+    asked resident = do
+      told <- informed resident
+      let number = _asked told + 1
+      logDebug (printf "Asking the resident program '%s' to fire atom '%s' as request %d" _program (T.unpack func) number)
+      said (_input told) (request number)
+      reply <- BS.hGetLine (_output told) `catch` hungUp told
+      answer <- replied number reply
+      pure (told{_asked = number}, answer)
+    -- Tell the program the universe, unless it is the one it was told last.
+    informed :: Resident -> IO Resident
+    informed resident
+      | _told resident == Just univ = pure resident
+      | otherwise = do
+          said (_input resident) (lined (object ["𝑒" .= rendered univ]))
+          pure resident{_told = Just univ}
+    request :: Int -> BS.ByteString
+    request number = lined (object ["id" .= number, "λ" .= func, "𝑏" .= rendered form])
+    -- One line to the program, pushed through at once, since a pipe is
+    -- buffered and the program answers nothing it has not seen. A program that
+    -- has died leaves the write with nobody to drain it; the failure worth
+    -- reporting is the one the program made, so a broken pipe is swallowed
+    -- here and the read that follows finds out.
+    said :: Handle -> BS.ByteString -> IO ()
+    said handle line = (BS.hPut handle line >> hFlush handle) `catch` unheard
+    -- The program closed its stdout instead of answering: if it has exited
+    -- with a failure, that is the failure; otherwise it went mute.
+    hungUp :: Resident -> IOError -> IO BS.ByteString
+    hungUp Resident{..} _ = do
+      status <- timeout 1000000 (waitForProcess _process)
+      complaint <- readErrors _complaints
+      case status of
+        Just (ExitFailure code) -> throwIO (AtomBroke func code complaint)
+        Just ExitSuccess -> throwIO (AtomMute func "" (unwords ("the program quit without answering" : [complaint | not (null complaint)])))
+        Nothing -> throwIO (AtomMute func "" (unwords ("the program closed its stdout without answering" : [complaint | not (null complaint)])))
+    -- Parse what the program said back: a JSON object answering this very
+    -- request, with the raw 𝜑-expression under '𝑛'.
+    replied :: Int -> BS.ByteString -> IO Expression
+    replied number reply = case eitherDecodeStrict' reply of
+      Left failure -> throwIO (AtomMute func (spoken reply) failure)
+      Right (Reply echoed raw)
+        | echoed /= number -> throwIO (AtomMute func (spoken reply) (printf "it answers request %d, while phino asked request %d" echoed number))
+        | otherwise -> parsedAnswer func raw
+
+-- Spawn the program with its input and its output on pipes and its stderr on
+-- the given handle, as bytes on every stream: a 𝜑 expression carries
+-- characters no single-byte locale can spell, so nothing is left to the locale.
+spawned :: T.Text -> String -> [String] -> Handle -> IO (Handle, Handle, ProcessHandle)
+spawned func program arguments stderr' = do
+  spawn <- createProcess started `catch` missing
+  case spawn of
+    (Just stdin', Just stdout', _, process) -> do
+      hSetBinaryMode stdin' True
+      hSetBinaryMode stdout' True
+      pure (stdin', stdout', process)
+    _ -> throwIO (AtomMute func "" "the program gave phino no streams to talk over")
+  where
+    started :: CreateProcess
+    started =
+      (proc program arguments)
+        { std_in = CreatePipe
+        , std_out = CreatePipe
+        , std_err = UseHandle stderr'
+        }
+    missing :: IOError -> IO a
+    missing failure = throwIO (NoRuntime func program (show failure))
+
+-- The 𝜑-expression a program answered with, parsed, or the failure to.
+parsedAnswer :: T.Text -> T.Text -> IO Expression
+parsedAnswer func raw = case parseExpression (T.unpack raw) of
+  Left failure -> throwIO (AtomMute func (T.unpack raw) failure)
+  Right expr -> pure expr
+
+-- Whatever the program said, decoded leniently and trimmed: the stream is the
+-- program's, so it may hold anything at all.
+spoken :: BS.ByteString -> String
+spoken = T.unpack . T.strip . decodeUtf8Lenient
+
+-- Whatever the program complained about, read from the file its stderr goes to.
+readErrors :: FilePath -> IO String
+readErrors errors = spoken <$> BS.readFile errors
+
+unheard :: IOError -> IO ()
+unheard _ = pure ()
+
+-- The JSON phino feeds a one-shot program on stdin: the formation being
+-- evaluated under 'b', with its λ binding removed so the program may dispatch
+-- on it, and the universe Φ under 's'. The text is what phino's own parser
+-- reads back, so a program may hand any part of it to another phino run (see
+-- the '--inside' option).
+--
+-- @todo #1121:35min Rename the keys of the one-shot payload and its answer to
+--  the letters of the calculus paper, '𝑏', '𝑒' and '𝑛', the way the resident
+--  protocol already spells them: here the universe goes under 's', which in
+--  the paper stands for the state, not for the universe. The fixture script,
+--  the README and every registered script must change together with it.
 payload :: Expression -> Expression -> BS.ByteString
 payload form univ = BSL.toStrict (A.encode (object ["b" .= rendered form, "s" .= rendered univ]))
-  where
-    rendered :: Expression -> T.Text
-    rendered expr = T.pack (printExpression' expr (SALTY, UNICODE, SINGLELINE, defaultMargin))
+
+-- One JSON object as one line, for the programs that read by the line.
+lined :: A.Value -> BS.ByteString
+lined value = BSL.toStrict (A.encode value) <> "\n"
+
+-- An expression as canonical 𝜑-calculus on a single line — no syntax sugar,
+-- whatever '--sweet' says about the output of the run — so a program never has
+-- to know phino's sugar to find a datum: every byte array it may need is
+-- spelled out as a Δ binding.
+rendered :: Expression -> T.Text
+rendered expr = T.pack (printExpression' expr (SALTY, UNICODE, SINGLELINE, defaultMargin))
 
 -- Write the content to a fresh temporary file, hand its path to the action and
 -- delete the file afterwards, whatever the action does.

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -10,9 +10,8 @@
 -- not of the calculus. phino therefore implements none of them: it reads a
 -- registry of them from a JSON file given with '--atoms' and fires each one as
 -- a POSIX process. The registry maps a λ name to the runtime that runs its
--- script, to 'exec' and the path of a file that runs on its own once per fire,
--- or to 'serve' and the path of a file that stays for the whole run and is
--- asked over its streams, one line per fire:
+-- script, or to 'exec' and the path of a file that runs on its own, and says
+-- with 'serve' whether the program is to be started once and kept for the run:
 --
 -- > {
 -- >   "L_bytes_eq": {
@@ -24,10 +23,17 @@
 -- >     "path": "/opt/eo/atoms/number-plus"
 -- >   },
 -- >   "L_number_times": {
--- >     "rt": "serve",
--- >     "path": "/opt/eo/atoms/resident"
+-- >     "rt": "exec",
+-- >     "path": "/opt/eo/atoms/resident",
+-- >     "serve": true
 -- >   }
 -- > }
+--
+-- Whichever way it is run, a program speaks one protocol, in the letters of the
+-- evaluation rule of the calculus paper, 𝔼(𝑏, 𝑒, 𝑠) = 𝑛: one JSON object per
+-- line, the universe under '𝑒', then a request with an 'id', the λ name under
+-- 'λ' and the formation under '𝑏', answered by a line with the same 'id' and
+-- the 𝜑-expression under '𝑛'.
 --
 -- A name absent from the registry has no λ function at all: 𝔼 gets stuck on
 -- it, exactly as it does for a name no one ever declared (see 'Stuck' in
@@ -35,6 +41,7 @@
 module Atoms
   ( Atom (..)
   , AtomException (..)
+  , Program (..)
   , Registry
   , Runtime (..)
   , Session (_program)
@@ -49,17 +56,15 @@ where
 
 import AST
 import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar)
-import Control.Exception (Exception, SomeException, bracket, catch, throwIO, try)
-import Control.Monad (foldM, unless, void)
-import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.:), (.:?), (.=))
+import Control.Exception (Exception, SomeException, catch, onException, throwIO, try)
+import Control.Monad (foldM, unless)
+import Data.Aeson (FromJSON (parseJSON), eitherDecodeStrict', object, withObject, withText, (.!=), (.:), (.:?), (.=))
 import qualified Data.Aeson as A
-import Data.Aeson.Types (Parser)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (find, intercalate)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (isJust)
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8Lenient, encodeUtf8)
 import Encoding (Encoding (UNICODE))
@@ -71,7 +76,7 @@ import Printer (printExpression')
 import Sugar (SugarType (SALTY))
 import System.Directory (doesFileExist, executable, getPermissions, getTemporaryDirectory, removePathForcibly)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
-import System.IO (Handle, IOMode (WriteMode), hClose, hFlush, hSetBinaryMode, openBinaryTempFile, withBinaryFile)
+import System.IO (Handle, hClose, hFlush, hSetBinaryMode, openBinaryTempFile)
 import System.Process (CreateProcess (std_err, std_in, std_out), ProcessHandle, StdStream (CreatePipe, UseHandle), createProcess, proc, terminateProcess, waitForProcess)
 import System.Timeout (timeout)
 import Text.Printf (printf)
@@ -81,58 +86,61 @@ import Text.Printf (printf)
 -- is read, before dataization starts, so a run never gets half-way through a
 -- program to discover that one of its atoms cannot be run at all.
 data Runtime = RtNode
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Ord, Show)
 
--- One entry of the registry, as the file spells it: a script under the runtime
--- that interprets it, a file that runs on its own once per fire, or a file
--- that is started once and serves every fire of the run. This is what the JSON
--- says; what phino fires is an 'Atom', which 'readRegistry' makes of it.
-data Entry
-  = EnScripted Runtime T.Text
-  | EnExecutable FilePath
-  | EnServed FilePath
-
--- One λ function phino may fire. Either a script, which phino stages in a
--- temporary file and hands to the interpreter of its runtime, or an executable
+-- How the program of an atom is started: as a script under the interpreter of
+-- its runtime, which phino stages in a temporary file, or as an executable
 -- file, which phino runs as it is, since the object model brought its own
--- binary and there is nothing to stage, or a session with a program that stays
--- resident for the run and is asked over its streams, so that a run of many
--- fires spawns it once instead of once per fire.
-data Atom
+-- binary and there is nothing to stage.
+data Program
   = Scripted Runtime T.Text
   | Executable FilePath
-  | Served Session
+  deriving stock (Eq, Ord, Show)
+
+-- One λ function phino may fire: its program, either started afresh for every
+-- fire and gone once it has answered, or kept in a session for the run, so
+-- that one process answers every fire — which is what an entry saying 'serve'
+-- asks for, and what a program that is slow to start needs.
+data Atom
+  = Transient Program
+  | Resident Session
   deriving stock (Eq, Show)
 
--- The program a 'serve' entry names, together with the process phino has
+-- A program to be kept for the run, together with the process phino has
 -- started of it, if it has: none until the first fire, since a run that never
--- reaches the atom should not pay for it. Every entry naming the same file
+-- reaches the atom should not pay for it. Every entry naming the same program
 -- shares one session, so one process serves all the λ names it is registered
 -- under.
 data Session = Session
-  { _program :: FilePath
-  , _resident :: MVar (Maybe Resident)
+  { _program :: Program
+  , _running :: MVar (Maybe Running)
   }
 
--- Two sessions are the same when they serve from the same file, whatever
--- their processes are up to.
+-- Two sessions are the same when they keep the same program, whatever their
+-- processes are up to.
 instance Eq Session where
   Session left _ == Session right _ = left == right
 
 instance Show Session where
   show (Session program _) = show program
 
--- A resident program while it runs: its streams, the file its complaints go to,
--- the universe it was told last, so it is told again only when the universe
--- changes, and how many requests it has been asked, which numbers the next one.
-data Resident = Resident
+-- A program while it runs: its streams, the file its complaints go to, the
+-- file its script is staged in, if it is a script, the universe it was told
+-- last, so it is told again only when the universe changes, and how many
+-- requests it has been asked, which numbers the next one.
+data Running = Running
   { _input :: Handle
   , _output :: Handle
   , _process :: ProcessHandle
   , _complaints :: FilePath
+  , _staged :: Maybe FilePath
   , _told :: Maybe Expression
-  , _asked :: Int
+  , _requests :: Int
   }
+
+-- One entry of the registry, as the file spells it: the program and whether
+-- it is to be kept for the run.
+data Entry = Entry Program Bool
 
 -- Every λ function phino may fire, keyed by name.
 type Registry = Map T.Text Atom
@@ -145,7 +153,7 @@ data AtomException
     NoRuntime T.Text String String
   | -- The program exited with a non-zero status; the message carries its stderr.
     AtomBroke T.Text Int String
-  | -- The program said nothing phino can use: its answer is not a JSON object,
+  | -- The program said nothing phino can use: its reply is not a JSON object,
     -- carries no 𝜑-expression, answers another request, or the 𝜑-expression
     -- does not parse.
     AtomMute T.Text String String
@@ -183,37 +191,29 @@ runtimes = [RtNode]
 execName :: String
 execName = "exec"
 
--- The 'rt' of an atom that is a file started once and kept for the run.
-serveName :: String
-serveName = "serve"
-
 -- Every name the 'rt' field of a registry entry may take.
 runtimeNames :: [String]
-runtimeNames = map runtimeName runtimes ++ [execName, serveName]
+runtimeNames = map runtimeName runtimes ++ [execName]
 
 instance FromJSON Runtime where
   parseJSON = withText "runtime" $ \name -> case find ((== T.unpack name) . runtimeName) runtimes of
     Just runtime -> pure runtime
     Nothing -> fail (printf "unknown runtime '%s', expected one of: %s" (T.unpack name) (intercalate ", " runtimeNames))
 
+instance FromJSON Program where
+  parseJSON = withObject "atom" $ \entry -> do
+    named <- entry .: "rt"
+    if named == execName
+      then Executable <$> entry .: "path"
+      else Scripted <$> parseJSON (A.String (T.pack named)) <*> entry .: "script"
+
+-- The 'serve' field is optional and off by default: a program is started for
+-- every fire unless the entry says otherwise.
 instance FromJSON Entry where
-  parseJSON = withObject "atom" $ \entry -> entry .: "rt" >>= shaped entry
-    where
-      shaped :: A.Object -> String -> Parser Entry
-      shaped entry named
-        | named == execName = EnExecutable <$> entry .: "path"
-        | named == serveName = EnServed <$> entry .: "path"
-        | otherwise = EnScripted <$> parseJSON (A.String (T.pack named)) <*> entry .: "script"
+  parseJSON value = Entry <$> parseJSON value <*> withObject "atom" (\entry -> entry .:? "serve" .!= False) value
 
--- What a one-shot program writes to stdout: one JSON object whose 'n' field is
--- the 𝜑-expression the atom answers with.
-newtype Answer = Answer T.Text
-
-instance FromJSON Answer where
-  parseJSON = withObject "answer" $ \answer -> Answer <$> answer .: "n"
-
--- What a resident program writes back for one request: the 'id' of the request
--- it answers and, under '𝑛', the 𝜑-expression the atom answers with.
+-- What a program writes back for one request: the 'id' of the request it
+-- answers and, under '𝑛', the 𝜑-expression the atom answers with.
 data Reply = Reply Int T.Text
 
 instance FromJSON Reply where
@@ -233,8 +233,8 @@ registeredAtom registry func = Map.lookup func registry
 
 -- Read the registry of λ functions from a JSON file. An unknown runtime, a
 -- missing 'script', a 'path' that names no executable file or malformed JSON
--- fails here, before any dataization starts. The entries naming the same file
--- to serve from are given one session between them, so that one resident
+-- fails here, before any dataization starts. The entries that are to keep the
+-- same program are given one session between them, so that one resident
 -- process answers for every λ name it is registered under.
 readRegistry :: FilePath -> IO Registry
 readRegistry path = do
@@ -249,28 +249,24 @@ readRegistry path = do
   where
     unreadable :: IOError -> IO BS.ByteString
     unreadable failure = throwIO (BrokenRegistry path (show failure))
-    -- The file of an executable or a resident atom is the only thing phino
-    -- knows about it, and it staged none of it, so the file is looked at here,
-    -- while the registry is being read, rather than half-way through a program
-    -- that turns out to name that atom.
+    -- The file of an executable atom is the only thing phino knows about it,
+    -- and it staged none of it, so the file is looked at here, while the
+    -- registry is being read, rather than half-way through a program that
+    -- turns out to name that atom.
     runnable :: T.Text -> Entry -> IO ()
-    runnable _ (EnScripted _ _) = pure ()
-    runnable func (EnExecutable file) = runs func file
-    runnable func (EnServed file) = runs func file
-    runs :: T.Text -> FilePath -> IO ()
-    runs func file = do
+    runnable func (Entry (Executable file) _) = do
       there <- doesFileExist file
       unless there (throwIO (NoRuntime func file "there is no such file"))
       allowed <- executable <$> getPermissions file
       unless allowed (throwIO (NoRuntime func file "the file is not executable"))
+    runnable _ _ = pure ()
     -- Turn an entry into the atom phino fires, sharing a session between the
-    -- entries that serve from the same file.
-    admitted :: (Registry, Map FilePath Session) -> (T.Text, Entry) -> IO (Registry, Map FilePath Session)
-    admitted (registry, sessions) (func, EnScripted runtime script) = pure (Map.insert func (Scripted runtime script) registry, sessions)
-    admitted (registry, sessions) (func, EnExecutable file) = pure (Map.insert func (Executable file) registry, sessions)
-    admitted (registry, sessions) (func, EnServed file) = do
-      session <- maybe (Session file <$> newMVar Nothing) pure (Map.lookup file sessions)
-      pure (Map.insert func (Served session) registry, Map.insert file session sessions)
+    -- entries that are to keep the same program.
+    admitted :: (Registry, Map Program Session) -> (T.Text, Entry) -> IO (Registry, Map Program Session)
+    admitted (registry, sessions) (func, Entry program False) = pure (Map.insert func (Transient program) registry, sessions)
+    admitted (registry, sessions) (func, Entry program True) = do
+      session <- maybe (Session program <$> newMVar Nothing) pure (Map.lookup program sessions)
+      pure (Map.insert func (Resident session) registry, Map.insert program session sessions)
 
 -- Stop every resident program the registry has started: its stdin is closed,
 -- which is its cue to quit, and a program that has not quit within a second is
@@ -280,131 +276,96 @@ closeRegistry :: Registry -> IO ()
 closeRegistry registry = mapM_ dismissed (Map.elems registry)
   where
     dismissed :: Atom -> IO ()
-    dismissed (Served Session{..}) = modifyMVar_ _resident (maybe (pure Nothing) stopped)
+    dismissed (Resident Session{..}) = modifyMVar_ _running (maybe (pure Nothing) (\running -> Nothing <$ stopped briefly running))
     dismissed _ = pure ()
-    stopped :: Resident -> IO (Maybe Resident)
-    stopped Resident{..} = do
-      hClose _input `catch` unheard
-      quit <- timeout 1000000 (waitForProcess _process)
-      unless (isJust quit) (terminateProcess _process >> void (waitForProcess _process))
-      hClose _output `catch` unheard
-      removePathForcibly _complaints
-      pure Nothing
 
--- Fire the λ function 'func' by running its program. A scripted atom is staged
--- in a temporary file and handed to the interpreter of its runtime; an
--- executable one is run straight off its path, under no interpreter at all;
--- both get the λ name as their last command-line argument — one program may be
--- registered under several names and branch on it — and answer once, over
--- stdin and stdout, before they exit. A served atom is asked instead: its
--- program is started on the first fire and stays for the run, and every fire
--- is one line to it and one line back. Whichever way, the 𝜑-expression the
--- program answers with becomes the atom's raw result, which 𝔼 normalizes
--- exactly as it normalized the answer of a built-in one.
+-- Fire the λ function 'func' by asking its program. A transient program is
+-- started for the fire and waited for once it has answered, so that its exit
+-- status has its say; a resident one is started on the first fire and stays
+-- for the run, kept whatever the fire ended with, so that 'closeRegistry'
+-- finds it. Whichever way, the 𝜑-expression the program answers with becomes
+-- the atom's raw result, which 𝔼 normalizes exactly as it normalized the
+-- answer of a built-in one.
 fireAtom :: T.Text -> Atom -> Expression -> Expression -> IO Expression
-fireAtom func (Scripted runtime script) form univ =
-  withTemp (printf "phino-atom-.%s" (extension runtime)) (encodeUtf8 script) $ \staged ->
-    fireOnce func (interpreter runtime) [staged, T.unpack func] form univ
-fireAtom func (Executable file) form univ = fireOnce func file [T.unpack func] form univ
-fireAtom func (Served session) form univ = askResident func session form univ
-
--- Run the program as a POSIX process that answers once: it is fed a JSON
--- object on stdin (see 'payload') and answers with one on stdout, whose 'n'
--- field is the 𝜑-expression. A non-zero exit, unparsable output or a missing
--- 'n' fails the run.
-fireOnce :: T.Text -> String -> [String] -> Expression -> Expression -> IO Expression
-fireOnce func program arguments form univ =
-  withTemp "phino-atom-.err" "" $ \errors -> do
-    logDebug (printf "Firing atom '%s' as '%s %s'" (T.unpack func) program (unwords arguments))
-    (status, answer) <- executed errors
-    complaint <- readErrors errors
-    unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
-    case status of
-      ExitFailure code -> throwIO (AtomBroke func code complaint)
-      ExitSuccess -> answered answer
-  where
-    -- Run the program with its input and its output on pipes and its
-    -- complaints in a file. The input is written and closed before the output is
-    -- read, so the parent never has two streams to drain at once — which would
-    -- need threads to be safe — and the program's own stderr, which may be
-    -- anything at all, cannot fill a pipe nobody is reading. Every stream is
-    -- bytes: a 𝜑 expression carries characters no single-byte locale can spell,
-    -- so nothing is left to the locale.
-    executed :: FilePath -> IO (ExitCode, BS.ByteString)
-    executed errors =
-      withBinaryFile errors WriteMode $ \stderr' -> do
-        (stdin', stdout', process) <- spawned func program arguments stderr'
-        -- A program that dies before reading its input leaves this write with
-        -- nobody to drain it. The failure worth reporting is the one the program
-        -- made, so a broken pipe is swallowed here and the exit status decides.
-        BS.hPut stdin' (payload form univ) `catch` unheard
-        hClose stdin' `catch` unheard
-        answer <- BS.hGetContents stdout'
-        status <- waitForProcess process
-        pure (status, answer)
-    -- Parse what the program said: a JSON object with the raw 𝜑-expression
-    -- under 'n'.
-    answered :: BS.ByteString -> IO Expression
-    answered answer = case eitherDecodeStrict' answer of
-      Left failure -> throwIO (AtomMute func (spoken answer) failure)
-      Right (Answer raw) -> parsedAnswer func raw
-
--- Ask the resident program of the session, starting it if this is the first
--- fire. The program is told the universe Φ first, as one line holding it under
--- '𝑒', and again only when a fire comes with a different universe; every fire
--- is then one line holding the λ name under 'λ', the formation under '𝑏' and
--- an 'id', and one line back holding the 𝜑-expression under '𝑛' and the same
--- 'id'. The letters are those of the evaluation rule of the calculus, 𝔼(𝑏, 𝑒,
--- 𝑠) = 𝑛. A reply that is not JSON, carries no '𝑛', answers another request,
--- or a program that hangs up fails the run, with the program's stderr in the
--- message. The process is kept whatever the fire ended with, so that
--- 'closeRegistry' finds it.
-askResident :: T.Text -> Session -> Expression -> Expression -> IO Expression
-askResident func Session{..} form univ = do
-  outcome <- modifyMVar _resident $ \current -> do
-    resident <- maybe started pure current
-    attempt <- try (asked resident) :: IO (Either SomeException (Resident, Expression))
-    pure (Just (either (const resident) fst attempt), snd <$> attempt)
+fireAtom func (Transient program) form univ = do
+  running <- started func program
+  (_, answer) <- asked func running form univ hClose `onException` stopped patiently running
+  (status, complaint) <- stopped patiently running
+  unless (null complaint) (logDebug (printf "Atom '%s' wrote to stderr: %s" (T.unpack func) complaint))
+  case status of
+    ExitFailure code -> throwIO (AtomBroke func code complaint)
+    ExitSuccess -> pure answer
+fireAtom func (Resident Session{..}) form univ = do
+  outcome <- modifyMVar _running $ \current -> do
+    running <- maybe (started func _program) pure current
+    attempt <- try (asked func running form univ hFlush) :: IO (Either SomeException (Running, Expression))
+    pure (Just (either (const running) fst attempt), snd <$> attempt)
   either throwIO pure outcome
+
+-- Start the program, with its input and its output on pipes and its complaints
+-- in a file that lives as long as the process does: a script is staged in a
+-- temporary file first and handed to the interpreter of its runtime, an
+-- executable file is run as it is. Every stream is bytes: a 𝜑 expression
+-- carries characters no single-byte locale can spell, so nothing is left to
+-- the locale.
+started :: T.Text -> Program -> IO Running
+started func program = do
+  dir <- getTemporaryDirectory
+  (complaints, handle) <- openBinaryTempFile dir "phino-atom-.err"
+  (executable, arguments, staged) <- commanded dir
+  logDebug (printf "Starting atom '%s' as '%s'" (T.unpack func) (unwords (executable : arguments)))
+  (input, output, process) <- spawned executable arguments handle `onException` discarded complaints staged
+  pure (Running input output process complaints staged Nothing 0)
   where
-    -- Start the program with its input and its output on pipes and its
-    -- complaints in a file that lives as long as the process does.
-    started :: IO Resident
-    started = do
-      dir <- getTemporaryDirectory
-      (complaints, handle) <- openBinaryTempFile dir "phino-atom-.err"
-      logDebug (printf "Starting the resident program '%s' to serve atom '%s'" _program (T.unpack func))
-      (input, output, process) <- spawned func _program [] handle
-      pure (Resident input output process complaints Nothing 0)
-    asked :: Resident -> IO (Resident, Expression)
-    asked resident = do
-      told <- informed resident
-      let number = _asked told + 1
-      logDebug (printf "Asking the resident program '%s' to fire atom '%s' as request %d" _program (T.unpack func) number)
-      said (_input told) (request number)
-      reply <- BS.hGetLine (_output told) `catch` hungUp told
-      answer <- replied number reply
-      pure (told{_asked = number}, answer)
-    -- Tell the program the universe, unless it is the one it was told last.
-    informed :: Resident -> IO Resident
-    informed resident
-      | _told resident == Just univ = pure resident
-      | otherwise = do
-          said (_input resident) (lined (object ["𝑒" .= rendered univ]))
-          pure resident{_told = Just univ}
-    request :: Int -> BS.ByteString
-    request number = lined (object ["id" .= number, "λ" .= func, "𝑏" .= rendered form])
-    -- One line to the program, pushed through at once, since a pipe is
-    -- buffered and the program answers nothing it has not seen. A program that
-    -- has died leaves the write with nobody to drain it; the failure worth
-    -- reporting is the one the program made, so a broken pipe is swallowed
-    -- here and the read that follows finds out.
-    said :: Handle -> BS.ByteString -> IO ()
-    said handle line = (BS.hPut handle line >> hFlush handle) `catch` unheard
-    -- The program closed its stdout instead of answering: if it has exited
-    -- with a failure, that is the failure; otherwise it went mute.
-    hungUp :: Resident -> IOError -> IO BS.ByteString
-    hungUp Resident{..} _ = do
+    -- The command line the program is started with, and the file staged for
+    -- it, if it is a script.
+    commanded :: FilePath -> IO (String, [String], Maybe FilePath)
+    commanded dir = case program of
+      Executable file -> pure (file, [], Nothing)
+      Scripted runtime script -> do
+        (path, handle) <- openBinaryTempFile dir (printf "phino-atom-.%s" (extension runtime))
+        BS.hPut handle (encodeUtf8 script)
+        hClose handle
+        pure (interpreter runtime, [path], Just path)
+    spawned :: String -> [String] -> Handle -> IO (Handle, Handle, ProcessHandle)
+    spawned executable arguments stderr' = do
+      spawn <- createProcess (proc executable arguments){std_in = CreatePipe, std_out = CreatePipe, std_err = UseHandle stderr'} `catch` missing executable
+      case spawn of
+        (Just input, Just output, _, process) -> do
+          hSetBinaryMode input True
+          hSetBinaryMode output True
+          pure (input, output, process)
+        _ -> throwIO (AtomMute func "" "the program gave phino no streams to talk over")
+    missing :: String -> IOError -> IO a
+    missing executable failure = throwIO (NoRuntime func executable (show failure))
+
+-- Ask the running program to fire the λ function: it is told the universe,
+-- unless it was told already, then the request, and its reply is read back.
+-- How the request is pushed through is the caller's: a transient program has
+-- its stdin closed behind it, since it may read its input whole before it
+-- answers, a resident one has it flushed, since it reads on. A reply that is
+-- not JSON, carries no '𝑛', answers another request, or a program that hangs
+-- up fails the fire, with the program's stderr in the message.
+asked :: T.Text -> Running -> Expression -> Expression -> (Handle -> IO ()) -> IO (Running, Expression)
+asked func running@Running{..} form univ pushed = do
+  let number = _requests + 1
+      universe = lined (object ["𝑒" .= rendered univ])
+      request = lined (object ["id" .= number, "λ" .= func, "𝑏" .= rendered form])
+  logDebug (printf "Asking atom '%s' as request %d" (T.unpack func) number)
+  said (if _told == Just univ then request else universe <> request)
+  reply <- BS.hGetLine _output `catch` hungUp
+  answer <- replied number reply
+  pure (running{_told = Just univ, _requests = number}, answer)
+  where
+    -- A program that has died leaves the write with nobody to drain it. The
+    -- failure worth reporting is the one the program made, so a broken pipe is
+    -- swallowed here and the read that follows finds out.
+    said :: BS.ByteString -> IO ()
+    said content = (BS.hPut _input content >> pushed _input) `catch` unheard
+    -- The program closed its stdout instead of answering: if it has quit with
+    -- a failure, that is the failure; otherwise it went mute.
+    hungUp :: IOError -> IO BS.ByteString
+    hungUp _ = do
       status <- timeout 1000000 (waitForProcess _process)
       complaint <- readErrors _complaints
       case status of
@@ -418,36 +379,38 @@ askResident func Session{..} form univ = do
       Left failure -> throwIO (AtomMute func (spoken reply) failure)
       Right (Reply echoed raw)
         | echoed /= number -> throwIO (AtomMute func (spoken reply) (printf "it answers request %d, while phino asked request %d" echoed number))
-        | otherwise -> parsedAnswer func raw
+        | otherwise -> case parseExpression (T.unpack raw) of
+            Left failure -> throwIO (AtomMute func (T.unpack raw) failure)
+            Right expr -> pure expr
 
--- Spawn the program with its input and its output on pipes and its stderr on
--- the given handle, as bytes on every stream: a 𝜑 expression carries
--- characters no single-byte locale can spell, so nothing is left to the locale.
-spawned :: T.Text -> String -> [String] -> Handle -> IO (Handle, Handle, ProcessHandle)
-spawned func program arguments stderr' = do
-  spawn <- createProcess started `catch` missing
-  case spawn of
-    (Just stdin', Just stdout', _, process) -> do
-      hSetBinaryMode stdin' True
-      hSetBinaryMode stdout' True
-      pure (stdin', stdout', process)
-    _ -> throwIO (AtomMute func "" "the program gave phino no streams to talk over")
-  where
-    started :: CreateProcess
-    started =
-      (proc program arguments)
-        { std_in = CreatePipe
-        , std_out = CreatePipe
-        , std_err = UseHandle stderr'
-        }
-    missing :: IOError -> IO a
-    missing failure = throwIO (NoRuntime func program (show failure))
+-- Hang up on the program: close its stdin, which is its cue to quit, wait for
+-- it the given way and remove the files it was given, its complaints read
+-- first, since they are what a failure is reported with.
+stopped :: (Running -> IO ExitCode) -> Running -> IO (ExitCode, String)
+stopped waited running@Running{..} = do
+  hClose _input `catch` unheard
+  status <- waited running
+  hClose _output `catch` unheard
+  complaint <- readErrors _complaints
+  discarded _complaints _staged
+  pure (status, complaint)
 
--- The 𝜑-expression a program answered with, parsed, or the failure to.
-parsedAnswer :: T.Text -> T.Text -> IO Expression
-parsedAnswer func raw = case parseExpression (T.unpack raw) of
-  Left failure -> throwIO (AtomMute func (T.unpack raw) failure)
-  Right expr -> pure expr
+-- Wait for the program to quit for as long as it takes, draining whatever else
+-- it writes, so that a chatty one never blocks on a full pipe: a transient
+-- program is on its way out once it has answered, and its exit status is the
+-- verdict on its answer.
+patiently :: Running -> IO ExitCode
+patiently Running{..} = BS.hGetContents _output >> waitForProcess _process
+
+-- Wait for the program to quit for a second, then terminate it: a resident one
+-- was told to quit and gets no say in the matter.
+briefly :: Running -> IO ExitCode
+briefly Running{..} = timeout 1000000 (waitForProcess _process) >>= maybe (terminateProcess _process >> waitForProcess _process) pure
+
+-- Remove the files a program was given: the one its complaints went to and the
+-- one its script was staged in, if it was a script.
+discarded :: FilePath -> Maybe FilePath -> IO ()
+discarded complaints staged = removePathForcibly complaints >> mapM_ removePathForcibly staged
 
 -- Whatever the program said, decoded leniently and trimmed: the stream is the
 -- program's, so it may hold anything at all.
@@ -461,20 +424,6 @@ readErrors errors = spoken <$> BS.readFile errors
 unheard :: IOError -> IO ()
 unheard _ = pure ()
 
--- The JSON phino feeds a one-shot program on stdin: the formation being
--- evaluated under 'b', with its λ binding removed so the program may dispatch
--- on it, and the universe Φ under 's'. The text is what phino's own parser
--- reads back, so a program may hand any part of it to another phino run (see
--- the '--inside' option).
---
--- @todo #1121:35min Rename the keys of the one-shot payload and its answer to
---  the letters of the calculus paper, '𝑏', '𝑒' and '𝑛', the way the resident
---  protocol already spells them: here the universe goes under 's', which in
---  the paper stands for the state, not for the universe. The fixture script,
---  the README and every registered script must change together with it.
-payload :: Expression -> Expression -> BS.ByteString
-payload form univ = BSL.toStrict (A.encode (object ["b" .= rendered form, "s" .= rendered univ]))
-
 -- One JSON object as one line, for the programs that read by the line.
 lined :: A.Value -> BS.ByteString
 lined value = BSL.toStrict (A.encode value) <> "\n"
@@ -482,19 +431,8 @@ lined value = BSL.toStrict (A.encode value) <> "\n"
 -- An expression as canonical 𝜑-calculus on a single line — no syntax sugar,
 -- whatever '--sweet' says about the output of the run — so a program never has
 -- to know phino's sugar to find a datum: every byte array it may need is
--- spelled out as a Δ binding.
+-- spelled out as a Δ binding. The text is what phino's own parser reads back,
+-- so a program may hand any part of it to another phino run (see the
+-- '--inside' option).
 rendered :: Expression -> T.Text
 rendered expr = T.pack (printExpression' expr (SALTY, UNICODE, SINGLELINE, defaultMargin))
-
--- Write the content to a fresh temporary file, hand its path to the action and
--- delete the file afterwards, whatever the action does.
-withTemp :: String -> BS.ByteString -> (FilePath -> IO a) -> IO a
-withTemp template content action = do
-  dir <- getTemporaryDirectory
-  bracket (openBinaryTempFile dir template) discarded $ \(path, handle) -> do
-    BS.hPut handle content
-    hClose handle
-    action path
-  where
-    discarded :: (FilePath, Handle) -> IO ()
-    discarded (path, handle) = hClose handle >> removePathForcibly path

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -216,7 +216,7 @@ optAtoms =
             <> metavar "FILE"
             <> help
               ( printf
-                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script, the executable or the resident program it runs"
+                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s), the script or the executable it runs and, with \"serve\", whether one process of it is to serve the whole run"
                   (intercalate ", " runtimeNames)
               )
         )

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -216,7 +216,7 @@ optAtoms =
             <> metavar "FILE"
             <> help
               ( printf
-                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script or the executable it runs"
+                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s) and the script, the executable or the resident program it runs"
                   (intercalate ", " runtimeNames)
               )
         )

--- a/src/CLI/Parsers.hs
+++ b/src/CLI/Parsers.hs
@@ -216,7 +216,7 @@ optAtoms =
             <> metavar "FILE"
             <> help
               ( printf
-                  "Path to the JSON registry of λ functions this run may fire, mapping each name to the runtime that runs it (%s), the script or the executable it runs and, with \"serve\", whether one process of it is to serve the whole run"
+                  "Path to the JSON registry of λ functions this run may fire, whose keys are regular expressions over λ names, tried top to bottom, each mapped to the runtime that runs it (%s), the script or the executable it runs and, with \"serve\", whether one process of it is to serve the whole run"
                   (intercalate ", " runtimeNames)
               )
         )

--- a/src/CLI/Runners.hs
+++ b/src/CLI/Runners.hs
@@ -8,6 +8,7 @@
 module CLI.Runners where
 
 import AST
+import Atoms (closeRegistry)
 import CLI.Helpers
 import CLI.Types
 import CLI.Validators
@@ -160,10 +161,15 @@ runDataize OptsDataize{..} = do
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
   (outcome, chain) <-
-    withEvalFunc _evaluations printCtx $ \record -> do
-      let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
-      (universe, aiming) <- aimed _inside expr ctx
-      dataize universe aiming
+    withEvalFunc
+      _evaluations
+      printCtx
+      ( \record -> do
+          let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
+          (universe, aiming) <- aimed _inside expr ctx
+          dataize universe aiming
+      )
+      `finally` closeRegistry atoms
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (printOutcome printCtx outcome >>= putStrLn)
   where
@@ -235,10 +241,15 @@ runMorph OptsMorph{..} = do
       include = (`F.include` included)
   save <- saveStepFunc _stepsDir printCtx
   (morphed, chain) <-
-    withEvalFunc _evaluations printCtx $ \record -> do
-      let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
-      (universe, aiming) <- aimed _inside expr ctx
-      morph universe aiming
+    withEvalFunc
+      _evaluations
+      printCtx
+      ( \record -> do
+          let ctx = DataizeContext loc _maxDepth _maxCycles (Steps _maxSteps 0) _depthSensitive _shuffle _partial atoms buildTerm save record
+          (universe, aiming) <- aimed _inside expr ctx
+          morph universe aiming
+      )
+      `finally` closeRegistry atoms
   when _sequence (printRewrittens printCtx (exclude $ include chain, False) >>= putStrLn)
   unless _quiet (printFocused printCtx morphed >>= putStrLn)
   where

--- a/test-resources/atoms/primitives.js
+++ b/test-resources/atoms/primitives.js
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 // The λ functions phino's own tests fire. phino implements none of them: it
-// writes this script to a temporary file, runs it under 'node' with the name of
-// the λ function as the first argument, feeds it the formation being evaluated
-// ('b') and the universe Φ ('s') on stdin as JSON, and reads the 𝜑-expression
-// to use as the atom's raw result back from stdout, under 'n'.
+// writes this script to a temporary file, runs it under 'node' and talks to it
+// over stdin and stdout, one JSON object per line, in the letters of the
+// evaluation rule of the calculus: the universe Φ under '𝑒', then a request
+// with an 'id', the name of the λ function under 'λ' and the formation being
+// evaluated under '𝑏', which this script answers with a line carrying the same
+// 'id' and, under '𝑛', the 𝜑-expression to use as the atom's raw result. The
+// lines are read as they come and answered as they come, so the script serves
+// just as well started once per fire as kept for the run with 'serve'.
 //
 // This is a fixture, not a runtime: it goes just far enough to let the specs
 // reduce arithmetic and byte comparisons. Both payloads arrive as canonical
@@ -16,16 +20,13 @@
 
 'use strict';
 
-const fs = require('fs');
-
-const atom = process.argv[2];
-const { b } = JSON.parse(fs.readFileSync(0, 'utf8'));
+const readline = require('readline');
 
 const OPENING = '⟦(';
 const CLOSING = '⟧)';
 
 // The 𝜑 text bound to the attribute 'name' by the formation 'b'.
-function bound(name) {
+function bound(b, name) {
   const head = name + ' ↦ ';
   let depth = 0;
   for (let index = 0; index < b.length; index += 1) {
@@ -35,7 +36,7 @@ function bound(name) {
     } else if (CLOSING.includes(char)) {
       depth -= 1;
     } else if (depth === 1 && b.startsWith(head, index) && ' ,⟦'.includes(b[index - 1])) {
-      return bindingValue(index + head.length);
+      return bindingValue(b, index + head.length);
     }
   }
   return null;
@@ -43,7 +44,7 @@ function bound(name) {
 
 // The 𝜑 text of one binding's value: everything up to the comma or the closing
 // bracket that ends it.
-function bindingValue(start) {
+function bindingValue(b, start) {
   let depth = 0;
   let text = '';
   for (let index = start; index < b.length; index += 1) {
@@ -120,32 +121,33 @@ function asBool(yes) {
 
 // A number atom with an operand carrying no number yields the terminator ⊥,
 // the way every EO number atom does.
-function arithmetic(operation) {
-  const left = number(bound('x'));
-  const right = number(bound('ρ'));
+function arithmetic(b, operation) {
+  const left = number(bound(b, 'x'));
+  const right = number(bound(b, 'ρ'));
   return Number.isNaN(left) || Number.isNaN(right) ? '⊥' : asNumber(operation(left, right));
 }
 
-function answer() {
+// The 𝜑-expression the λ function 'atom' answers with for the formation 'b'.
+function answer(atom, b) {
   switch (atom) {
     case 'L_number_plus':
-      return arithmetic((x, rho) => rho + x);
+      return arithmetic(b, (x, rho) => rho + x);
     case 'L_number_times':
-      return arithmetic((x, rho) => rho * x);
+      return arithmetic(b, (x, rho) => rho * x);
     case 'L_number_div':
-      return arithmetic((x, rho) => rho / x);
+      return arithmetic(b, (x, rho) => rho / x);
     case 'L_number_gt': {
-      const left = number(bound('x'));
-      const right = number(bound('ρ'));
+      const left = number(bound(b, 'x'));
+      const right = number(bound(b, 'ρ'));
       return Number.isNaN(left) || Number.isNaN(right) ? '⊥' : asBool(right > left);
     }
     case 'L_bytes_eq': {
-      const left = bytes(bound('b'));
-      const right = bytes(bound('ρ'));
+      const left = bytes(bound(b, 'b'));
+      const right = bytes(bound(b, 'ρ'));
       return left === null || right === null ? '⊥' : asBool(left.equals(right));
     }
     case 'L_bytes_not': {
-      const raw = bytes(bound('ρ'));
+      const raw = bytes(bound(b, 'ρ'));
       return raw === null ? '⊥' : asBytes(Buffer.from([...raw].map((octet) => ~octet & 0xff)));
     }
     default:
@@ -153,4 +155,11 @@ function answer() {
   }
 }
 
-process.stdout.write(JSON.stringify({ n: answer() }));
+// The universe under '𝑒' is not needed here, since no operand is dataized, so
+// its line is read and let go; every request is answered on the spot.
+readline.createInterface({ input: process.stdin }).on('line', (line) => {
+  const message = JSON.parse(line);
+  if ('id' in message) {
+    process.stdout.write(`${JSON.stringify({ id: message.id, '𝑛': answer(message['λ'], message['𝑏']) })}\n`);
+  }
+});

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -13,8 +13,10 @@ import Control.Monad (forM_)
 import Data.Aeson (Value, object, (.=))
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.Types (Pair)
+import Data.ByteString qualified as BS
 import Data.List (isInfixOf)
 import Data.Text qualified as T
+import Data.Text.Encoding (encodeUtf8)
 import Fixtures (resident, withExecutable, withNode, withRegistryOf, withScript, withShell, withTemp)
 import Parser (parseExpressionThrows)
 import System.Directory (doesFileExist, getTemporaryDirectory, removePathForcibly)
@@ -39,6 +41,11 @@ scripted script = ["rt" .= ("node" :: T.Text), "script" .= script]
 -- The same entry, kept for the run
 served :: [Pair] -> [Pair]
 served fields = ("serve" .= True) : fields
+
+-- The text of a registry of node scripts under the given keys, in exactly the
+-- order given, which 'registryOf' cannot promise
+ordered :: [(T.Text, T.Text)] -> BS.ByteString
+ordered entries = encodeUtf8 ("{" <> T.intercalate ", " ["\"" <> key <> "\": {\"rt\": \"node\", \"script\": \"" <> script <> "\"}" | (key, script) <- entries] <> "}")
 
 -- The λ functions of the given registry, read from a file, with every program
 -- it has started stopped afterwards, so that no spec leaves a process behind
@@ -196,6 +203,33 @@ spec = do
         registry <- readRegistry path
         registeredAtom registry "L_bytes_eq" `shouldBe` Nothing
 
+    -- A key is a regular expression, so one entry may stand for a whole family
+    -- of atoms and the same program need not be spelled once per name
+    it "matches a λ name against the key as a regular expression" $
+      withRegistryOf (registryOf ["L_number_.*"] (scripted "say(1)")) $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_number_plus" `shouldBe` Just (Transient (Scripted RtNode "say(1)"))
+
+    -- A plain name is a regular expression too, and it means that one atom,
+    -- not every atom whose name it is a part of
+    it "matches the key against the whole λ name" $
+      withRegistryOf (registryOf ["L_number"] (scripted "say(1)")) $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_number_plus" `shouldBe` Nothing
+
+    -- The keys are tried in the order the file lists them, so a catch-all
+    -- placed first hides everything below it, and the file is written by hand
+    -- here because 'object' does not keep the order of its keys
+    it "fires the first key top to bottom that matches" $
+      withTemp "phino-atoms-.json" (ordered [(".*", "say(1)"), ("L_answer", "say(2)")]) $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_answer" `shouldBe` Just (Transient (Scripted RtNode "say(1)"))
+
+    it "reaches a later key when the earlier ones do not match" $
+      withTemp "phino-atoms-.json" (ordered [("L_other", "say(1)"), (".*", "say(2)")]) $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_answer" `shouldBe` Just (Transient (Scripted RtNode "say(2)"))
+
     -- A malformed entry is refused where the file is read, which is before any
     -- dataization starts, rather than at the moment an atom of it would fire
     forM_
@@ -246,6 +280,21 @@ spec = do
       withTemp "phino-atoms-.json" "L_answer: js" $ \path ->
         readRegistry path
           `shouldThrow` (\failure -> "cannot be read" `isInfixOf` show (failure :: SomeException))
+
+    it "fails when a key is not a regular expression" $
+      withRegistryOf (registryOf ["L_(answer"] (scripted "say(1)")) $ \path ->
+        readRegistry path
+          `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) ["L_(answer", "regular expression"])
+
+    it "fails when the file is a JSON array" $
+      withTemp "phino-atoms-.json" "[]" $ \path ->
+        readRegistry path
+          `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) ["cannot be read", "object"])
+
+    it "fails when there is more in the file than the JSON object" $
+      withTemp "phino-atoms-.json" "{} {}" $ \path ->
+        readRegistry path
+          `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) ["cannot be read", "more in the file"])
 
     it "fails when the file is not there" $
       readRegistry "no-such-registry.json"
@@ -367,6 +416,16 @@ spec = do
     it "serves every λ name registered on the same file from one program" $
       withShell $
         withServed ["L_answer", "L_other"] (replying "0$n-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_other" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
+          second `shouldBe` wanted
+
+    -- One key matching many names is the way to have one program serve them
+    -- all without spelling it once per name
+    it "serves every λ name one key matches from one program" $
+      withShell $
+        withServed [".*"] (replying "0$n-") $ \registry -> do
           _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
           second <- firedFrom registry "L_other" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
           wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -7,21 +7,23 @@
 module AtomsSpec (spec) where
 
 import AST
-import Atoms (Atom (..), Runtime (RtNode), emptyRegistry, fireAtom, readRegistry, registeredAtom)
-import Control.Exception (SomeException, bracket)
+import Atoms (Atom (..), Registry, Runtime (RtNode), Session (_program), closeRegistry, emptyRegistry, fireAtom, readRegistry, registeredAtom)
+import Control.Exception (SomeException, bracket, finally)
 import Control.Monad (forM_)
-import Data.Aeson (encode, object, (.=))
+import Data.Aeson (Value, encode, object, (.=))
+import Data.Aeson.Key qualified as Key
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.List (isInfixOf)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Fixtures (withNode)
+import Fixtures (resident, withExecutable, withNode, withRegistryOf, withScript, withShell)
 import Parser (parseExpressionThrows)
-import System.Directory (getPermissions, getTemporaryDirectory, removePathForcibly, setOwnerExecutable, setPermissions)
+import System.Directory (doesFileExist, getTemporaryDirectory, removePathForcibly)
+import System.FilePath ((</>))
 import System.IO (Handle, hClose, openBinaryTempFile)
-import System.Info (os)
 import Test.Hspec
+import Text.Printf (printf)
 
 -- A registry file holding the given content, removed afterwards
 withRegistry :: T.Text -> (FilePath -> IO a) -> IO a
@@ -35,40 +37,39 @@ withRegistry content action = do
     discarded :: (FilePath, Handle) -> IO ()
     discarded (path, handle) = hClose handle >> removePathForcibly path
 
--- A file in the temporary directory holding the given POSIX shell script,
--- removed afterwards
-withScript :: T.Text -> (FilePath -> IO a) -> IO a
-withScript script action = do
-  dir <- getTemporaryDirectory
-  bracket (openBinaryTempFile dir "phino-exec-.sh") discarded $ \(path, handle) -> do
-    BS.hPut handle (encodeUtf8 (T.unlines ["#!/bin/sh", script]))
-    hClose handle
-    action path
-  where
-    discarded :: (FilePath, Handle) -> IO ()
-    discarded (path, handle) = hClose handle >> removePathForcibly path
-
--- The same file, executable, which is what an 'exec' atom names and phino
--- never stages itself
-withExecutable :: T.Text -> (FilePath -> IO a) -> IO a
-withExecutable script action = withScript script $ \path -> do
-  permissions <- getPermissions path
-  setPermissions path (setOwnerExecutable True permissions)
-  action path
-
--- A POSIX shell script is executable nowhere on Windows, so a case that needs
--- one is pending there rather than red
-withShell :: Expectation -> Expectation
-withShell expectation
-  | os == "mingw32" = pendingWith "no POSIX shell script is executable on Windows"
-  | otherwise = expectation
-
 -- The registry of one executable λ function, naming the given file. The path
 -- goes through JSON encoding rather than into the text by hand, since a
 -- Windows one spells its separators with the escape character of JSON
 executing :: FilePath -> T.Text
-executing file =
-  decodeUtf8 (BSL.toStrict (encode (object ["L_answer" .= object ["rt" .= ("exec" :: T.Text), "path" .= file]])))
+executing file = decodeUtf8 (BSL.toStrict (encode (serving "exec" ["L_answer"] file)))
+
+-- The registry of the given λ functions all served by, or executed as, the
+-- given file
+serving :: T.Text -> [T.Text] -> FilePath -> Value
+serving runtime names file = object [Key.fromText name .= object ["rt" .= runtime, "path" .= file] | name <- names]
+
+-- The λ functions of the registry read from a file naming a resident program
+-- built of the given per-request snippet (see 'resident'), stopped afterwards,
+-- so that no spec leaves a shell behind
+withServed :: [T.Text] -> T.Text -> (Registry -> IO a) -> IO a
+withServed names snippet action =
+  withExecutable (resident snippet) $ \file ->
+    withRegistryOf (serving "serve" names file) $ \path -> do
+      registry <- readRegistry path
+      action registry `finally` closeRegistry registry
+
+-- Fire the given λ function out of the registry, against the same formation
+-- and universe 'fired' uses, unless a different universe is given
+firedFrom :: Registry -> T.Text -> String -> IO Expression
+firedFrom registry func universe = do
+  form <- parseExpressionThrows "⟦ x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧"
+  univ <- parseExpressionThrows universe
+  maybe (fail (printf "'%s' is not registered" (T.unpack func))) (\atom -> fireAtom func atom form univ) (registeredAtom registry func)
+
+-- The path a served λ function is served from, if it is one
+servedFrom :: Maybe Atom -> Maybe FilePath
+servedFrom (Just (Served session)) = Just (_program session)
+servedFrom _ = Nothing
 
 -- Fire the λ function 'L_answer' out of the given atom, against a formation
 -- binding 'x' inside a universe binding 'y'
@@ -93,6 +94,27 @@ executes script expected = withShell $
     answer <- fired (Executable file)
     wanted <- parseExpressionThrows expected
     answer `shouldBe` wanted
+
+-- The same, for an atom served by a resident program built of the given
+-- per-request snippet
+serves :: T.Text -> String -> Expectation
+serves snippet expected = withShell $
+  withServed ["L_answer"] snippet $ \registry -> do
+    answer <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+    wanted <- parseExpressionThrows expected
+    answer `shouldBe` wanted
+
+-- A firing of a served atom that has to fail, with the reason naming the given
+-- fragments
+refuses :: T.Text -> [String] -> Expectation
+refuses snippet fragments = withShell $
+  withServed ["L_answer"] snippet $ \registry ->
+    firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+      `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
+
+-- The reply of a resident program answering the request with the given bytes
+replying :: T.Text -> T.Text
+replying bytes = "printf '{\"id\": %s, \"𝑛\": \"⟦ Δ ⤍ %s ⟧\"}\\n' \"$id\" \"" <> bytes <> "\""
 
 -- A firing that has to fail, with the reason naming the given fragments
 fails :: T.Text -> [String] -> Expectation
@@ -123,6 +145,13 @@ spec = do
           withRegistry (executing file) $ \path -> do
             registry <- readRegistry path
             registeredAtom registry "L_answer" `shouldBe` Just (Executable file)
+
+    it "reads a served λ function as the file it is served from" $
+      withShell $
+        withExecutable "" $ \file ->
+          withRegistryOf (serving "serve" ["L_answer"] file) $ \path -> do
+            registry <- readRegistry path
+            servedFrom (registeredAtom registry "L_answer") `shouldBe` Just file
 
     it "leaves a name the file does not carry unregistered" $
       withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
@@ -158,6 +187,16 @@ spec = do
         , ["L_answer", "no-such-atom", "there is no such file"]
         )
       ,
+        ( "a served entry carries no path"
+        , "{\"L_answer\": {\"rt\": \"serve\"}}"
+        , ["path"]
+        )
+      ,
+        ( "the served file is not there"
+        , "{\"L_answer\": {\"rt\": \"serve\", \"path\": \"no-such-atom\"}}"
+        , ["L_answer", "no-such-atom", "there is no such file"]
+        )
+      ,
         ( "the file is not JSON at all"
         , "L_answer: js"
         , ["cannot be read"]
@@ -179,6 +218,12 @@ spec = do
     it "fails when the file of an executable λ function cannot be run" $
       withScript "" $ \file ->
         withRegistry (executing file) $ \path ->
+          readRegistry path
+            `shouldThrow` (\failure -> "not executable" `isInfixOf` show (failure :: SomeException))
+
+    it "fails when the file of a served λ function cannot be run" $
+      withScript "" $ \file ->
+        withRegistryOf (serving "serve" ["L_answer"] file) $ \path ->
           readRegistry path
             `shouldThrow` (\failure -> "not executable" `isInfixOf` show (failure :: SomeException))
 
@@ -240,3 +285,90 @@ spec = do
       executes
         "case \"$(cat)\" in *'x ↦'*) echo '{\"n\": \"⟦ Δ ⤍ FF- ⟧\"}';; *) echo '{\"n\": \"⟦ Δ ⤍ 00- ⟧\"}';; esac"
         "⟦ Δ ⤍ FF- ⟧"
+
+    -- A served atom is asked over the streams of a program that stays for the
+    -- run, one line per fire, so the program speaks another protocol than a
+    -- one-shot one: the letters of the evaluation rule of the calculus
+    it "hands back the 𝜑-expression the resident program wrote under '𝑛'" $
+      serves (replying "2A-") "⟦ Δ ⤍ 2A- ⟧"
+
+    it "keeps one resident program across the fires" $
+      withShell $
+        withServed ["L_answer"] (replying "0$n-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
+          second `shouldBe` wanted
+
+    -- One file may be registered under several λ names, and it is one program
+    -- that serves them all, not one per name
+    it "serves every λ name registered on the same file from one program" $
+      withShell $
+        withServed ["L_answer", "L_other"] (replying "0$n-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_other" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
+          second `shouldBe` wanted
+
+    it "tells the resident program the universe under '𝑒' before the first request" $
+      serves (replying "0$e-") "⟦ Δ ⤍ 01- ⟧"
+
+    it "does not tell the resident program a universe it was told already" $
+      withShell $
+        withServed ["L_answer"] (replying "0$e-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 01- ⟧"
+          second `shouldBe` wanted
+
+    it "tells the resident program the universe again when it changes" $
+      withShell $
+        withServed ["L_answer"] (replying "0$e-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_answer" "⟦ z ↦ ⟦ Δ ⤍ 03- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
+          second `shouldBe` wanted
+
+    it "names the λ function being fired under 'λ' in the request" $
+      serves
+        ("case \"$line\" in *'\"λ\":\"L_answer\"'*) " <> replying "FF-" <> ";; *) " <> replying "00-" <> ";; esac")
+        "⟦ Δ ⤍ FF- ⟧"
+
+    it "carries the formation under '𝑏' in the request" $
+      serves
+        ("case \"$line\" in *'x ↦'*) " <> replying "FF-" <> ";; *) " <> replying "00-" <> ";; esac")
+        "⟦ Δ ⤍ FF- ⟧"
+
+    it "fails when the resident program answers another request" $
+      refuses "printf '{\"id\": 99, \"𝑛\": \"⟦ Δ ⤍ 2A- ⟧\"}\\n'" ["L_answer", "request 99"]
+
+    it "fails with the resident program's own complaint when it quits non-zero" $
+      refuses "echo 'no idea what to do' >&2; exit 4" ["L_answer", "exit code 4", "no idea what to do"]
+
+    it "fails when the resident program quits without answering" $
+      refuses "exit 0" ["L_answer", "without answering"]
+
+    it "fails when the resident program writes something other than JSON" $
+      refuses "echo almost" ["L_answer", "almost"]
+
+    it "fails when the resident program writes JSON with no '𝑛' in it" $
+      refuses "printf '{\"id\": %s, \"m\": \"⟦ ⟧\"}\\n' \"$id\"" ["L_answer", "𝑛"]
+
+    it "fails when what the resident program put under '𝑛' is not a 𝜑-expression" $
+      refuses "printf '{\"id\": %s, \"𝑛\": \"⟦ ⟧⟧\"}\\n' \"$id\"" ["L_answer"]
+
+  describe "closeRegistry" $ do
+    -- The program is told to quit by its stdin closing, which its read loop
+    -- notices, so it gets to run whatever it does on exit
+    it "stops the resident program the registry has started" $
+      withShell $ do
+        dir <- getTemporaryDirectory
+        let mark = dir </> "phino-resident-quit"
+        removePathForcibly mark
+        withServed ["L_answer"] ("trap 'touch " <> T.pack mark <> "' EXIT; " <> replying "2A-") $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          closeRegistry registry
+          doesFileExist mark `shouldReturn` True
+
+    it "leaves a registry that started no program alone" $
+      closeRegistry emptyRegistry `shouldReturn` ()

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -7,69 +7,61 @@
 module AtomsSpec (spec) where
 
 import AST
-import Atoms (Atom (..), Registry, Runtime (RtNode), Session (_program), closeRegistry, emptyRegistry, fireAtom, readRegistry, registeredAtom)
-import Control.Exception (SomeException, bracket, finally)
+import Atoms (Atom (..), Program (..), Registry, Runtime (RtNode), Session (_program), closeRegistry, emptyRegistry, fireAtom, readRegistry, registeredAtom)
+import Control.Exception (SomeException, finally)
 import Control.Monad (forM_)
-import Data.Aeson (Value, encode, object, (.=))
+import Data.Aeson (Value, object, (.=))
 import Data.Aeson.Key qualified as Key
-import Data.ByteString qualified as BS
-import Data.ByteString.Lazy qualified as BSL
+import Data.Aeson.Types (Pair)
 import Data.List (isInfixOf)
 import Data.Text qualified as T
-import Data.Text.Encoding (decodeUtf8, encodeUtf8)
-import Fixtures (resident, withExecutable, withNode, withRegistryOf, withScript, withShell)
+import Fixtures (resident, withExecutable, withNode, withRegistryOf, withScript, withShell, withTemp)
 import Parser (parseExpressionThrows)
 import System.Directory (doesFileExist, getTemporaryDirectory, removePathForcibly)
 import System.FilePath ((</>))
-import System.IO (Handle, hClose, openBinaryTempFile)
 import Test.Hspec
 import Text.Printf (printf)
 
--- A registry file holding the given content, removed afterwards
-withRegistry :: T.Text -> (FilePath -> IO a) -> IO a
-withRegistry content action = do
-  dir <- getTemporaryDirectory
-  bracket (openBinaryTempFile dir "phino-registry-.json") discarded $ \(path, handle) -> do
-    BS.hPut handle (encodeUtf8 content)
-    hClose handle
-    action path
-  where
-    discarded :: (FilePath, Handle) -> IO ()
-    discarded (path, handle) = hClose handle >> removePathForcibly path
+-- The registry of the given λ functions, every one of them the same entry
+registryOf :: [T.Text] -> [Pair] -> Value
+registryOf names fields = object [Key.fromText name .= object fields | name <- names]
 
--- The registry of one executable λ function, naming the given file. The path
--- goes through JSON encoding rather than into the text by hand, since a
--- Windows one spells its separators with the escape character of JSON
-executing :: FilePath -> T.Text
-executing file = decodeUtf8 (BSL.toStrict (encode (serving "exec" ["L_answer"] file)))
+-- The entry of a λ function run as the given file, which goes through JSON
+-- encoding rather than into text by hand, since a Windows path spells its
+-- separators with the escape character of JSON
+executing :: FilePath -> [Pair]
+executing file = ["rt" .= ("exec" :: T.Text), "path" .= file]
 
--- The registry of the given λ functions all served by, or executed as, the
--- given file
-serving :: T.Text -> [T.Text] -> FilePath -> Value
-serving runtime names file = object [Key.fromText name .= object ["rt" .= runtime, "path" .= file] | name <- names]
+-- The entry of a λ function run as the given script under node
+scripted :: T.Text -> [Pair]
+scripted script = ["rt" .= ("node" :: T.Text), "script" .= script]
 
--- The λ functions of the registry read from a file naming a resident program
--- built of the given per-request snippet (see 'resident'), stopped afterwards,
--- so that no spec leaves a shell behind
+-- The same entry, kept for the run
+served :: [Pair] -> [Pair]
+served fields = ("serve" .= True) : fields
+
+-- The λ functions of the given registry, read from a file, with every program
+-- it has started stopped afterwards, so that no spec leaves a process behind
+withRegistered :: Value -> (Registry -> IO a) -> IO a
+withRegistered registry action =
+  withRegistryOf registry $ \path -> do
+    atoms <- readRegistry path
+    action atoms `finally` closeRegistry atoms
+
+-- The λ functions of the registry naming a resident program built of the given
+-- per-request snippet (see 'resident') under every given name
 withServed :: [T.Text] -> T.Text -> (Registry -> IO a) -> IO a
 withServed names snippet action =
   withExecutable (resident snippet) $ \file ->
-    withRegistryOf (serving "serve" names file) $ \path -> do
-      registry <- readRegistry path
-      action registry `finally` closeRegistry registry
+    withRegistered (registryOf names (served (executing file))) action
 
 -- Fire the given λ function out of the registry, against the same formation
--- and universe 'fired' uses, unless a different universe is given
+-- 'fired' uses, inside the given universe
 firedFrom :: Registry -> T.Text -> String -> IO Expression
 firedFrom registry func universe = do
   form <- parseExpressionThrows "⟦ x ↦ ⟦ Δ ⤍ 01- ⟧ ⟧"
   univ <- parseExpressionThrows universe
   maybe (fail (printf "'%s' is not registered" (T.unpack func))) (\atom -> fireAtom func atom form univ) (registeredAtom registry func)
-
--- The path a served λ function is served from, if it is one
-servedFrom :: Maybe Atom -> Maybe FilePath
-servedFrom (Just (Served session)) = Just (_program session)
-servedFrom _ = Nothing
 
 -- Fire the λ function 'L_answer' out of the given atom, against a formation
 -- binding 'x' inside a universe binding 'y'
@@ -79,11 +71,45 @@ fired atom = do
   univ <- parseExpressionThrows "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
   fireAtom "L_answer" atom form univ
 
--- What the script wrote under 'n' has to come back parsed, so a case asserting
+-- The program a λ function is kept for the run with, if it is kept at all
+kept :: Maybe Atom -> Maybe Program
+kept (Just (Resident session)) = Just (_program session)
+kept _ = Nothing
+
+-- A script run once per fire, answering the request with the given JavaScript
+-- expression, in which 'lines' is every line phino said, 'universe' the one
+-- carrying '𝑒' and 'request' the one carrying 'id', so a case asserts on what
+-- phino says rather than on how a script reads it
+scripting :: T.Text -> T.Text
+scripting expr =
+  T.unlines
+    [ "const lines = require('fs').readFileSync(0, 'utf8').split('\\n').filter(Boolean).map((line) => JSON.parse(line));"
+    , "const universe = lines.find((message) => '𝑒' in message);"
+    , "const request = lines.find((message) => 'id' in message);"
+    , "process.stdout.write(JSON.stringify({id: request.id, '𝑛': " <> expr <> "}));"
+    ]
+
+-- A script reading phino's lines one by one until its stdin closes and
+-- answering every request with how many it has seen, so a case tells one
+-- process kept across fires from one started afresh for each
+counting :: T.Text
+counting =
+  T.unlines
+    [ "let seen = 0;"
+    , "require('readline').createInterface({input: process.stdin}).on('line', (line) => {"
+    , "  const message = JSON.parse(line);"
+    , "  if ('id' in message) {"
+    , "    seen += 1;"
+    , "    process.stdout.write(JSON.stringify({id: message.id, '𝑛': '⟦ Δ ⤍ 0' + seen + '- ⟧'}) + '\\n');"
+    , "  }"
+    , "});"
+    ]
+
+-- What the script wrote under '𝑛' has to come back parsed, so a case asserting
 -- on it says which expression it expects in 𝜑 rather than in constructors
 answers :: T.Text -> String -> Expectation
 answers script expected = withNode $ do
-  answer <- fired (Scripted RtNode script)
+  answer <- fired (Transient (Scripted RtNode script))
   wanted <- parseExpressionThrows expected
   answer `shouldBe` wanted
 
@@ -91,7 +117,7 @@ answers script expected = withNode $ do
 executes :: T.Text -> String -> Expectation
 executes script expected = withShell $
   withExecutable script $ \file -> do
-    answer <- fired (Executable file)
+    answer <- fired (Transient (Executable file))
     wanted <- parseExpressionThrows expected
     answer `shouldBe` wanted
 
@@ -104,8 +130,15 @@ serves snippet expected = withShell $
     wanted <- parseExpressionThrows expected
     answer `shouldBe` wanted
 
--- A firing of a served atom that has to fail, with the reason naming the given
+-- A firing of a script that has to fail, with the reason naming the given
 -- fragments
+fails :: T.Text -> [String] -> Expectation
+fails script fragments =
+  withNode $
+    fired (Transient (Scripted RtNode script))
+      `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
+
+-- The same, for a served atom
 refuses :: T.Text -> [String] -> Expectation
 refuses snippet fragments = withShell $
   withServed ["L_answer"] snippet $ \registry ->
@@ -115,13 +148,6 @@ refuses snippet fragments = withShell $
 -- The reply of a resident program answering the request with the given bytes
 replying :: T.Text -> T.Text
 replying bytes = "printf '{\"id\": %s, \"𝑛\": \"⟦ Δ ⤍ %s ⟧\"}\\n' \"$id\" \"" <> bytes <> "\""
-
--- A firing that has to fail, with the reason naming the given fragments
-fails :: T.Text -> [String] -> Expectation
-fails script fragments =
-  withNode $
-    fired (Scripted RtNode script)
-      `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
 
 spec :: Spec
 spec = do
@@ -133,81 +159,93 @@ spec = do
 
   describe "readRegistry" $ do
     it "reads a λ function together with its runtime and script" $
-      withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
+      withRegistryOf (registryOf ["L_answer"] (scripted "say(1)")) $ \path -> do
         registry <- readRegistry path
-        registeredAtom registry "L_answer" `shouldBe` Just (Scripted RtNode "say(1)")
+        registeredAtom registry "L_answer" `shouldBe` Just (Transient (Scripted RtNode "say(1)"))
 
     -- An atom the object model brought as a binary of its own names no
     -- interpreter at all, only the file phino is to run
     it "reads an executable λ function as the file it runs" $
       withShell $
         withExecutable "" $ \file ->
-          withRegistry (executing file) $ \path -> do
+          withRegistryOf (registryOf ["L_answer"] (executing file)) $ \path -> do
             registry <- readRegistry path
-            registeredAtom registry "L_answer" `shouldBe` Just (Executable file)
+            registeredAtom registry "L_answer" `shouldBe` Just (Transient (Executable file))
 
-    it "reads a served λ function as the file it is served from" $
+    -- Whether a program is kept for the run is its own flag, so any program
+    -- may be kept, whatever runs it
+    it "keeps an executable λ function for the run when its entry says serve" $
       withShell $
         withExecutable "" $ \file ->
-          withRegistryOf (serving "serve" ["L_answer"] file) $ \path -> do
+          withRegistryOf (registryOf ["L_answer"] (served (executing file))) $ \path -> do
             registry <- readRegistry path
-            servedFrom (registeredAtom registry "L_answer") `shouldBe` Just file
+            kept (registeredAtom registry "L_answer") `shouldBe` Just (Executable file)
+
+    it "keeps a script for the run when its entry says serve" $
+      withRegistryOf (registryOf ["L_answer"] (served (scripted "say(1)"))) $ \path -> do
+        registry <- readRegistry path
+        kept (registeredAtom registry "L_answer") `shouldBe` Just (Scripted RtNode "say(1)")
+
+    it "starts a program afresh for every fire when its entry says not to serve" $
+      withRegistryOf (registryOf ["L_answer"] (("serve" .= False) : scripted "say(1)")) $ \path -> do
+        registry <- readRegistry path
+        registeredAtom registry "L_answer" `shouldBe` Just (Transient (Scripted RtNode "say(1)"))
 
     it "leaves a name the file does not carry unregistered" $
-      withRegistry "{\"L_answer\": {\"rt\": \"node\", \"script\": \"say(1)\"}}" $ \path -> do
+      withRegistryOf (registryOf ["L_answer"] (scripted "say(1)")) $ \path -> do
         registry <- readRegistry path
         registeredAtom registry "L_bytes_eq" `shouldBe` Nothing
 
-    -- An unknown runtime is refused where the file is read, which is before any
+    -- A malformed entry is refused where the file is read, which is before any
     -- dataization starts, rather than at the moment an atom of it would fire
     forM_
       [
         ( "the runtime is not one phino can run"
-        , "{\"L_answer\": {\"rt\": \"ruby\", \"script\": \"say(1)\"}}"
+        , registryOf ["L_answer"] ["rt" .= ("ruby" :: T.Text), "script" .= ("say(1)" :: T.Text)]
         , ["unknown runtime 'ruby'", "node"]
         )
       ,
         ( "an entry carries no script"
-        , "{\"L_answer\": {\"rt\": \"node\"}}"
+        , registryOf ["L_answer"] ["rt" .= ("node" :: T.Text)]
         , ["script"]
         )
       ,
         ( "an entry carries no runtime"
-        , "{\"L_answer\": {\"script\": \"say(1)\"}}"
+        , registryOf ["L_answer"] ["script" .= ("say(1)" :: T.Text)]
         , ["rt"]
         )
       ,
         ( "an executable entry carries no path"
-        , "{\"L_answer\": {\"rt\": \"exec\"}}"
+        , registryOf ["L_answer"] ["rt" .= ("exec" :: T.Text)]
         , ["path"]
         )
       ,
         ( "the executable file is not there"
-        , "{\"L_answer\": {\"rt\": \"exec\", \"path\": \"no-such-atom\"}}"
+        , registryOf ["L_answer"] (executing "no-such-atom")
         , ["L_answer", "no-such-atom", "there is no such file"]
         )
       ,
-        ( "a served entry carries no path"
-        , "{\"L_answer\": {\"rt\": \"serve\"}}"
-        , ["path"]
-        )
-      ,
-        ( "the served file is not there"
-        , "{\"L_answer\": {\"rt\": \"serve\", \"path\": \"no-such-atom\"}}"
+        ( "the file to serve from is not there"
+        , registryOf ["L_answer"] (served (executing "no-such-atom"))
         , ["L_answer", "no-such-atom", "there is no such file"]
         )
       ,
-        ( "the file is not JSON at all"
-        , "L_answer: js"
-        , ["cannot be read"]
+        ( "serve is not a boolean"
+        , registryOf ["L_answer"] (("serve" .= ("yes" :: T.Text)) : scripted "say(1)")
+        , ["serve", "Bool"]
         )
       ]
-      ( \(desc, content, fragments) ->
+      ( \(desc, registry, fragments) ->
           it ("fails when " ++ desc) $
-            withRegistry content $ \path ->
+            withRegistryOf registry $ \path ->
               readRegistry path
                 `shouldThrow` (\failure -> all (`isInfixOf` show (failure :: SomeException)) fragments)
       )
+
+    it "fails when the file is not JSON at all" $
+      withTemp "phino-atoms-.json" "L_answer: js" $ \path ->
+        readRegistry path
+          `shouldThrow` (\failure -> "cannot be read" `isInfixOf` show (failure :: SomeException))
 
     it "fails when the file is not there" $
       readRegistry "no-such-registry.json"
@@ -217,78 +255,102 @@ spec = do
     -- the atom would fire
     it "fails when the file of an executable λ function cannot be run" $
       withScript "" $ \file ->
-        withRegistry (executing file) $ \path ->
+        withRegistryOf (registryOf ["L_answer"] (executing file)) $ \path ->
           readRegistry path
             `shouldThrow` (\failure -> "not executable" `isInfixOf` show (failure :: SomeException))
 
-    it "fails when the file of a served λ function cannot be run" $
+    it "fails when the file to serve from cannot be run" $
       withScript "" $ \file ->
-        withRegistryOf (serving "serve" ["L_answer"] file) $ \path ->
+        withRegistryOf (registryOf ["L_answer"] (served (executing file))) $ \path ->
           readRegistry path
             `shouldThrow` (\failure -> "not executable" `isInfixOf` show (failure :: SomeException))
 
   describe "fireAtom" $ do
-    it "hands back the 𝜑-expression the script wrote under 'n'" $
-      answers "process.stdout.write(JSON.stringify({n: '⟦ Δ ⤍ 2A- ⟧'}))" "⟦ Δ ⤍ 2A- ⟧"
+    -- Every program is spoken to in the letters of the evaluation rule of the
+    -- calculus, 𝔼(𝑏, 𝑒, 𝑠) = 𝑛, one JSON object per line, whether it is
+    -- started for the fire or kept for the run
+    it "hands back the 𝜑-expression the script wrote under '𝑛'" $
+      answers (scripting "'⟦ Δ ⤍ 2A- ⟧'") "⟦ Δ ⤍ 2A- ⟧"
 
-    -- One script may stand for several λ functions, so the name of the one
-    -- being fired is its first command-line argument — where node puts it
-    it "names the λ function being fired as the first command-line argument" $
+    -- One script may stand for several λ functions, so every request names
+    -- the one being fired
+    it "names the λ function being fired under 'λ' in the request" $
       answers
-        "process.stdout.write(JSON.stringify({n: process.argv[2] === 'L_answer' ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        (scripting "request['λ'] === 'L_answer' ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'")
         "⟦ Δ ⤍ FF- ⟧"
 
-    -- The formation being evaluated arrives under 'b' and the universe Φ under
-    -- 's', both as 𝜑 text on stdin
-    it "feeds the formation and the universe to the script on stdin" $
+    it "carries the formation under '𝑏' in the request and the universe under '𝑒'" $
       answers
-        "const {b, s} = JSON.parse(require('fs').readFileSync(0, 'utf8'));\
-        \process.stdout.write(JSON.stringify({n: b.includes('x ↦') && s.includes('y ↦') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        (scripting "request['𝑏'].includes('x ↦') && universe['𝑒'].includes('y ↦') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'")
+        "⟦ Δ ⤍ FF- ⟧"
+
+    it "tells the script the universe before the request" $
+      answers
+        (scripting "'𝑒' in lines[0] && 'id' in lines[1] ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'")
         "⟦ Δ ⤍ FF- ⟧"
 
     -- Neither payload carries syntax sugar, whatever '--sweet' says about the
     -- output of the run, so a script finds every datum spelled as a Δ binding
     it "spells the payloads as canonical 𝜑-calculus" $
       answers
-        "const {b} = JSON.parse(require('fs').readFileSync(0, 'utf8'));\
-        \process.stdout.write(JSON.stringify({n: b.includes('Δ ⤍ 01-') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'}))"
+        (scripting "request['𝑏'].includes('Δ ⤍ 01-') ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'")
         "⟦ Δ ⤍ FF- ⟧"
 
+    -- A script started for the fire is asked one request, the first, so it
+    -- may answer without reading anything at all
     it "reads a script that says nothing to stdin without waiting for it" $
-      answers "process.stdout.write(JSON.stringify({n: '⟦ Δ ⤍ 01- ⟧'}))" "⟦ Δ ⤍ 01- ⟧"
+      answers "process.stdout.write(JSON.stringify({id: 1, '𝑛': '⟦ Δ ⤍ 01- ⟧'}))" "⟦ Δ ⤍ 01- ⟧"
+
+    -- The stdin of a script started for the fire closes behind the request,
+    -- so a script that reads line by line answers and quits on its own, the
+    -- same as it would were it kept for the run
+    it "lets a script that reads line by line answer and quit on its own" $
+      answers counting "⟦ Δ ⤍ 01- ⟧"
 
     it "fails with the script's own complaint when it exits non-zero" $
       fails
         "process.stderr.write('no idea what to do');process.exit(4)"
         ["L_answer", "exit code 4", "no idea what to do"]
 
+    -- A script is judged by its exit status even once it has answered, since
+    -- an answer it did not stand behind is no answer
+    it "fails when the script answers and then exits non-zero" $
+      fails
+        "process.stdout.write(JSON.stringify({id: 1, '𝑛': '⟦ Δ ⤍ 2A- ⟧'}) + '\\n');process.exit(2)"
+        ["L_answer", "exit code 2"]
+
     it "fails when the script writes something other than JSON" $
       fails "process.stdout.write('almost')" ["L_answer", "almost"]
 
-    it "fails when the script writes JSON with no 'n' in it" $
-      fails "process.stdout.write(JSON.stringify({m: '⟦ ⟧'}))" ["L_answer", "n"]
+    it "fails when the script writes JSON with no '𝑛' in it" $
+      fails "process.stdout.write(JSON.stringify({id: 1, m: '⟦ ⟧'}))" ["L_answer", "𝑛"]
 
-    it "fails when what the script put under 'n' is not a 𝜑-expression" $
-      fails "process.stdout.write(JSON.stringify({n: '⟦ ⟧⟧'}))" ["L_answer"]
+    it "fails when the script answers another request" $
+      fails "process.stdout.write(JSON.stringify({id: 7, '𝑛': '⟦ Δ ⤍ 2A- ⟧'}))" ["L_answer", "request 7"]
+
+    it "fails when what the script put under '𝑛' is not a 𝜑-expression" $
+      fails "process.stdout.write(JSON.stringify({id: 1, '𝑛': '⟦ ⟧⟧'}))" ["L_answer"]
 
     -- An executable atom is spawned as it is, under no interpreter, so phino
     -- stages nothing of it and the file speaks the same protocol a script does
     it "runs an executable λ function straight off its path" $
-      executes "echo '{\"n\": \"⟦ Δ ⤍ 2A- ⟧\"}'" "⟦ Δ ⤍ 2A- ⟧"
+      executes "echo '{\"id\": 1, \"𝑛\": \"⟦ Δ ⤍ 2A- ⟧\"}'" "⟦ Δ ⤍ 2A- ⟧"
 
-    it "names the λ function being fired as the first argument of an executable" $
+    it "speaks the same lines to an executable as to a script" $
       executes
-        "if [ \"$1\" = L_answer ]; then echo '{\"n\": \"⟦ Δ ⤍ FF- ⟧\"}'; else echo '{\"n\": \"⟦ Δ ⤍ 00- ⟧\"}'; fi"
+        "case \"$(cat)\" in *'\"λ\":\"L_answer\"'*) echo '{\"id\": 1, \"𝑛\": \"⟦ Δ ⤍ FF- ⟧\"}';; *) echo '{\"id\": 1, \"𝑛\": \"⟦ Δ ⤍ 00- ⟧\"}';; esac"
         "⟦ Δ ⤍ FF- ⟧"
 
-    it "feeds the formation and the universe to an executable on stdin" $
-      executes
-        "case \"$(cat)\" in *'x ↦'*) echo '{\"n\": \"⟦ Δ ⤍ FF- ⟧\"}';; *) echo '{\"n\": \"⟦ Δ ⤍ 00- ⟧\"}';; esac"
-        "⟦ Δ ⤍ FF- ⟧"
+    -- A program kept for the run is asked over the streams of one process,
+    -- whatever runs it, so a script that counts its requests sees them all
+    it "keeps a script that serves across the fires" $
+      withNode $
+        withRegistered (registryOf ["L_answer"] (served (scripted counting))) $ \registry -> do
+          _ <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          second <- firedFrom registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧"
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
+          second `shouldBe` wanted
 
-    -- A served atom is asked over the streams of a program that stays for the
-    -- run, one line per fire, so the program speaks another protocol than a
-    -- one-shot one: the letters of the evaluation rule of the calculus
     it "hands back the 𝜑-expression the resident program wrote under '𝑛'" $
       serves (replying "2A-") "⟦ Δ ⤍ 2A- ⟧"
 
@@ -329,16 +391,6 @@ spec = do
           wanted <- parseExpressionThrows "⟦ Δ ⤍ 02- ⟧"
           second `shouldBe` wanted
 
-    it "names the λ function being fired under 'λ' in the request" $
-      serves
-        ("case \"$line\" in *'\"λ\":\"L_answer\"'*) " <> replying "FF-" <> ";; *) " <> replying "00-" <> ";; esac")
-        "⟦ Δ ⤍ FF- ⟧"
-
-    it "carries the formation under '𝑏' in the request" $
-      serves
-        ("case \"$line\" in *'x ↦'*) " <> replying "FF-" <> ";; *) " <> replying "00-" <> ";; esac")
-        "⟦ Δ ⤍ FF- ⟧"
-
     it "fails when the resident program answers another request" $
       refuses "printf '{\"id\": 99, \"𝑛\": \"⟦ Δ ⤍ 2A- ⟧\"}\\n'" ["L_answer", "request 99"]
 
@@ -350,12 +402,6 @@ spec = do
 
     it "fails when the resident program writes something other than JSON" $
       refuses "echo almost" ["L_answer", "almost"]
-
-    it "fails when the resident program writes JSON with no '𝑛' in it" $
-      refuses "printf '{\"id\": %s, \"m\": \"⟦ ⟧\"}\\n' \"$id\"" ["L_answer", "𝑛"]
-
-    it "fails when what the resident program put under '𝑛' is not a 𝜑-expression" $
-      refuses "printf '{\"id\": %s, \"𝑛\": \"⟦ ⟧⟧\"}\\n' \"$id\"" ["L_answer"]
 
   describe "closeRegistry" $ do
     -- The program is told to quit by its stdin closing, which its read loop

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -12,10 +12,11 @@ import Control.Exception
 import Control.Monad (forM_, unless)
 import Data.Char (isDigit)
 import Data.List (intercalate, isInfixOf, isPrefixOf, sort)
+import Data.Text qualified as T
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
-import Fixtures (withFixtureRegistry, withNode)
+import Fixtures (withFixtureRegistry, withNode, withServing, withShell)
 import GHC.IO.Handle
 import Paths_phino (version)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, removeFile, removePathForcibly, setModificationTime)
@@ -398,6 +399,16 @@ spec = do
           length files `shouldBe` 4
           doesFileExist (dir ++ "/00001.phi") `shouldReturn` True
           doesFileExist (dir ++ "/00003.phi") `shouldReturn` True
+
+    -- A served atom is asked over the streams of one resident program that
+    -- 'phino' starts on the first fire and stops when the run is over, so the
+    -- whole of it goes through the command line here: registry, program and
+    -- the bytes it answers with
+    it "dataizes with an atom served by a resident program" $
+      withShell $
+        withServing (T.pack "printf '{\"id\": %s, \"𝑛\": \"⟦ Δ ⤍ 2A- ⟧\"}\\n' \"$id\"") $ \registry ->
+          withStdin "⟦ @ ↦ ⟦ λ ⤍ L_answer ⟧ ⟧" $
+            testCLISucceeded ["dataize", "--atoms=" ++ registry] ["2A-"]
 
     it "saves dataize steps to dir with --steps-dir" $
       withAtoms $ \atoms ->

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -6,9 +6,9 @@
 -- The λ functions the specs fire. phino implements none of them, so a spec that
 -- needs an atom to answer brings its own: one JavaScript fixture,
 -- 'test-resources/atoms/primitives.js', registered under every name in
--- 'fixtureAtoms' and branching on the one it is handed as its first
--- command-line argument, or a POSIX shell script written for the occasion,
--- either run once per fire or kept resident for the run.
+-- 'fixtureAtoms' and branching on the one each request names under 'λ', or a
+-- POSIX shell script written for the occasion, either run once per fire or
+-- kept resident for the run.
 module Fixtures
   ( fixtureAtoms
   , fixtureRegistry
@@ -20,10 +20,11 @@ module Fixtures
   , withScript
   , withServing
   , withShell
+  , withTemp
   )
 where
 
-import Atoms (Atom (..), Registry, Runtime (RtNode))
+import Atoms (Atom (..), Program (..), Registry, Runtime (RtNode))
 import Control.Exception (bracket)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.Aeson.Key qualified as Key
@@ -59,7 +60,7 @@ fixtureScript = decodeUtf8 <$> BS.readFile "test-resources/atoms/primitives.js"
 fixtureRegistry :: IO Registry
 fixtureRegistry = do
   script <- fixtureScript
-  pure (Map.fromList [(name, Scripted RtNode script) | name <- fixtureAtoms])
+  pure (Map.fromList [(name, Transient (Scripted RtNode script)) | name <- fixtureAtoms])
 
 -- The same registry as the JSON file '--atoms' reads, in a temporary file
 -- removed afterwards, for the specs that go through the command line.
@@ -105,19 +106,20 @@ withExecutable script action = withScript script $ \path -> do
   setPermissions path (setOwnerExecutable True permissions)
   action path
 
--- The registry of one served λ function, 'L_answer', as the JSON file
--- '--atoms' reads, together with the resident program it names: a POSIX shell
--- script built of the given per-request snippet (see 'resident'). Both files
--- are removed afterwards.
+-- The registry of one λ function, 'L_answer', kept for the run, as the JSON
+-- file '--atoms' reads, together with the resident program it names: a POSIX
+-- shell script built of the given per-request snippet (see 'resident'). Both
+-- files are removed afterwards.
 withServing :: T.Text -> (FilePath -> IO a) -> IO a
 withServing snippet action =
   withExecutable (resident snippet) $ \program ->
-    withRegistryOf (object ["L_answer" .= object ["rt" .= ("serve" :: T.Text), "path" .= program]]) action
+    withRegistryOf (object ["L_answer" .= object ["rt" .= ("exec" :: T.Text), "path" .= program, "serve" .= True]]) action
 
--- A resident program as a POSIX shell script: it reads phino's lines until its
--- stdin closes, counts the universes it is told in 'e', and runs the given
--- snippet for every request, with the request in 'line', its number in 'id'
--- and how many requests it has seen so far in 'n'.
+-- A program as a POSIX shell script that reads phino's lines until its stdin
+-- closes, so it serves started once per fire and kept for the run alike: it
+-- counts the universes it is told in 'e' and runs the given snippet for every
+-- request, with the request in 'line', its number in 'id' and how many
+-- requests it has seen so far in 'n'.
 resident :: T.Text -> T.Text
 resident snippet =
   T.unlines

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -24,13 +24,12 @@ module Fixtures
   )
 where
 
-import Atoms (Atom (..), Program (..), Registry, Runtime (RtNode))
+import Atoms (Registry, readRegistry)
 import Control.Exception (bracket)
 import Data.Aeson (Value, encode, object, (.=))
 import Data.Aeson.Key qualified as Key
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
-import Data.Map.Strict qualified as Map
 import Data.Maybe (isNothing)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
@@ -56,11 +55,10 @@ fixtureAtoms =
 fixtureScript :: IO T.Text
 fixtureScript = decodeUtf8 <$> BS.readFile "test-resources/atoms/primitives.js"
 
--- The registry the specs that drive 'Dataize' directly run against.
+-- The registry the specs that drive 'Dataize' directly run against: the same
+-- file '--atoms' reads, read once and gone.
 fixtureRegistry :: IO Registry
-fixtureRegistry = do
-  script <- fixtureScript
-  pure (Map.fromList [(name, Transient (Scripted RtNode script)) | name <- fixtureAtoms])
+fixtureRegistry = withFixtureRegistry readRegistry
 
 -- The same registry as the JSON file '--atoms' reads, in a temporary file
 -- removed afterwards, for the specs that go through the command line.

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -7,21 +7,35 @@
 -- needs an atom to answer brings its own: one JavaScript fixture,
 -- 'test-resources/atoms/primitives.js', registered under every name in
 -- 'fixtureAtoms' and branching on the one it is handed as its first
--- command-line argument.
-module Fixtures (fixtureAtoms, fixtureRegistry, withFixtureRegistry, withNode) where
+-- command-line argument, or a POSIX shell script written for the occasion,
+-- either run once per fire or kept resident for the run.
+module Fixtures
+  ( fixtureAtoms
+  , fixtureRegistry
+  , resident
+  , withExecutable
+  , withFixtureRegistry
+  , withNode
+  , withRegistryOf
+  , withScript
+  , withServing
+  , withShell
+  )
+where
 
 import Atoms (Atom (..), Registry, Runtime (RtNode))
 import Control.Exception (bracket)
-import Data.Aeson (encode, object, (.=))
+import Data.Aeson (Value, encode, object, (.=))
 import Data.Aeson.Key qualified as Key
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BSL
 import Data.Map.Strict qualified as Map
 import Data.Maybe (isNothing)
 import Data.Text qualified as T
-import Data.Text.Encoding (decodeUtf8)
-import System.Directory (findExecutable, getTemporaryDirectory, removePathForcibly)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import System.Directory (findExecutable, getPermissions, getTemporaryDirectory, removePathForcibly, setOwnerExecutable, setPermissions)
 import System.IO (Handle, hClose, openBinaryTempFile)
+import System.Info (os)
 import Test.Hspec (Expectation, pendingWith)
 
 -- Every λ function the fixture answers for. A name outside this list is
@@ -52,15 +66,15 @@ fixtureRegistry = do
 withFixtureRegistry :: (FilePath -> IO a) -> IO a
 withFixtureRegistry action = do
   script <- fixtureScript
-  dir <- getTemporaryDirectory
-  bracket (openBinaryTempFile dir "phino-atoms-.json") discarded $ \(path, handle) -> do
-    BSL.hPut handle (encode (object [Key.fromText name .= entry script | name <- fixtureAtoms]))
-    hClose handle
-    action path
+  withRegistryOf (object [Key.fromText name .= entry script | name <- fixtureAtoms]) action
   where
+    entry :: T.Text -> Value
     entry script = object ["rt" .= ("node" :: T.Text), "script" .= script]
-    discarded :: (FilePath, Handle) -> IO ()
-    discarded (path, handle) = hClose handle >> removePathForcibly path
+
+-- The given JSON, as the registry file '--atoms' reads, in a temporary file
+-- removed afterwards.
+withRegistryOf :: Value -> (FilePath -> IO a) -> IO a
+withRegistryOf registry = withTemp "phino-atoms-.json" (BSL.toStrict (encode registry))
 
 -- Every atom the fixture provides runs under 'node', so a machine without it
 -- cannot fire one at all: such an expectation is pending rather than red.
@@ -70,3 +84,62 @@ withNode expectation = do
   if isNothing node
     then pendingWith "'node' is not installed, so no λ function can be fired"
     else expectation
+
+-- A POSIX shell script is executable nowhere on Windows, so a case that needs
+-- one is pending there rather than red.
+withShell :: Expectation -> Expectation
+withShell expectation
+  | os == "mingw32" = pendingWith "no POSIX shell script is executable on Windows"
+  | otherwise = expectation
+
+-- A file in the temporary directory holding the given POSIX shell script,
+-- removed afterwards.
+withScript :: T.Text -> (FilePath -> IO a) -> IO a
+withScript script = withTemp "phino-exec-.sh" (encodeUtf8 (T.unlines ["#!/bin/sh", script]))
+
+-- The same file, executable, which is what an 'exec' or a 'serve' atom names
+-- and phino never stages itself.
+withExecutable :: T.Text -> (FilePath -> IO a) -> IO a
+withExecutable script action = withScript script $ \path -> do
+  permissions <- getPermissions path
+  setPermissions path (setOwnerExecutable True permissions)
+  action path
+
+-- The registry of one served λ function, 'L_answer', as the JSON file
+-- '--atoms' reads, together with the resident program it names: a POSIX shell
+-- script built of the given per-request snippet (see 'resident'). Both files
+-- are removed afterwards.
+withServing :: T.Text -> (FilePath -> IO a) -> IO a
+withServing snippet action =
+  withExecutable (resident snippet) $ \program ->
+    withRegistryOf (object ["L_answer" .= object ["rt" .= ("serve" :: T.Text), "path" .= program]]) action
+
+-- A resident program as a POSIX shell script: it reads phino's lines until its
+-- stdin closes, counts the universes it is told in 'e', and runs the given
+-- snippet for every request, with the request in 'line', its number in 'id'
+-- and how many requests it has seen so far in 'n'.
+resident :: T.Text -> T.Text
+resident snippet =
+  T.unlines
+    [ "e=0"
+    , "n=0"
+    , "while IFS= read -r line; do"
+    , "  case \"$line\" in"
+    , "    *'\"𝑒\"'*) e=$((e+1));;"
+    , "    *) n=$((n+1)); id=$(printf '%s' \"$line\" | sed 's/.*\"id\":\\([0-9]*\\).*/\\1/'); " <> snippet <> ";;"
+    , "  esac"
+    , "done"
+    ]
+
+-- Write the content to a fresh temporary file, hand its path to the action and
+-- delete the file afterwards.
+withTemp :: String -> BS.ByteString -> (FilePath -> IO a) -> IO a
+withTemp template content action = do
+  dir <- getTemporaryDirectory
+  bracket (openBinaryTempFile dir template) discarded $ \(path, handle) -> do
+    BS.hPut handle content
+    hClose handle
+    action path
+  where
+    discarded :: (FilePath, Handle) -> IO ()
+    discarded (path, handle) = hClose handle >> removePathForcibly path


### PR DESCRIPTION
Every atom program is now talked to the same way, whether phino starts it for one fire or keeps it for the run: one JSON object per line, in the letters of the evaluation rule of the calculus paper, 𝔼(𝑏, 𝑒, 𝑠) = 𝑛. The universe goes under `𝑒` in a line of its own, then a request carries an `id`, the λ name under `λ` and the formation under `𝑏`, and the program answers with the same `id` under `𝑛`. A one-shot program has its stdin closed behind the request, so it may slurp its input or read it line by line, and the very same program works both ways. The λ name is no longer passed on the command line, since every request names it.

Whether a program is kept for the run is a boolean `serve` on any registry entry, off by default, rather than a runtime of its own, so a `node` script can be resident just as an `exec` file can. Every λ name registered on the same program is served by one process; the runners close the registry when the run is over, closing the program's stdin as its cue to quit and terminating it if it has not quit within a second. A reply that is not JSON, lacks `𝑛`, answers another `id`, a program that quits without answering, or a one-shot program that exits non-zero fails the run with the program's stderr in the message.

The keys of the registry are regular expressions over λ names, tried top to bottom in the order the file lists them, and the first one matching the whole name wins. So one entry such as `".*"` with `"serve": true` stands for every atom an object model brings, instead of the same program being spelled once per name, while a plain name still means that one atom. Since aeson forgets the order of keys, the registry is walked token by token; a key that is not a regular expression, a file that is not a JSON object, or text after the object are refused where the file is read.

The README documents the protocol, the flag and the keys, and the test fixture `primitives.js` reads lines with `readline`, so it stands as an example of a program that runs either way. The old `b`/`s`/`n` payload is gone, so every registered script has to move to the new lines.

Closes #1121
