### PR TITLE
Expect the φ payload in the nested-atom deep case

### DIFF
--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -228,7 +228,7 @@ spec = do
         ( "fires the atom nested in the argument of the atom it fires"
         , "Q.@"
         , primitives "[[ x -> 5.plus( 6.plus( 7 ) ) ]]"
-        , "[[ x -> Q.number( as-bytes -> Q.bytes( data -> [[ D> 40-32-00-00-00-00-00-00 ]] ) ) ]]"
+        , "[[ x -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) ) ]]"
         )
       ,
         ( "keeps the answer of the last atom fired along one chain of them"


### PR DESCRIPTION
One line in `test/DataizeSpec.hs`. The `morph --deep` case "fires the atom
nested in the argument of the atom it fires" expected the datum payload under
`data`; it now expects it under `φ`, the way the two cases either side of it
already spell it.

Master is red — `cabal`, `stack` and `codecov` all fail on this single
expectation. #1146 renamed the printed payload from `data` to `φ` (the void the
real `bytes` object declares) and moved every expectation in the suite over.
#1147 merged five minutes later with a brand new case whose expectation had been
written before that rename. Neither branch was rebased on the other, so both
were green alone and the merge is not. Nothing is wrong with the production
code from either change.

Locally: 2412 examples, 0 failures, hlint and fourmolu clean.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
