### PR TITLE
fix(dataize): walk --deep innermost-first so nested atoms fire (#1143)

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -316,8 +316,9 @@ deepened expr univ = go ExXi expr
     go :: Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)
     go context term state' caller = do
       ctx' <- deeper caller
-      answer <- fired (contextualize term context) univ state' ctx'
-      maybe (parts context term state' ctx') pure answer
+      (walked, walkedState) <- parts context term state' caller
+      answer <- fired (contextualize walked context) univ walkedState ctx'
+      maybe (pure (walked, walkedState)) pure answer
     -- The parts of a term nothing fired on, walked one by one and put back
     -- where they were, so the term keeps the shape it was written in.
     parts :: Expression -> Expression -> State -> DataizeContext -> IO (Expression, State)

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -226,6 +226,12 @@ spec = do
         , "[[ x -> Q.number( as-bytes -> Q.bytes( data -> [[ D> 40-26-00-00-00-00-00-00 ]] ) ) ]]"
         )
       ,
+        ( "fires the atom nested in the argument of the atom it fires"
+        , "Q.@"
+        , primitives "[[ x -> 5.plus( 6.plus( 7 ) ) ]]"
+        , "[[ x -> Q.number( as-bytes -> Q.bytes( data -> [[ D> 40-32-00-00-00-00-00-00 ]] ) ) ]]"
+        )
+      ,
         ( "keeps the answer of the last atom fired along one chain of them"
         , "Q.@"
         , primitives "[[ x -> 5.plus( 6 ).plus( 7 ) ]]"


### PR DESCRIPTION
Fixes #1143. Follow-up to #1124.

## Problem

`go` in `deepened` (`src/Dataize.hs:316`) asked `fired` about the whole term **first** and only descended into `parts` when nothing fired. An atom's answer replaces the entire sub-tree, so a λ standing inside that atom's **argument** is dropped unfired, and the outer atom receives an argument nobody reduced.

An atom can't repair this from its side: given `𝑏`/`𝑒` it would have to re-invoke phino on `𝑏.x`, but on real operands `𝑏` is enormous (an operand carries the whole `number` object inline) — `--inside` fails with `spawnSync phino E2BIG`, and stdin splicing re-runs the caller's reduction (~2 min for one small fragment). This blocks Step 4 of objectionary/eo#8548.

## Fix

Make the walk **innermost-first** — descend into `parts`, then ask `fired` about the rebuilt term:

```haskell
go context term state' caller = do
  ctx' <- deeper caller
  (walked, walkedState) <- parts context term state' caller
  answer <- fired (contextualize walked context) univ walkedState ctx'
  maybe (pure (walked, walkedState)) pure answer
```

So an atom's arguments are already reduced when its λ fires, and no nested λ is thrown away.

## Reproduction (before → after)

With one served `L_p` logging the `𝑏` it gets and answering `Φ.a`, on the issue's `order.phi`, `morph --deep --inside 'Φ.probe'`:

- **before**: outer `L_p` fired with `𝑏 = ⟦ x ↦ Φ.a.p( α0 ↦ Φ.a ), …⟧` — the inner atom still unreduced, and only it fired.
- **after**: result `⟦ φ ↦ Φ.a ⟧`, **two** `L_p` calls, and the outer's `𝑏 = ⟦ x ↦ Φ.a, …⟧` — the inner atom fired first and reduced the argument.

## Test

A `morph --deep` case `5.plus( 6.plus( 7 ) )` → 18 (`40-32`): the inner `plus` must fire before the outer, else the outer gets an unevaluated operand and the run collapses to `⊥`. Verified this case is **red without the change and green with it**.

## Notes / scope

- Full suite: **2409 examples, 13 failures — all pre-existing `LocatorSpec` on local GHC 9.10.3** (the `HasCallStack` leak, fixed in #1100). CI (9.6.7/9.8.4) is green; 0 new failures here (filtering out `Locator` leaves none).
- `go` fires once per visited node on the rebuilt term (no extra fix-point re-walk of `answer`), matching the original `fired` contract; the issue's suggested minimal change.
