### PR TITLE
ci(release): remove the image ghcup on ubuntu-24.04 so setup wins (#1141)

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -20,6 +20,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Remove pre-installed ghcup (ubuntu-24.04)
+        # The ubuntu-24.04 image ships its own ghcup in /usr/local/.ghcup.
+        # It stays ahead of the /home/runner/.ghcup that haskell-actions/setup
+        # installs, so `ghc` and `cabal` resolve to stale binaries that do not
+        # carry the requested versions ('The version ... is not installed'),
+        # and the leg fails while the other four legs pass. The image ghcup is
+        # dead anyway once setup prepends its own bin to PATH; only one ghcup
+        # may win, see https://github.com/objectionary/phino/issues/1141
+        if: matrix.os == 'ubuntu-24.04'
+        shell: bash
+        run: |
+          sudo rm -rf /usr/local/.ghcup
       - name: Set up GHC and Cabal
         uses: haskell-actions/setup@v2.12.0
         with:


### PR DESCRIPTION
Fixes #1141.

## Problem

The `ubuntu-24.04` leg of the `release-binary.yml` matrix failed on four consecutive tags (0.0.117–0.0.120) while the other four legs succeeded. Since the upload step never runs on a failed leg, the bucket holds no `ubuntu-24.04` binary after 0.0.116, and downstream consumers (e.g. `hone-maven-plugin`) get a bare `curl: (22)` 403.

Root cause: the ubuntu-24.04 runner image ships its own ghcup in `/usr/local/.ghcup`, which stays ahead of the `/home/runner/.ghcup` installed by `haskell-actions/setup@v2.12.0` on PATH. `ghc`/`cabal` then resolve to the stale `/usr/local` binaries that lack the requested versions (`The version '9.6.7' of the tool ghc is not installed`, GHCup-00330 `has shadowed binaries` naming exactly that pair).

## Fix

`haskell-actions/setup` (v2.12.0) has no input to prefer or disable the image's ghcup, so the leg removes the pre-installed one before setup runs — only the `/home/runner/.ghcup` remains on PATH, which is exactly the setup the other legs already have:

```yaml
- name: Remove pre-installed ghcup (ubuntu-24.04)
  if: matrix.os == 'ubuntu-24.04'
  run: sudo rm -rf /usr/local/.ghcup
```

Only the failing leg is touched; `macos-15`, `macos-14-large`, `ubuntu-22.04` and `windows-2022` are unchanged.