### PR TITLE
fix(ast): bind a data object to φ, the only void number and string declare (#1155)

### DIFF
--- a/src/AST.hs
+++ b/src/AST.hs
@@ -202,10 +202,11 @@ pattern BaseObject label <- (matchBaseObject -> Just label)
 
 -- Minimal matcher function (required for view pattern)
 --
--- The primitive→bytes binding is named 'as-bytes' and the bytes→payload
--- binding is named 'data' (jeo-maven-plugin 0.15.3+, following phi-calculus
--- dropping positional attributes). The legacy positional α0 form is still
--- recognized so XMIR produced by older jeo versions keeps sugaring back.
+-- The real 'number' and 'string' of eo-runtime declare '[@]' as their only
+-- void (objectionary/eo#8620), so both primitive→bytes and bytes→payload
+-- bindings are printed as 'φ' (#1155). The reader still accepts the legacy
+-- names 'as-bytes'/'data' and the positional α0 form so XMIR produced by
+-- older jeo versions keeps sugaring back.
 matchDataObject :: Expression -> Maybe (T.Text, Bytes)
 matchDataObject (ExApplication outer arg)
   | Just inner <- asBytesArg arg = case (matchOuter outer, matchInner inner) of
@@ -213,6 +214,7 @@ matchDataObject (ExApplication outer arg)
       _ -> Nothing
   where
     asBytesArg :: Argument -> Maybe Expression
+    asBytesArg (ArTau AtPhi inner) = Just inner
     asBytesArg (ArTau (AtLabel "as-bytes") inner) = Just inner
     asBytesArg (ArAlpha (Alpha 0) inner) = Just inner
     asBytesArg _ = Nothing
@@ -254,13 +256,13 @@ pattern DataObject :: T.Text -> Bytes -> Expression
 pattern DataObject label bts <- (matchDataObject -> Just (label, bts))
   where
     DataObject label bts =
-      ExApplication (BaseObject label) (ArTau (AtLabel "as-bytes") (dataBytes bts))
+      ExApplication (BaseObject label) (ArTau AtPhi (dataBytes bts))
 
 -- The bytes object Φ.bytes(φ ↦ ⟦ Δ ⤍ …, ρ ↦ ∅ ⟧) — what a 'bytes' atom
--- yields and what a 'DataObject' carries under its 'as-bytes' argument.
--- The payload is bound to 'φ', the void that the real 'bytes' object
--- declares ([@] > bytes), so that every dispatch on the literal can bind
--- (see #1142)
+-- yields and what a 'DataObject' carries under its 'φ' argument.
+-- Both bindings are named 'φ', the void that the real 'bytes', 'number'
+-- and 'string' objects declare ([@] > bytes, objectionary/eo#8620), so
+-- that every dispatch on the literal can bind (see #1142 and #1155)
 dataBytes :: Bytes -> Expression
 dataBytes bts =
   ExApplication

--- a/src/Sugar.hs
+++ b/src/Sugar.hs
@@ -207,7 +207,7 @@ saltifyPrimitive base bytes data' tb@TAB{..} rhos =
             ( AA_TAUS
                 ( BI_PAIR
                     ( PA_TAU
-                        (AT_LABEL "as-bytes")
+                        (AT_PHI PHI)
                         ARROW
                         ( EX_APPLICATION
                             bytes

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -113,7 +113,7 @@ expression (ExDispatch expr attr) ctx = do
 expression (DataNumber bytes) XmirContext{..} =
   let bts =
         object
-          [("as", "as-bytes"), ("base", "Φ.bytes")]
+          [("as", "φ"), ("base", "Φ.bytes")]
           [object [("as", "φ")] [NodeContent (T.pack (printBytes bytes))]]
    in pure
         ( "Φ.number"
@@ -127,7 +127,7 @@ expression (DataNumber bytes) XmirContext{..} =
 expression (DataString bytes) XmirContext{..} =
   let bts =
         object
-          [("as", "as-bytes"), ("base", "Φ.bytes")]
+          [("as", "φ"), ("base", "Φ.bytes")]
           [object [("as", "φ")] [NodeContent (T.pack (printBytes bytes))]]
    in pure
         ( "Φ.string"

--- a/test-resources/atoms/primitives.js
+++ b/test-resources/atoms/primitives.js
@@ -66,13 +66,17 @@ function bindingValue(b, start) {
 
 // Every shape an already-reduced datum reaches this script in: a literal
 // argument, a copy of the 'number', 'string' or 'bytes' object bound to ρ, or a
-// bare byte formation. The bytes are what follows. Since #1142 the payload of
-// a datum is named φ (the void the real 'bytes' object declares), so the φ
-// shapes come first; the legacy 'data' shapes stay for inputs jeo wrote.
+// bare byte formation. The bytes are what follows. Since #1155 both bindings
+// of a datum are named φ (the only void the real 'number' and 'string' declare,
+// objectionary/eo#8620), so the φ shapes come first; the legacy 'as-bytes' and
+// 'data' shapes stay for inputs jeo wrote.
 const DATA = [
+  'Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
+  'Φ.string( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
   'Φ.number( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
   'Φ.string( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
   'Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
+  '⟦ φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
   '⟦ as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ',
   '⟦ φ ↦ ⟦ Δ ⤍ ',
   '⟦ Δ ⤍ ',
@@ -119,7 +123,7 @@ function asBytes(raw) {
 function asNumber(value) {
   const raw = Buffer.alloc(8);
   raw.writeDoubleBE(value, 0);
-  return `Φ.number( as-bytes ↦ ${asBytes(raw)} )`;
+  return `Φ.number( φ ↦ ${asBytes(raw)} )`;
 }
 
 function asBool(yes) {

--- a/test-resources/cst/to-salty-packs/application-with-alphas.yaml
+++ b/test-resources/cst/to-salty-packs/application-with-alphas.yaml
@@ -8,7 +8,7 @@ result: |-
   ⟦
     x ↦ Φ.y(
       α0 ↦ Φ.number(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦
             Δ ⤍ 3F-F0-00-00-00-00-00-00,
             ρ ↦ ∅
@@ -17,7 +17,7 @@ result: |-
       )
     )(
       α1 ↦ Φ.number(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦
             Δ ⤍ 40-00-00-00-00-00-00-00,
             ρ ↦ ∅

--- a/test-resources/cst/to-salty-packs/application.yaml
+++ b/test-resources/cst/to-salty-packs/application.yaml
@@ -8,7 +8,7 @@ result: |-
   ⟦
     x ↦ Φ.y(
       z ↦ Φ.string(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦
             Δ ⤍ 68-65-79,
             ρ ↦ ∅
@@ -17,7 +17,7 @@ result: |-
       )
     )(
       b ↦ Φ.number(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦
             Δ ⤍ 3F-F0-00-00-00-00-00-00,
             ρ ↦ ∅

--- a/test-resources/cst/to-salty-packs/non-finite-doubles.yaml
+++ b/test-resources/cst/to-salty-packs/non-finite-doubles.yaml
@@ -11,7 +11,7 @@ expression: |
 result: |-
   ⟦
     nan ↦ Φ.number(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ 7F-F8-00-00-00-00-00-00,
           ρ ↦ ∅
@@ -19,7 +19,7 @@ result: |-
       )
     ),
     pinf ↦ Φ.number(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ 7F-F0-00-00-00-00-00-00,
           ρ ↦ ∅
@@ -27,7 +27,7 @@ result: |-
       )
     ),
     ninf ↦ Φ.number(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ FF-F0-00-00-00-00-00-00,
           ρ ↦ ∅

--- a/test-resources/cst/to-salty-packs/primitives-with-rhos.yaml
+++ b/test-resources/cst/to-salty-packs/primitives-with-rhos.yaml
@@ -14,7 +14,7 @@ expression: |
 result: |-
   ⟦
     x ↦ Φ.number(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ 3F-F0-00-00-00-00-00-00,
           ρ ↦ ∅
@@ -26,7 +26,7 @@ result: |-
       ρ ↦ ⟦ ρ ↦ ∅ ⟧
     ),
     y ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ 48-65-79,
           ρ ↦ ∅

--- a/test-resources/cst/to-salty-packs/with-num-and-void-rho.yaml
+++ b/test-resources/cst/to-salty-packs/with-num-and-void-rho.yaml
@@ -7,7 +7,7 @@ expression: |
 result: |-
   ⟦
     x ↦ Φ.number(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦
           Δ ⤍ 3F-F0-00-00-00-00-00-00,
           ρ ↦ ∅

--- a/test-resources/rewriter-packs/custom/desugar-fibo.yaml
+++ b/test-resources/rewriter-packs/custom/desugar-fibo.yaml
@@ -26,7 +26,7 @@ output: |-
           n ↦ ∅,
           φ ↦ ξ.n.lt(
             α0 ↦ Φ.number(
-              as-bytes ↦ Φ.bytes(
+              φ ↦ Φ.bytes(
                 φ ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧
               )
             )
@@ -36,7 +36,7 @@ output: |-
             α1 ↦ Φ.eo.example.fibonacci(
               α0 ↦ ξ.n.minus(
                 α0 ↦ Φ.number(
-                  as-bytes ↦ Φ.bytes(
+                  φ ↦ Φ.bytes(
                     φ ↦ ⟦ Δ ⤍ 3F-F0-00-00-00-00-00-00 ⟧
                   )
                 )
@@ -45,7 +45,7 @@ output: |-
               α0 ↦ Φ.eo.example.fibonacci(
                 α0 ↦ ξ.n.minus(
                   α0 ↦ Φ.number(
-                    as-bytes ↦ Φ.bytes(
+                    φ ↦ Φ.bytes(
                       φ ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧
                     )
                   )

--- a/test-resources/rewriter-packs/custom/desugar-strings.yaml
+++ b/test-resources/rewriter-packs/custom/desugar-strings.yaml
@@ -12,27 +12,27 @@ input: |
 output: |-
   ⟦
     str ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦ Δ ⤍ 68-65-6C-6C-6F ⟧
       )
     ),
     ch ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦ Δ ⤍ 68- ⟧
       )
     ),
     uni ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦ Δ ⤍ 01-02 ⟧
       )
     ),
     empty ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦ Δ ⤍ -- ⟧
       )
     ),
     new-line ↦ Φ.string(
-      as-bytes ↦ Φ.bytes(
+      φ ↦ Φ.bytes(
         φ ↦ ⟦ Δ ⤍ 68-0A-65 ⟧
       )
     )

--- a/test-resources/rewriter-packs/custom/desugares-without-match.yaml
+++ b/test-resources/rewriter-packs/custom/desugares-without-match.yaml
@@ -11,7 +11,7 @@ output: |-
   ⟦
     foo ↦ ⟦
       x ↦ Φ.number(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦ Δ ⤍ 41-EF-FF-FF-FF-E0-00-00 ⟧
         )
       )

--- a/test-resources/rewriter-packs/custom/desugares.yaml
+++ b/test-resources/rewriter-packs/custom/desugares.yaml
@@ -11,7 +11,7 @@ output: |-
   ⟦
     foo ↦ ⟦
       x ↦ Φ.number(
-        as-bytes ↦ Φ.bytes(
+        φ ↦ Φ.bytes(
           φ ↦ ⟦ Δ ⤍ 41-EF-FF-FF-FF-E0-00-00 ⟧
         )
       )

--- a/test-resources/xmir-printing-packs/legacy-positional-data-object.yaml
+++ b/test-resources/xmir-printing-packs/legacy-positional-data-object.yaml
@@ -4,13 +4,13 @@
 ---
 # jeo-maven-plugin versions before 0.15.3 emit the as-bytes/data pair of a
 # primitive data object positionally (α0) instead of by name; 'matchDataObject'
-# in AST.hs still recognizes that legacy form, so it must print exactly like
-# the modern named form.
+# in AST.hs still recognizes that legacy form, so it prints like the modern
+# one: both voids bound as φ (#1155, objectionary/eo#8620).
 phi: |
   [[
     x -> Q.number(~0 -> Q.bytes(~0 -> [[ D> 40-14-00-00-00-00-00-00 ]]))
   ]]
 xpaths:
   - '/object/o[@name="x" and @base="Φ.number"]'
-  - '/object/o/o[@as="as-bytes" and @base="Φ.bytes"]'
+  - '/object/o/o[@as="φ" and @base="Φ.bytes"]'
   - '/object/o/o/o[@as="φ"]'

--- a/test/ASTSpec.hs
+++ b/test/ASTSpec.hs
@@ -299,15 +299,20 @@ spec = do
           (ArTau AtPhi (ExFormation [BiDelta (BtOne "48"), BiVoid AtRho]))
 
   describe "DataObject/DataString/DataNumber pattern" $ do
-    it "constructs the named, unwrapped as-bytes form" $
+    it "constructs the canonical φ-void form" $
       DataString (BtOne "48")
         `shouldBe` ExApplication
           (ExDispatch ExRoot (AtLabel "string"))
-          (ArTau (AtLabel "as-bytes") (dataBytes (BtOne "48")))
+          (ArTau AtPhi (dataBytes (BtOne "48")))
 
     forM_
       [
-        ( "matches the named, unwrapped form"
+        ( "matches the canonical φ-void form"
+        , ExApplication (ExDispatch ExRoot (AtLabel "string")) (ArTau AtPhi (dataBytes (BtOne "48")))
+        , Just (BtOne "48")
+        )
+      ,
+        ( "matches the legacy named as-bytes form"
         , ExApplication (ExDispatch ExRoot (AtLabel "string")) (ArTau (AtLabel "as-bytes") (dataBytes (BtOne "48")))
         , Just (BtOne "48")
         )

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -425,7 +425,7 @@ spec = do
     it "saves dataize steps to dir with --steps-dir" $
       withAtoms $ \atoms ->
         withTempDirectory "phino-steps-dataize" $ \dir ->
-          withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $ do
+          withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $ do
             testCLISucceeded
               ["dataize", atoms, "--steps-dir=" ++ dir, "--sweet"]
               ["40-32"]
@@ -1146,14 +1146,14 @@ spec = do
 
     it "focuses a compressed sequence whose meet replaces a step root" $
       withAtoms $ \atoms ->
-        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
+        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
           testCLISucceeded
             ["dataize", atoms, "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--hide=Q.bytes", "--hide=Q.number", "--locator=Q.@", "--focus=Q.@", "--meet-length=5", "--meet-popularity=1"]
             ["\\phinoMeet{dataization:1}{ [[ @ -> |c| . |plus| ( 32 ), |c| -> 25 ]] } \\leadsto_{\\nameref{r:contextualize}}"]
 
     it "compresses a canonized whole-expression sequence into a meet" $
       withAtoms $ \atoms ->
-        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
+        withStdin "[[ @ -> [[ @ -> $.c.plus( 32.0 ), c -> 25.0 ]], bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus -> [[ x -> ?, L> L_number_plus ]] ]] ]]" $
           testCLISucceeded
             ["dataize", atoms, "--output=latex", "--sweet", "--nonumber", "--compress", "--canonize", "--meet-prefix=dataization", "--sequence", "--flat", "--quiet", "--meet-length=5", "--meet-popularity=1"]
             ["\\phinoMeet{dataization:1}"]
@@ -1171,7 +1171,7 @@ spec = do
         withAtoms $ \atoms ->
           withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
             hClose stream
-            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
               testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
             records <- readUtf8 path
             records `shouldBe` "L_number_plus\t⟦ x ↦ 6 ⟧\t11\n"
@@ -1180,7 +1180,7 @@ spec = do
         withAtoms $ \atoms ->
           withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
             hClose stream
-            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $
+            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]" $
               testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"] []
             records <- readUtf8 path
             lines records `shouldBe` ["L_number_plus\t⟦ x ↦ 6 ⟧\t11", "L_number_plus\t⟦ x ↦ 7 ⟧\t18"]
@@ -1189,16 +1189,16 @@ spec = do
         withAtoms $ \atoms ->
           withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
             hClose stream
-            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
               testCLISucceeded ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--hide-rho"] []
             records <- readUtf8 path
-            records `shouldEndWith` "\tΦ.number( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
+            records `shouldEndWith` "\tΦ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) )\n"
 
       it "keeps the records of a run that fails" $
         withAtoms $ \atoms ->
           withTempFile "evaluationsXXXXXX.txt" $ \(path, stream) -> do
             hClose stream
-            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]], nope -> [[ L> L_number_nope ]] ]], @ -> 5.plus(6).nope ]]" $
+            withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]], nope -> [[ L> L_number_nope ]] ]], @ -> 5.plus(6).nope ]]" $
               testCLIFailed
                 ["dataize", atoms, "--evaluations=" ++ path, "--quiet", "--sweet", "--hide-rho"]
                 ["Atom 'L_number_nope' does not exist"]
@@ -1229,7 +1229,7 @@ spec = do
     -- an operation the caller left out of its registry on purpose. The run used
     -- to die on it, discarding what it had already evaluated (#1060)
     describe "--partial" $ do
-      let stuck = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, times(x) -> [[ L> L_number_times ]], nope -> [[ L> L_number_nope ]] ]], @ -> 2.times(3).nope ]]"
+      let stuck = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, times(x) -> [[ L> L_number_times ]], nope -> [[ L> L_number_nope ]] ]], @ -> 2.times(3).nope ]]"
       it "fails on an atom that cannot fire without the flag" $
         withAtoms $ \atoms ->
           withStdin stuck $
@@ -1247,7 +1247,7 @@ spec = do
           withStdin stuck $
             testCLISucceeded
               ["dataize", atoms, "--partial", "--sweet"]
-              ["as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
+              ["φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-18-00-00-00-00-00-00 ⟧ )"]
 
       it "records every stuck site in --evaluations with no result" $
         withAtoms $ \atoms ->
@@ -1263,7 +1263,7 @@ spec = do
 
       it "still prints bytes when nothing gets stuck" $
         withAtoms $ \atoms ->
-          withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
+          withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]" $
             testCLISucceeded ["dataize", atoms, "--partial"] ["40-26-00-00-00-00-00-00"]
 
       it "prints the chain of steps ending in the residue with --sequence" $
@@ -1280,7 +1280,7 @@ spec = do
     -- Which λ functions exist is not phino's business any more: the registry
     -- given with '--atoms' decides, and phino carries none of its own
     describe "--atoms" $ do
-      let sum' = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
+      let sum' = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
       it "fires the λ function the registry carries" $
         withAtoms $ \atoms ->
           withStdin sum' $
@@ -1310,7 +1310,7 @@ spec = do
     -- asks phino for them: '--inside' binds an expression to a synthetic
     -- attribute of the universe and aims the run at it
     describe "--inside" $ do
-      let universe = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> [[ D> 01- ]] ]]"
+      let universe = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> [[ D> 01- ]] ]]"
       it "dataizes an expression the input does not contain" $
         withAtoms $ \atoms ->
           withStdin universe $
