### PR TITLE
fix(print): keep a non-UTF-8 string datum in byte form instead of aborting (#1138)

### DIFF
--- a/src/Bytes.hs
+++ b/src/Bytes.hs
@@ -15,6 +15,7 @@ module Bytes
   , unescapeStr
   , btsToNum
   , btsToUnescapedStr
+  , btsIsUtf8
   , btsAnd
   , btsOr
   , btsNot
@@ -328,6 +329,22 @@ unescapeStr = go
 -- "5"
 btsToUnescapedStr :: Bytes -> String
 btsToUnescapedStr bytes = T.unpack (T.decodeUtf8 (B.pack (btsToWord8 bytes)))
+
+-- Whether the byte array is valid UTF-8. The string-side counterpart of the
+-- eight-byte check on numbers: a short or malformed datum is legal, and the
+-- printer keeps it in its byte form instead of aborting with an uncaught
+-- 'decodeUtf8' exception (see #1138).
+-- >>> btsIsUtf8 (BtMany ["77", "6F", "72", "6C", "64"])
+-- True
+-- >>> btsIsUtf8 (BtMany ["F0", "90", "80", "41"])
+-- False
+-- >>> btsIsUtf8 (BtOne "FE")
+-- False
+btsIsUtf8 :: Bytes -> Bool
+btsIsUtf8 bytes =
+  case T.decodeUtf8' (B.pack (btsToWord8 bytes)) of
+    Left _ -> False
+    Right _ -> True
 
 -- Bitwise conjunction of two byte arrays, byte by byte. EO's 'BytesRaw.and'
 -- refuses operands of different lengths, so there is nothing to yield for them

--- a/src/CST.hs
+++ b/src/CST.hs
@@ -11,7 +11,7 @@
 module CST where
 
 import AST
-import Bytes (NonFinite, btsSize, btsToNonFinite, btsToNum, btsToStr)
+import Bytes (NonFinite, btsIsUtf8, btsSize, btsToNonFinite, btsToNum, btsToStr)
 import Data.Maybe (isJust)
 import qualified Data.Text as T
 import qualified Yaml as Y
@@ -276,9 +276,17 @@ sweetNumber bts = case btsToNum bts of
   Right dbl | isNaN dbl || isInfinite dbl -> isJust (btsToNonFinite bts)
   _ -> True
 
+-- A string can be rendered as a literal only when its bytes decode as UTF-8.
+-- An arbitrary byte array is a legal datum and nothing promises it decodes, so
+-- a malformed one is kept in its byte form, exactly as a payload NaN is kept
+-- today (see #1138).
+sweetString :: Bytes -> Bool
+sweetString = btsIsUtf8
+
 -- Whether a data object may be collapsed into its sweet literal form.
 sweetCollapsible :: Expression -> Bool
 sweetCollapsible (DataNumber bts) = sweetNumber bts
+sweetCollapsible (DataString bts) = sweetString bts
 sweetCollapsible _ = True
 
 attributeToCST :: Attribute -> ATTRIBUTE
@@ -353,7 +361,7 @@ instance ToCST Expression EXPRESSION where
       withoutLastVoidRho [] = []
       withoutLastVoidRho [BiVoid AtRho] = []
       withoutLastVoidRho (bd : bds') = bd : withoutLastVoidRho bds'
-  toCST (DataString bts) (tabs, _) = EX_STRING (btsToStr bts) (TAB tabs) []
+  toCST (DataString bts) (tabs, _) | sweetString bts = EX_STRING (btsToStr bts) (TAB tabs) []
   -- The three canonical non-finite doubles have no sweet numeric literal, so
   -- they become the root dispatches `Φ.nan`, `Φ.pinf` and `Φ.ninf`. Any other
   -- non-finite pattern is left in its byte form `Φ.number(Φ.bytes(⟦ Δ ⤍ … ⟧))`

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -22,7 +22,7 @@ module XMIR
 where
 
 import AST
-import Bytes (btsSize, btsToNum, btsToStr, bytesToBts)
+import Bytes (btsIsUtf8, btsSize, btsToNum, btsToStr, bytesToBts)
 import Control.Exception (Exception (displayException), throwIO)
 import Data.Bifunctor (bimap)
 import Data.Foldable (foldlM)
@@ -131,7 +131,7 @@ expression (DataString bytes) XmirContext{..} =
           [object [("as", "data")] [NodeContent (T.pack (printBytes bytes))]]
    in pure
         ( "Φ.string"
-        , if _omitComments
+        , if _omitComments || not (btsIsUtf8 bytes)
             then [bts]
             else
               [ NodeComment (T.pack ('"' : btsToStr bytes ++ "\""))

--- a/test/CSTSpec.hs
+++ b/test/CSTSpec.hs
@@ -155,6 +155,17 @@ spec = do
       ]
       (\(desc, bts, expected) -> it desc (sweetNumber bts `shouldBe` expected))
 
+  describe "sweetString" $
+    forM_
+      [ ("is true for a valid ASCII datum", BtMany ["77", "6F", "72", "6C", "64"], True)
+      , ("is true for a valid multi-byte datum", BtMany ["D0", "B0"], True)
+      , ("is true for empty bytes", BtEmpty, True)
+      , ("is false for a lone continuation byte", BtOne "A0", False)
+      , ("is false for a truncated surrogate sequence", BtMany ["F0", "90", "80", "41"], False)
+      , ("is false for a lone 0xFE byte", BtOne "FE", False)
+      ]
+      (\(desc, bts, expected) -> it desc (sweetString bts `shouldBe` expected))
+
   describe "sweetCollapsible" $
     forM_
       [

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -116,6 +116,21 @@ spec = do
             parseExpression printed `shouldBe` Right expr
       )
 
+  describe "printExpression keeps a string with a non-UTF-8 datum in byte form" $
+    forM_
+      [ ("a lone 0xFE", BtOne "FE")
+      , ("a truncated surrogate sequence", BtMany ["F0", "90", "80", "41"])
+      , ("a bare continuation byte", BtOne "A0")
+      ]
+      ( \(desc, bts) ->
+          it desc $ do
+            let expr = DataString bts
+                printed = printExpression' expr (SWEET, ASCII, SINGLELINE, defaultMargin)
+            printed `shouldContain` "string"
+            printed `shouldContain` "bytes"
+            parseExpression printed `shouldBe` Right expr
+      )
+
   describe "printExpression keeps a compressed meet atomic under a narrow margin" $
     -- A \phinoMeet is a single \overbracket visual unit, so its body must stay
     -- on one line even when the surrounding margin forces the outer formation to


### PR DESCRIPTION
Fixes #1138.

## Problem

Printing a `Φ.string` whose Δ datum is not valid UTF-8 aborted the run with an uncaught `decodeUtf8` exception:

```
$ phino rewrite <<< '⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ FE- ⟧ ) ) ⟧'
[ERROR]: Cannot decode byte '\xfe': Data.Text.Encoding: Invalid UTF-8 stream
```

`btsToUnescapedStr` (src/Bytes.hs:330) uses the throwing `T.decodeUtf8`, and the print path reached it unguarded at both `EX_STRING` sites in CST (src/CST.hs:356, and the `applicationToPrimitive` collapse) and at the comment in the XMIR writer (src/XMIR.hs:137). An arbitrary byte array is a legal datum, and eo-runtime tests malformed input deliberately. This is the string-side sibling of #1129.

## Fix

| File | Change |
|------|--------|
| `src/Bytes.hs` | New `btsIsUtf8` predicate using the non-throwing `T.decodeUtf8'` |
| `src/CST.hs` | `sweetString = btsIsUtf8` next to `sweetNumber`; guard on the `EX_STRING` clause and on `sweetCollapsible (DataString ...)` so malformed datums fall through to the generic application clause (byte form) |
| `src/XMIR.hs` | Skip the string comment when the datum is not valid UTF-8 |

## Verification

```
$ phino rewrite --sweet <<< '⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ FE- ⟧ ) ) ⟧'
⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ FE- ⟧ ) ) ⟧   # byte form kept, no crash

$ phino rewrite --sweet <<< '⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ F0-90-80-41 ⟧ ) ) ⟧'
⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ F0-90-80-41 ⟧ ) ) ⟧

$ phino rewrite --sweet <<< '⟦ a ↦ Φ.string( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 77-6F-72-6C-64 ⟧ ) ) ⟧'
⟦ a ↦ "world" ⟧   # valid UTF-8 still collapses to the literal
```

- Full suite: 2408 examples, 13 pre-existing (LocatorSpec, GHC 9.10.3)
- `hlint` and `fourmolu --mode check` clean