### PR TITLE
fix(dataize): park --max-steps exhaustion as a residual under --partial (#1078)

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -95,11 +95,17 @@ data DataizeException
     -- everything reduced before it already in place: the residual program that
     -- '_partial' turns into the 'Residual' outcome.
     StuckAt T.Text (NonEmpty Rewritten)
+  | -- An 'OutOfSteps' caught by a spine frame, carrying that frame's derivation
+    -- just like 'StuckAt': a term that never reduces is a stuck site too, so
+    -- '_partial' parks it and hands back the residual instead of failing hard
+    -- (#1078)
+    OutOfStepsAt Int (NonEmpty Rewritten)
   deriving anyclass (Exception)
 
 instance Show DataizeException where
   show (OutOfSteps limit) =
     printf "Dataization did not finish before reaching the limit of steps: --max-steps=%d" limit
+  show (OutOfStepsAt limit _) = show (OutOfSteps limit)
   show (Stuck func) = printf "Atom '%s' does not exist" (T.unpack func)
   show (StuckAt func _) = show (Stuck func)
 
@@ -153,20 +159,23 @@ saturated bds = case lambda bds of
     filled (BiVoid _) = False
     filled _ = True
 
--- Run one frame of the 𝕄/𝔻 spine, attaching its derivation to a stuck atom
--- escaping it. 'Stuck' is raised deep inside an atom, which knows nothing about
--- the chain, so the innermost spine frame it reaches is the one to record where
--- the derivation stopped: the head of that frame's chain is the working
--- expression with the stuck application intact and everything reduced before
--- it already in place. Outer frames see 'StuckAt' and let it pass, since their
--- chains are prefixes of that one; a side-computation running on a chain of its
--- own strips the chain off again (see 'unparked') before the signal reaches
--- the spine.
+-- Run one frame of the 𝕄/𝔻 spine, attaching its derivation to a stuck atom or
+-- an exhausted budget escaping it. 'Stuck' is raised deep inside an atom, which
+-- knows nothing about the chain, so the innermost spine frame it reaches is the
+-- one to record where the derivation stopped: the head of that frame's chain is
+-- the working expression with the stuck application intact and everything
+-- reduced before it already in place. The same holds for 'OutOfSteps': a term
+-- cycling through the universe is no more a failure of the chain than a missing
+-- atom is, and under '_partial' it deserves the same parked residual (#1078).
+-- Outer frames see the '…At' signals and let them pass, since their chains are
+-- prefixes of that one; a side-computation running on a chain of its own strips
+-- the chain off again (see 'unparked') before the signal reaches the spine.
 parking :: NonEmpty Rewritten -> IO a -> IO a
 parking seq action = action `catch` rethrow
   where
     rethrow :: DataizeException -> IO a
     rethrow (Stuck func) = throwIO (StuckAt func seq)
+    rethrow (OutOfSteps limit) = throwIO (OutOfStepsAt limit seq)
     rethrow failure = throwIO failure
 
 -- Strip the derivation off a stuck atom escaping a side-computation that ran
@@ -179,6 +188,7 @@ unparked action = action `catch` rethrow
   where
     rethrow :: DataizeException -> IO a
     rethrow (StuckAt func _) = throwIO (Stuck func)
+    rethrow (OutOfStepsAt limit _) = throwIO (OutOfSteps limit)
     rethrow failure = throwIO failure
 
 -- The Morphing function 𝕄 maps normal forms to formations. It is ternary,
@@ -272,6 +282,9 @@ morph universe ctx@DataizeContext{..} = do
   case result of
     Right ((morphed, seq), state) -> walked morphed seq state
     Left (StuckAt _ seq) | _partial -> do
+      residue <- locatedExpression _locator (fst (NE.head seq))
+      walked residue seq emptyState
+    Left (OutOfStepsAt _ seq) | _partial -> do
       residue <- locatedExpression _locator (fst (NE.head seq))
       walked residue seq emptyState
     Left failure -> throwIO (failure :: DataizeException)
@@ -430,6 +443,7 @@ dataize universe ctx@DataizeContext{..} = do
   case result of
     Right ((bytes, seq), _state) -> pure (Dataized bytes, reverse seq)
     Left (StuckAt _ seq) | _partial -> pure (Residual (fst (NE.head seq)), reverse (NE.toList seq))
+    Left (OutOfStepsAt _ seq) | _partial -> pure (Residual (fst (NE.head seq)), reverse (NE.toList seq))
     Left failure -> throwIO (failure :: DataizeException)
 
 -- The Dataization function 𝔻 retrieves bytes from an expression. It is partial

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1108,6 +1108,15 @@ spec = do
             ["dataize", atoms, "--max-steps=40"]
             ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=40"]
 
+    -- Under '--partial' the same term does not fail: the spent budget is a
+    -- stuck site too, and the run ends on the residual the spine reached (#1078)
+    it "parks --max-steps on a residual with --partial" $
+      withAtoms $ \atoms ->
+        withStdin "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧" $
+          testCLISucceeded
+            ["dataize", atoms, "--max-steps=40", "--partial", "--flat"]
+            ["Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-35-00-00-00-00-00-00"]
+
     it "dataizes with --sequence" $
       withStdin "[[ @ -> [[ x -> [[ D> 01-, y -> ? ]](y -> [[ ]]) ]].x ]]" $
         testCLISucceeded
@@ -1515,6 +1524,14 @@ spec = do
         testCLIFailed
           ["morph", "--locator=Q.@", "--max-steps=3"]
           ["[ERROR]: Dataization did not finish before reaching the limit of steps: --max-steps=3"]
+
+    -- '--partial' parks a spent 𝕄 budget the same way it parks a stuck atom:
+    -- the answer is the term the walk had reached, dispatch intact (#1078)
+    it "parks the spent budget as a residual with --partial" $
+      withStdin "⟦ φ ↦ 5.gt(Φ.nan) ⟧" $
+        testCLISucceeded
+          ["morph", "--locator=Q.@", "--max-steps=10", "--partial", "--flat", "--hide-rho", "--sweet"]
+          ["5.gt( Φ.nan )"]
 
     -- 𝕄 never fires a bare λ-formation, so only the atoms sitting under a
     -- dispatch ('ml') can get stuck; '--partial' parks them exactly as under 𝔻

--- a/test/DataizeSpec.hs
+++ b/test/DataizeSpec.hs
@@ -574,12 +574,23 @@ spec = do
   -- through md → ma → universe → mf → mphi → ml forever and no CLI option could
   -- stop it (#1052). '--max-steps' bounds that recursion and fails once the
   -- budget is gone.
-  describe "stops a dataization that never reaches bytes" $
+  describe "stops a dataization that never reaches bytes" $ do
     it "fails on the step limit instead of morphing forever" $
       withNode $ do
         expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
         dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True False False registry buildTerm dontSaveStep dontSaveEval)
           `shouldThrow` (\e -> "--max-steps=40" `isInfixOf` show (e :: SomeException))
+
+    -- A budget spent on a cycle is a stuck site just as an atom that cannot
+    -- fire is: under '_partial' the run ends on the residual the spine had
+    -- reached instead of failing hard (#1078)
+    it "parks the step limit as a residual with --partial" $
+      withNode $ do
+        expr <- parseExpressionThrows "⟦ @ ↦ ⟦ λ ⤍ L_number_div, ρ ↦ ⟦ Δ ⤍ 40-45-00-00-00-00-00-00 ⟧, x ↦ ⟦ Δ ⤍ 40-00-00-00-00-00-00-00 ⟧ ⟧ ⟧"
+        (outcome, _) <- dataize expr (DataizeContext ExRoot 25 25 (Steps 40 0) False True True False registry buildTerm dontSaveStep dontSaveEval)
+        case outcome of
+          Residual _ -> pure ()
+          Dataized bts -> expectationFailure ("expected a residual, dataized to " ++ show bts)
 
   -- An atom phino does not know — a name the '--atoms' registry does not carry,
   -- such as the placeholder ⟦ λ ⤍ Sym_arg_0 ⟧ standing in for a data input


### PR DESCRIPTION
Partial fix for #1078 — the "regardless?" half. The design question (whether atom results should be universe-independent, options 1 vs 2 in the issue and in my 09-07 question) is **not** decided by this PR and stays open for the maintainers.

## Problem
`deeper` throws \`OutOfSteps\` **before** `parking` can attach a derivation, so under `--partial --max-steps=N` a term that never reduces to bytes — a missing dispatch cycling through the universe rules (repro from #1134: `5.gt(Φ.nan)` loops even with **no atom fired at all**), or an atom result the universe cannot consume — failed hard instead of yielding the residual program that `--partial` promises. The behavior is re-verified on the current master (comment in #1078).

## Fix
The spent budget is a stuck site: the workflow "give me the stuck place so I can fix it" applies to it exactly as to an unregistered atom.
1. A spine frame now also parks \`OutOfSteps\`, as the new \`OutOfStepsAt\` carrying that frame's derivation; its \`Show\` stays word-for-word the old message, so **non-partial runs are unaffected**.
2. \`unparked\` strips the derivation off the signal escaping a side-computation, mirroring \`StuckAt\`.
3. \`dataize\` and \`morph\` turn \`OutOfStepsAt\` into \`Residual\` under \`_partial\` — the same one-line-adjacent branch as \`StuckAt\` already has.

## Changes
- `src/Dataize.hs` — \`OutOfStepsAt\`, \`parking\`/\`unparked\` and the two wrapper branches (52+/10-)
- `test/DataizeSpec.hs`, `test/CLISpec.hs` — three new cases; a lone-\`it\` \`describe\` gains the \`$ do\` it now needs

## Tests
- `dataize --partial --max-steps=40` on the #1052 div-loop now exits 0 with the parked `Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-35-… ⟧ ) )` residual; without `--partial` the message is unchanged
- `morph --locator=Q.@ --max-steps=10 --partial` parks `5.gt( Φ.nan )`
- `make test`: 2421 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10.3); hlint/fourmolu clean