@@ -1401,7 +1401,7 @@ spec = do
     -- Two chained atom calls: the inner one fires under 'ml', because '.plus'
     -- is dispatched on its result, while the outer application is saturated but
     -- bare, so 'mf' hands it back and firing it is 𝔻's job
-    let chained = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]"
+    let chained = "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6).plus(7) ]]"
     it "prints help" $
       testCLISucceeded ["morph", "--help"] ["Morph the 𝜑-expression"]
 
@@ -1521,7 +1521,7 @@ spec = do
     describe "--deep" $ do
       let program =
             "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, \
-            \number(as-bytes) -> [[ @ -> $.as-bytes, times(x) -> [[ L> L_number_times ]] ]], \
+            \number(φ) -> [[ as-bytes -> $.φ, times(x) -> [[ L> L_number_times ]] ]], \
             \bar(x) -> [[ L> L_bar ]], \
             \demo -> [[ foo -> [[ n -> 3, @ -> Q.bar( $.n.times( 5 ).times( 7 ) ) ]] ]] ]]"
       it "answers the formation as it was written without the flag" $
@@ -1558,7 +1558,7 @@ spec = do
           withStdin program $
             testCLISucceeded
               ["morph", atoms, "--deep", "--sweet", "--hide-rho", "--flat"]
