### PR TITLE
fix(xmir): read and write the terminator base="⊥" (#1128)

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -97,6 +97,7 @@ object attrs children = NodeElement (element "o" attrs children)
 expression :: Expression -> XmirContext -> IO (String, [Node])
 expression ExXi _ = pure (printExpression ExXi, [])
 expression ExRoot _ = pure (printExpression ExRoot, [])
+expression ExTermination _ = pure ("⊥", [])
 expression (ExFormation bds) ctx = do
   nested <- nestedBindings bds ctx
   pure ("", nested)
@@ -484,6 +485,10 @@ xmirToExpression cur fqn
           if null (cur C.$/ C.element (toName "o"))
             then pure ExRoot
             else throwIO (InvalidXMIRFormat "Application of 'Φ' is illegal in XMIR" cur)
+        "⊥" ->
+          if null (cur C.$/ C.element (toName "o"))
+            then pure ExTermination
+            else throwIO (InvalidXMIRFormat "Application of '⊥' is illegal in XMIR" cur)
         'Φ' : '.' : rest -> xmirToExpression' ExRoot "Φ" rest cur fqn
         'ξ' : '.' : rest -> xmirToExpression' ExXi "ξ" rest cur fqn
         _ -> throwIO (InvalidXMIRFormat "The @base attribute must be either ['∅'|'Φ'] or start with ['Φ.'|'ξ.'|'.']" cur)

--- a/test-resources/xmir-parsing-packs/termination-base.yaml
+++ b/test-resources/xmir-parsing-packs/termination-base.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="app">
+      <o name="x" base="⊥"/>
+    </o>
+  </object>
+phi: '[[ app -> [[ x -> T ]] ]]'

--- a/test-resources/xmir-parsing-packs/termination-with-application.yaml
+++ b/test-resources/xmir-parsing-packs/termination-with-application.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+failure: true
+xmir: |
+  <object>
+    <o name="app">
+      <o base="⊥">
+        <o base="Φ.number"/>
+      </o>
+    </o>
+  </object>
+phi: ''

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -219,7 +219,6 @@ spec = do
       , "Q"
       , "$"
       , "[[ x -> T ]]"
-      , "[[ top -> [[ x -> T ]] ]]"
       , "[[ x -> [[ !t1 -> 5 ]] ]]"
       , "[[ org -> [[ z -> ?, L> Package ]] ]]"
       ]
@@ -271,7 +270,7 @@ spec = do
       ,
         ( "explains an unsupported nested expression"
         , do
-            expr <- parseExpressionThrows "[[ x -> [[ y -> T ]] ]]"
+            expr <- parseExpressionThrows "[[ x -> [[ y -> !e1 ]] ]]"
             try (void (expressionToXMIR expr defaultXmirContext)) :: IO (Either SomeException ())
         , ["XMIR does not support such expression"]
         )


### PR DESCRIPTION
Fixes #1128 

## Problem

The XMIR reader rejected any element whose `@base` was the terminator `⊥`. The `case base of` ladder at `src/XMIR.hs:489` handled `.`-prefixed dispatch, `ξ`, `Φ` and their chains, but `⊥` fell into the catch-all that threw `InvalidXMIRFormat`. Since the EO compiler emits `base="⊥"` in 79 nodes across 32 of 173 parsed XMIR files, phino could not read most eo-runtime programs

The writer had the mirror problem: `expression` at `src/XMIR.hs:100..152` had no `ExTermination` clause, so serializing any formation containing `T` fell through to `UnsupportedExpression`

## Fix

Two one-line clauses:

1. **Reader** (`src/XMIR.hs`): `"⊥" -> pure ExTermination`, rejecting children the same way `Φ` and `ξ` do.
2. **Writer** (`src/XMIR.hs`): `expression ExTermination _ = pure ("⊥", [])`

## Changes

| File | What |
|------|------|
| `src/XMIR.hs` | Reader: `⊥` branch next to `Φ`/`ξ`; Writer: `ExTermination` clause |
| `test-resources/xmir-parsing-packs/termination-base.yaml` | `base="⊥"` → `T` round-trip |
| `test-resources/xmir-parsing-packs/termination-with-application.yaml` | `base="⊥"` with children rejected |
| `test/XMIRSpec.hs` | Removed `[[ top -> [[ x -> T ]] ]]` from prohibit (now serializes); replaced `[[ x -> [[ y -> T ]] ]]` with meta-variable expression in exception-message test |

## Verification

- Round-trip: `[[ app -> [[ x -> T ]] ]]` → XMIR with `<o base="⊥" name="x"/>` → `⟦ app ↦ ⟦ x ↦ ⊥ ⟧ ⟧` ✓
- XMIR spec: 98 examples, 0 failures
- Full suite: 2347 examples, 13 pre-existing LocatorSpec failures (GHC 9.10.3 backtrace, unrelated)
- `hlint` and `fourmolu --mode check` clean