### PR TITLE
fix(print): guard short-byte numbers in printer, XMIR writer and string() (#1129)

### DIFF
--- a/src/CST.hs
+++ b/src/CST.hs
@@ -11,7 +11,7 @@
 module CST where
 
 import AST
-import Bytes (NonFinite, btsToNonFinite, btsToNum, btsToStr)
+import Bytes (NonFinite, btsSize, btsToNonFinite, btsToNum, btsToStr)
 import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified Yaml as Y
@@ -270,6 +270,8 @@ expressionToCSTFrom tabs expr = toCST expr (tabs, EOL)
 -- pattern, such as a NaN carrying a payload, is kept in its byte form so that
 -- no bit of it is lost.
 sweetNumber :: Bytes -> Bool
+sweetNumber bts
+  | btsSize bts /= 8 = False
 sweetNumber bts = case btsToNum bts of
   Right dbl | isNaN dbl || isInfinite dbl -> isJust (btsToNonFinite bts)
   _ -> True

--- a/src/Functions.hs
+++ b/src/Functions.hs
@@ -169,7 +169,10 @@ _string :: BuildTermMethod
 _string [Y.ArgExpression expr] subst = do
   expr' <- buildExpressionThrows expr subst
   str <- case expr' of
-    DataNumber bts -> pure (DataString (strToBts (either show show (btsToNum bts))))
+    DataNumber bts
+      | btsSize bts /= 8 ->
+          throwIO (userError (printf "Expected 8 bytes for a number, got %d" (btsSize bts)))
+      | otherwise -> pure (DataString (strToBts (either show show (btsToNum bts))))
     DataString bts -> pure (DataString bts)
     ex ->
       throwIO

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -22,7 +22,7 @@ module XMIR
 where
 
 import AST
-import Bytes (btsToNum, btsToStr, bytesToBts)
+import Bytes (btsSize, btsToNum, btsToStr, bytesToBts)
 import Control.Exception (Exception (displayException), throwIO)
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldlM)
@@ -116,7 +116,7 @@ expression (DataNumber bytes) XmirContext{..} =
           [object [("as", "data")] [NodeContent (T.pack (printBytes bytes))]]
    in pure
         ( "Φ.number"
-        , if _omitComments
+        , if _omitComments || btsSize bytes /= 8
             then [bts]
             else
               [ NodeComment (T.pack (either show show (btsToNum bytes)))

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -150,6 +150,8 @@ spec = do
       , ("is true for negative infinity", BtMany ["FF", "F0", "00", "00", "00", "00", "00", "00"], True)
       , ("is false for a NaN carrying a payload", BtMany ["7F", "F8", "00", "00", "00", "00", "00", "01"], False)
       , ("is false for the negative quiet NaN", BtMany ["FF", "F8", "00", "00", "00", "00", "00", "00"], False)
+      , ("is false for fewer than eight bytes", BtOne "21", False)
+      , ("is false for empty bytes", BtEmpty, False)
       ]
       (\(desc, bts, expected) -> it desc (sweetNumber bts `shouldBe` expected))
 

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -102,6 +102,20 @@ spec = do
             parseExpression printed `shouldBe` Right expr
       )
 
+  describe "printExpression keeps a number with fewer than eight bytes in byte form" $
+    forM_
+      [ ("one byte", BtOne "21")
+      , ("three bytes", BtMany ["00", "01", "02"])
+      ]
+      ( \(desc, bts) ->
+          it desc $ do
+            let expr = DataNumber bts
+                printed = printExpression' expr (SWEET, ASCII, SINGLELINE, defaultMargin)
+            printed `shouldContain` "number"
+            printed `shouldContain` "bytes"
+            parseExpression printed `shouldBe` Right expr
+      )
+
   describe "printExpression keeps a compressed meet atomic under a narrow margin" $
     -- A \phinoMeet is a single \overbracket visual unit, so its body must stay
     -- on one line even when the surrounding margin forces the outer formation to


### PR DESCRIPTION
Fixes #1129 

## Problem

Printing a `Φ.number` whose Δ datum is not exactly eight bytes kills the process with a raw GHC `error`:

```
$ phino rewrite <<< '⟦ a ↦ Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 21- ⟧ ) ) ⟧'
[ERROR]: Expected 8 bytes for conversion, got 1
```

Three callers force `btsToNum` unguarded:
1. `sweetNumber` in `src/CST.hs:273` — the SWEET printer
2. XMIR number comment in `src/XMIR.hs:122`
3. `string()` build-term in `src/Functions.hs:172`

## Fix

| File | Guard | Effect |
|------|-------|--------|
| `src/CST.hs` | `sweetNumber bts \| btsSize bts /= 8 = False` | Falls through to generic application clause, keeps byte form |
| `src/XMIR.hs` | `_omitComments \|\| btsSize bytes /= 8` | Skips the number comment when datum is not 8 bytes |
| `src/Functions.hs` | `btsSize bts /= 8 -> throwIO (userError ...)` | Proper error with byte count, consistent with `argToNumber` (#1072) |

## Tests

- 2 `sweetNumber` cases: one byte, empty bytes → both `False`
- 2 `PrinterSpec` cases: one byte, three bytes → byte-form round-trip

## Verification

- Full suite: 2350 examples, 13 pre-existing LocatorSpec failures (GHC 9.10.3, unrelated)
- `hlint` and `fourmolu --mode check` clean