-              [ "number(as-bytes) ↦ ⟦ φ ↦ as-bytes, times(x) ↦ ⟦ λ ⤍ L_number_times ⟧ ⟧"
+              [ "number(φ) ↦ ⟦ as-bytes ↦ φ, times(x) ↦ ⟦ λ ⤍ L_number_times ⟧ ⟧"
               , "demo ↦ ⟦ foo ↦ ⟦ n ↦ 3, φ ↦ Φ.bar( 105 ) ⟧ ⟧"
               ]
 

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -107,8 +107,8 @@ primitives src =
     , "    eq -> [[ b -> ?, L> L_bytes_eq ]]"
     , "  ]],"
     , "  number -> [["
-    , "    as-bytes -> ?,"
-    , "    @ -> $.as-bytes,"
+    , "    φ -> ?,"
+    , "    as-bytes -> $.φ,"
     , "    plus -> [[ x -> ?, L> L_number_plus ]],"
     , "    times -> [[ x -> ?, L> L_number_times ]],"
     , "    div -> [[ x -> ?, L> L_number_div ]],"
@@ -116,7 +116,7 @@ primitives src =
     , "    eq -> [[ x -> ?, @ -> $.^.as-bytes.eq( x.as-bytes ) ]],"
     , "    nope -> [[ L> L_number_nope ]]"
     , "  ]],"
-    , "  string -> [[ as-bytes -> ?, @ -> $.as-bytes ]],"
+    , "  string -> [[ φ -> ?, as-bytes -> $.φ ]],"
     , "  true -> [[ @ -> [[ D> FF- ]] ]],"
     , "  false -> [[ @ -> [[ D> 00- ]] ]],"
     , "  @ -> " ++ src
@@ -222,25 +222,25 @@ spec = do
         ( "stands the answer of the λ that 'mf' left bare in its place"
         , "Q.@"
         , primitives "[[ x -> 5.plus( 6 ) ]]"
-        , "[[ x -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) ) ]]"
+        , "[[ x -> Q.number( φ -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) ) ]]"
         )
       ,
         ( "fires the atom nested in the argument of the atom it fires"
         , "Q.@"
         , primitives "[[ x -> 5.plus( 6.plus( 7 ) ) ]]"
-        , "[[ x -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) ) ]]"
+        , "[[ x -> Q.number( φ -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) ) ]]"
         )
       ,
         ( "keeps the answer of the last atom fired along one chain of them"
         , "Q.@"
         , primitives "[[ x -> 5.plus( 6 ).plus( 7 ) ]]"
-        , "[[ x -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) ) ]]"
+        , "[[ x -> Q.number( φ -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) ) ]]"
         )
       ,
         ( "resolves the ξ of a binding against the formation that holds it"
         , "Q.@"
         , primitives "[[ n -> 5, x -> $.n.plus( 6 ) ]]"
-        , "[[ n -> 5, x -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) ) ]]"
+        , "[[ n -> 5, x -> Q.number( φ -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-26-00-00-00-00-00-00 ⟧ ) ) ]]"
         )
       , -- The registry carries no 'L_number_nope', so there is nothing to fire
         -- and the binding keeps the name it was written under
@@ -267,7 +267,7 @@ spec = do
         ( "walks into the argument of an atom it cannot fire"
         , "Q.@"
         , primitives "[[ x -> [[ y -> ?, L> L_bar ]]( y -> 6.plus( 7 ) ) ]]"
-        , "[[ x -> [[ y -> ?, L> L_bar ]]( y -> Q.number( as-bytes -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-2A-00-00-00-00-00-00 ⟧ ) ) ) ]]"
+        , "[[ x -> [[ y -> ?, L> L_bar ]]( y -> Q.number( φ -> Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-2A-00-00-00-00-00-00 ⟧ ) ) ) ]]"
         )
       ]
 
