### PR TITLE
fix(xmir): keep residual documents schema-valid with one bare root <o> (#1076)

### DIFF
--- a/.github/workflows/objectionary.yml
+++ b/.github/workflows/objectionary.yml
@@ -82,3 +82,16 @@ jobs:
         run: |
           cd home
           eoc -s objects print --print-input=2-rewritten --print-output=../objects
+      - name: Validate a dataization residual against the XMIR schema
+        run: |
+          set -e
+          curl -sL -o /tmp/XMIR.xsd https://raw.githubusercontent.com/objectionary/eo/refs/heads/gh-pages/XMIR.xsd
+          cat > /tmp/stuck.phi <<'PHI'
+          ⟦
+            bytes ↦ ⟦ φ ↦ ∅ ⟧,
+            number ↦ ⟦ φ ↦ ∅, plus(x) ↦ ⟦ λ ⤍ L_number_plus ⟧ ⟧,
+            φ ↦ 5.plus(6)
+          ⟧
+          PHI
+          phino dataize --partial --output=xmir /tmp/stuck.phi > /tmp/residual.xml
+          xmllint --noout --schema /tmp/XMIR.xsd /tmp/residual.xml

--- a/.github/workflows/objectionary.yml
+++ b/.github/workflows/objectionary.yml
@@ -85,6 +85,8 @@ jobs:
       - name: Validate a dataization residual against the XMIR schema
         run: |
           set -e
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libxml2-utils
           curl -sL -o /tmp/XMIR.xsd https://raw.githubusercontent.com/objectionary/eo/refs/heads/gh-pages/XMIR.xsd
           cat > /tmp/stuck.phi <<'PHI'
           ⟦

--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -194,9 +194,9 @@ expressionToXMIR expr@(ExFormation [BiTau (AtLabel _) arg, BiVoid AtRho]) ctx = 
   ExRoot -> programToXMIR expr ctx
   _ -> throwIO (UnsupportedTopExpression expr)
 -- The top of a '--partial' residual and the result of 'merge' are arbitrary
--- formations: several τ/λ bindings, voids and a bound ρ. Every binding such a
--- formation carries becomes a child of <object>; 'xmirToPhi' reads the list
--- back (#1076)
+-- formations: several τ/λ bindings, voids and a bound ρ. The schema allows a
+-- single <o> under <object>, so the formation goes beneath one attribute-free
+-- <o> whose children are its bindings; 'xmirToPhi' reads that shape back (#1076)
 expressionToXMIR expr@(ExFormation bds) ctx =
   documentWith ctx [] expr rootNodes
   where
@@ -204,7 +204,7 @@ expressionToXMIR expr@(ExFormation bds) ctx =
     rootNodes = do
       roots <- nestedBindings bds ctx
       unless (any isElement roots) (throwIO (UnsupportedTopExpression expr))
-      pure roots
+      pure [object [] roots]
     isElement :: Node -> Bool
     isElement (NodeElement _) = True
     isElement _ = False
@@ -441,11 +441,9 @@ xmirToPhi xmir =
         NodeElement el
           | nameLocalName (elementName el) == "object" -> do
               unless (null (strayNodes doc)) (throwIO (InvalidXMIRFormat "No processing instructions or bare text are allowed in <object>" doc))
-              bds <- case doc C.$/ C.element (toName "o") of
-                [] -> throwIO (InvalidXMIRFormat "Expected at least one <o> element in <object>" doc)
-                -- A residual document (printed by '--partial', #1076) carries
-                -- one <o> per binding of the stuck formation, so read them all
-                os -> uniqueBindings' =<< mapM (`xmirToFormationBinding` []) os
+              o <- case doc C.$/ C.element (toName "o") of
+                [single] -> pure single
+                _ -> throwIO (InvalidXMIRFormat "Expected single <o> element in <object>" doc)
               let pckg =
                     [ T.unpack t
                     | meta <- doc C.$/ C.element (toName "metas") C.&/ C.element (toName "meta")
@@ -454,15 +452,29 @@ xmirToPhi xmir =
                     , tail' <- meta C.$/ C.element (toName "tail") C.&/ C.content
                     , t <- T.splitOn "." tail'
                     ]
-              if null pckg
-                then pure (ExFormation (withVoidRho bds))
-                else case bds of
-                  [obj] ->
-                    let bd = foldr (\part acc -> BiTau (AtLabel (T.pack part)) (ExFormation [acc, BiLambda (Function "Package"), BiVoid AtRho])) obj pckg
-                     in pure (ExFormation [bd, BiVoid AtRho])
-                  _ -> throwIO (InvalidXMIRFormat "A <object> with <metas> package must hold a single <o>" doc)
+              -- An attribute-free <o> is a residual formation printed by
+              -- '--partial': its children are the bindings themselves (#1076)
+              if bareRoot o
+                then
+                  if null pckg
+                    then xmirToFormation o []
+                    else throwIO (InvalidXMIRFormat "A <object> with <metas> package must hold a named <o>" doc)
+                else
+                  if null pckg
+                    then do
+                      bd <- xmirToFormationBinding o []
+                      pure (ExFormation (withVoidRho [bd]))
+                    else do
+                      obj <- xmirToFormationBinding o []
+                      let bd = foldr (\part acc -> BiTau (AtLabel (T.pack part)) (ExFormation [acc, BiLambda (Function "Package"), BiVoid AtRho])) obj pckg
+                      pure (ExFormation [bd, BiVoid AtRho])
           | otherwise -> throwIO (InvalidXMIRFormat "Expected single <object> element" doc)
         _ -> throwIO (InvalidXMIRFormat "NodeElement is expected as root element" doc)
+
+-- The single <o> of a residual document carries no attributes of its own:
+-- it is the formation, not one of its bindings (#1076)
+bareRoot :: C.Cursor -> Bool
+bareRoot o = not (any (`hasAttr` o) ["name", "base", "as"])
 
 xmirToFormationBinding :: C.Cursor -> [String] -> IO Binding
 xmirToFormationBinding cur fqn

--- a/test-resources/xmir-parsing-packs/multiple-root-formations.yaml
+++ b/test-resources/xmir-parsing-packs/multiple-root-formations.yaml
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# A <object> may carry several <o> children: that is how a '--partial'
-# residual and any multi-binding formation are printed (#1076). Two bare
-# name-only <o> read back as bindings to empty formations.
+# <object> allows at most one direct <o> (XMIR.xsd, objectionary/eo#8548
+# consumers validate against it), so two sibling roots are malformed. A
+# residual formation (see #1076) is printed under ONE attribute-free <o>,
+# not as several roots.
+failure: true
 xmir: |
   <object>
     <o name="app"/>
     <o name="other"/>
   </object>
-phi: '[[ app -> [[]], other -> [[]] ]]'
+phi: ''


### PR DESCRIPTION
Follow-up to #1158 (#1076), addressing the review @zaguzovmaksim0-hue left there after the merge.

## Problem
The residual encoding merged in #1158 emits **one direct `<o>` per binding** of the stuck formation. `XMIR.xsd` (gh-pages — the schema every document phino prints references in `xsi:noNamespaceSchemaLocation`) caps `<object>` at a single `<o>`: `<xs:element name="o" type="o" minOccurs="0" maxOccurs="1"/>`. Such documents pass phino's own (relaxed) reader but are schema-invalid — which breaks exactly the `eo-lowering` consumer (objectionary/eo#8548) the feature was requested for. `xcop` and `xmllint --schema` reject them.

## Fix
Encode the residual under **one attribute-free `<o>`** whose children are the bindings — the `o` type is `mixed` with unbounded nested `<o>`, so the output is valid as printed (verified locally with `xmllint --noout --schema XMIR.xsd`):
- `expressionToXMIR` wraps residual bindings in `object []` instead of returning siblings;
- `xmirToPhi` re-rejects multiple roots (`Expected single <o>`) and reads an attribute-free root `<o>` as the formation itself (named root = binding, as before; bare root + package `<metas>` is rejected);
- the `multiple-root-formations.yaml` parsing pack goes back to `failure: true`, with the schema rule named in its comment;
- the `objectionary` job now prints a fresh `dataize --partial --output=xmir` residual and validates it against `XMIR.xsd` with `xmllint` — the contract is checked by the schema, not only by phino's reader.

## Tests
- `make test`: 2418 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10.3); hlint/fourmolu clean
- Existing round-trip cases (λ-bound stuck formation, `--hide-rho`, omit flags) keep passing unchanged on the new encoding
