### PR TITLE
fix(xmir): accept applied terminator base="⊥" with children (#1135)

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -485,10 +485,7 @@ xmirToExpression cur fqn
           if null (cur C.$/ C.element (toName "o"))
             then pure ExRoot
             else throwIO (InvalidXMIRFormat "Application of 'Φ' is illegal in XMIR" cur)
-        "⊥" ->
-          if null (cur C.$/ C.element (toName "o"))
-            then pure ExTermination
-            else throwIO (InvalidXMIRFormat "Application of '⊥' is illegal in XMIR" cur)
+        "⊥" -> xmirToApplication ExTermination (cur C.$/ C.element (toName "o")) fqn
         'Φ' : '.' : rest -> xmirToExpression' ExRoot "Φ" rest cur fqn
         'ξ' : '.' : rest -> xmirToExpression' ExXi "ξ" rest cur fqn
         _ -> throwIO (InvalidXMIRFormat "The @base attribute must be either ['∅'|'Φ'] or start with ['Φ.'|'ξ.'|'.']" cur)

--- a/test-resources/xmir-parsing-packs/termination-with-application.yaml
+++ b/test-resources/xmir-parsing-packs/termination-with-application.yaml
@@ -1,13 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-failure: true
 xmir: |
   <object>
     <o name="app">
-      <o base="⊥">
+      <o name="x" base="⊥">
         <o base="Φ.number"/>
       </o>
     </o>
   </object>
-phi: ''
+phi: '[[ app -> [[ x -> T(Q.number) ]] ]]'


### PR DESCRIPTION
Fixes #1135.

## Problem

The #1128 fix read a bare `⊥` but refused an *applied* one with children,
copying the no-children guard from `Φ` and `ξ`. For `⊥` the guard is
wrong:

- The rules `dc` (`⊥(τ→e) → ⊥`) and `dca` (`⊥(αᵢ→e) → ⊥`) define
  reduction of applied terminator
- EO writes `⊥` with its panic reason, so every real-world occurrence has
  children (79 nodes across 32 XMIR files in `eo-runtime`)

With 0.0.119 (the #1128 fix), all 32 XMIR documents containing a terminator
in `eo-runtime` still fail to read — the terminator is never bare.

## Fix

One-line change in `src/XMIR.hs:488`:

```diff
-"⊥" ->
-  if null (cur C.$/ C.element (toName "o"))
-    then pure ExTermination
-    else throwIO (...)
+"⊥" -> xmirToApplication ExTermination (cur C.$/ C.element (toName "o")) fqn
```

Children become arguments that `dc`/`dca` can later collapse.
The writer side needs nothing — `expression ExTermination` already
returns `("⊥", [])`, and the generic `ExApplication` clause
renders the children around it.

## Verification

Round-trip:
```
<o name="x" base="⊥"><o base="Φ.number"/></o>
→ ⟦ x ↦ ⊥( Φ.number ) ⟧
```

- XMIR: 98 examples, 0 failures
- Full suite: 2398 examples, 13 pre-existing (LocatorSpec, GHC 9.10.3)
- `hlint` and `fourmolu --mode check` clean