@@ -612,8 +612,8 @@ spec = do
             length rho `shouldBe` 1
             -- 2 × 3 = 6.0, whose IEEE 754 bytes are 40-18-00-00-00-00-00-00
             show rho `shouldContain` show (BtMany ["40", "18", "00", "00", "00", "00", "00", "00"])
-            -- the times application is gone: ρ is the number it produced, its 'as-bytes' bound
-            [() | ExFormation inner <- rho, BiTau (AtLabel "as-bytes") _ <- inner] `shouldBe` [()]
+            -- the times application is gone: ρ is the number it produced, its 'φ' bound
+            [() | ExFormation inner <- rho, BiTau AtPhi _ <- inner] `shouldBe` [()]
           other -> expectationFailure ("expected a residual formation, got " ++ show other)
     it "reports the firing that succeeded with its result and the stuck site without one" $
       withNode $ do
@@ -711,7 +711,7 @@ spec = do
         labels <-
           labelsOf
             "Q"
-            "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(as-bytes) -> [[ @ -> $.as-bytes, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
+            "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ as-bytes -> $.φ, plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6) ]]"
         labels
           `shouldBe` [ "contextualize"
                      , "maa"
@@ -723,9 +723,8 @@ spec = do
                      , "copy"
                      , "mf"
                      , "contextualize"
-                     , "dot"
                      , "ma"
-                     , "stay"
+                     , "copy"
                      , "mf"
                      , "contextualize"
                      , "delta"
@@ -765,7 +764,7 @@ spec = do
       , "Q.x"
       , unlines
           [ "[["
-          , "  number(as-bytes) -> [[ @ -> as-bytes ]],"
+          , "  number -> [[ φ -> ? ]],"
           , "  bytes ↦ ⟦ φ ↦ ∅ ⟧,"
           , "  x -> 5"
           , "]]"
@@ -827,8 +826,8 @@ spec = do
                 , "    φ -> ?"
                 , "  ]],"
                 , "  number -> [["
-                , "    as-bytes -> ?,"
-                , "    @ -> $.as-bytes,"
+                , "    φ -> ?,"
+                , "    as-bytes -> $.φ,"
                 , "    plus -> [[ x -> ?, L> L_number_plus ]],"
                 , "    times -> [[ x -> ?, L> L_number_times ]]"
                 , "  ]],"

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -146,6 +146,21 @@ spec = do
       str `shouldContain` "φ ↦"
       str `shouldNotContain` "data ↦"
 
+  describe "printExpression binds a datum to φ at both levels in salty notation (#1155)" $
+    it "names the primitive→bytes binding φ (the only void number and string declare), not as-bytes" $ do
+      let number =
+            printExpression'
+              (DataNumber (BtMany ["40", "45", "00", "00", "00", "00", "00", "00"]))
+              (SALTY, UNICODE, SINGLELINE, defaultMargin)
+          str =
+            printExpression'
+              (DataString (BtMany ["68", "69"]))
+              (SALTY, UNICODE, SINGLELINE, defaultMargin)
+      number `shouldContain` "Φ.number( φ ↦ Φ.bytes("
+      number `shouldNotContain` "as-bytes"
+      str `shouldContain` "Φ.string( φ ↦ Φ.bytes("
+      str `shouldNotContain` "as-bytes"
+
   describe "printExpression keeps a compressed meet atomic under a narrow margin" $
     -- A \phinoMeet is a single \overbracket visual unit, so its body must stay
     -- on one line even when the surrounding margin forces the outer formation to

--- a/test/SugarSpec.hs
+++ b/test/SugarSpec.hs
@@ -211,47 +211,47 @@ spec = do
       ,
         ( "EX_NUMBER with no extra rho expands into the Q.number(Q.bytes(...)) form"
         , EX_NUMBER (Left 42) (TAB 1) []
-        , "Φ.number(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 40-45-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.number(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 40-45-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_NUMBER preserves an extra rho argument carried alongside the primitive"
         , EX_NUMBER (Left 42) (TAB 1) [ArTau AtRho (ExDispatch ExXi (AtLabel "y"))]
-        , "Φ.number(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 40-45-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )(\n    ρ ↦ ξ.y\n  )"
+        , "Φ.number(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 40-45-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )(\n    ρ ↦ ξ.y\n  )"
         )
       ,
         ( "EX_NONFINITE nan expands into the Q.number(Q.bytes(...)) form"
         , EX_NONFINITE Φ NfNan (TAB 1) []
-        , "Φ.number(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 7F-F8-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.number(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 7F-F8-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_NONFINITE pinf expands into the Q.number(Q.bytes(...)) form"
         , EX_NONFINITE Φ NfPinf (TAB 1) []
-        , "Φ.number(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 7F-F0-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.number(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 7F-F0-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_NONFINITE ninf keeps an extra rho argument carried alongside the primitive"
         , EX_NONFINITE Φ NfNinf (TAB 1) [ArTau AtRho (ExDispatch ExXi (AtLabel "y"))]
-        , "Φ.number(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ FF-F0-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )(\n    ρ ↦ ξ.y\n  )"
+        , "Φ.number(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ FF-F0-00-00-00-00-00-00,\n        ρ ↦ ∅\n      ⟧\n    )\n  )(\n    ρ ↦ ξ.y\n  )"
         )
       ,
         ( "EX_STRING expands into the Q.string(Q.bytes(...)) form"
         , EX_STRING "hi" (TAB 1) []
-        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 68-69,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.string(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 68-69,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_STRING unescapes a newline instead of taking its escape literally"
         , EX_STRING "e\\ne" (TAB 1) []
-        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 65-0A-65,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.string(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 65-0A-65,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_STRING unescapes a quote and a backslash into single bytes"
         , EX_STRING "\\\"\\\\" (TAB 1) []
-        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 22-5C,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.string(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 22-5C,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ,
         ( "EX_STRING unescapes a hex escape back into its byte"
         , EX_STRING "\\x01" (TAB 1) []
-        , "Φ.string(\n    as-bytes ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 01-,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
+        , "Φ.string(\n    φ ↦ Φ.bytes(\n      φ ↦ ⟦\n        Δ ⤍ 01-,\n        ρ ↦ ∅\n      ⟧\n    )\n  )"
         )
       ]
       (\(desc, sweetExpr, expected) -> it desc (render (toSalty sweetExpr) `shouldBe` expected))
@@ -628,13 +628,13 @@ spec = do
       $ do
         let number = DataNumber (BtMany ["40", "45", "00", "00", "00", "00", "00", "00"])
         printExpression' number (config SWEET) `shouldBe` "42"
-        printExpression' number (config SALTY) `shouldBe` "Φ.number( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00, ρ ↦ ∅ ⟧ ) )"
+        printExpression' number (config SALTY) `shouldBe` "Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00, ρ ↦ ∅ ⟧ ) )"
     it
       "a sweet string literal expands into Q.string(Q.bytes(...)) when salted"
       $ do
         let string = DataString (BtMany ["68", "69"])
         printExpression' string (config SWEET) `shouldBe` "\"hi\""
-        printExpression' string (config SALTY) `shouldBe` "Φ.string( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 68-69, ρ ↦ ∅ ⟧ ) )"
+        printExpression' string (config SALTY) `shouldBe` "Φ.string( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 68-69, ρ ↦ ∅ ⟧ ) )"
     it
       "an application with multiple positional arguments sugars/salts between e(e0, e1) and e(α0 ↦ e0)(α1 ↦ e1)"
       $ do


### PR DESCRIPTION
Fixes #1155.

## Problem
A data object is printed as `Φ.number( as-bytes ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ … ⟧ ) )`. #1142 fixed the inner payload name, but the outer binding stayed `as-bytes`. eo master (objectionary/eo#8620, commit eb650cea07) declares `[@] > number` and `[@] > string`: φ is their only void, and `as-bytes` is only a read. So every literal phino prints reduces to ⊥ against the real library — this blocks objectionary/eo#8548. Reproduced on 0.0.122 as described in the issue: `--inside Φ.old` answers the terminator, `--inside Φ.new` answers the bytes.

## Fix
Name the outer binding the void the object declares, one level up from #1142:
- `DataObject` (`src/AST.hs`) constructs `ArTau AtPhi`;
- `asBytesArg` (`src/AST.hs`) accepts `φ` alongside the legacy `as-bytes` and `α0` clauses, so older XMIR keeps sugaring back (compat preserved, as suggested in the issue);
- the XMIR writer (`src/XMIR.hs`) emits the outer element with `as="φ"` (reader already maps φ → AtPhi);
- `saltifyPrimitive` (`src/Sugar.hs`) emits `AT_PHI` in salty output, in lockstep.

## Changes
- `src/AST.hs` — canonical construction, reader clause, comments
- `src/XMIR.hs` — outer `as="φ"` for number and string data objects
- `src/Sugar.hs` — `φ` instead of `as-bytes` in salty printing
- `test-resources/atoms/primitives.js` — answers with `Φ.number( φ ↦ … )`, recognizes new φ shapes first, legacy `as-bytes`/`data` shapes stay
- fixture universes in `test/DataizeSpec.hs` and `test/CLISpec.hs` — declare number/string with a φ void and keep `as-bytes` as a read (`$.φ`), the way they were rewritten for bytes in #1142
- expected salty/XMIR outputs in `test/SugarSpec.hs`, `test/ASTSpec.hs`, `test/CLISpec.hs`, `test/DataizeSpec.hs` and the to-salty / rewriter / xmir-printing packs

## Tests
- New `PrinterSpec` case pins the invariant: salty output names both datum bindings φ and never mentions `as-bytes`
- The reduction-label sequence for `5.plus(6)` shortens (the `dot`/`stay` echo dispatch is gone) — that is the point of the fix
- `make test`: 2414 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10 backtrace, #1077); hlint and fourmolu clean
