### PR TITLE
test(atoms): pin a looping ask question to the parked residual under --partial

### DIFF
--- a/test-resources/atoms/asking-loops.js
+++ b/test-resources/atoms/asking-loops.js
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+// SPDX-License-Identifier: MIT
+
+// The λ function 'L_number_gt', answered by a resident program that asks
+// phino to reduce a term the universe can never finish reducing:
+// 'Φ.nan.gt( 1 )' walks dispatches into a cycle that ends only when the
+// step budget dies. Under '--partial' phino parks where the term cycles and
+// answers the question with the residual (#1078), so the run lives on;
+// without the flag the exhausted budget fails it, exactly as before the ask
+// channel existed (#1160). This script answers every request with the bytes
+// of 42 whatever the question came back with: a run that ends on '2A-' is
+// the proof that a looping question did not take the dataization down.
+
+'use strict';
+
+const readline = require('readline');
+
+// The questions phino has not answered yet, by the 'id' each was minted
+// with, every one of them holding the request it suspended.
+const open = new Map();
+
+let minted = 0;
+
+function said(message) {
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+readline.createInterface({ input: process.stdin }).on('line', (line) => {
+  const message = JSON.parse(line);
+  if ('λ' in message) {
+    minted += 1;
+    open.set(minted, message.id);
+    said({ id: minted, ask: 'Φ.nan.gt( 1 )' });
+  } else if ('𝑛' in message && open.has(message.id)) {
+    const id = open.get(message.id);
+    open.delete(message.id);
+    said({ id, '𝑛': '⟦ Δ ⤍ 2A- ⟧' });
+  }
+});

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -16,7 +16,7 @@ import Data.Text qualified as T
 import Data.Time.Clock (addUTCTime, getCurrentTime)
 import Data.Time.Clock.POSIX (getPOSIXTime)
 import Data.Version (showVersion)
-import Fixtures (withAskingRegistry, withFixtureRegistry, withNode, withServing, withShell)
+import Fixtures (withAskingRegistry, withFixtureRegistry, withLoopingAskRegistry, withNode, withServing, withShell)
 import GHC.IO.Handle
 import Paths_phino (version)
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive, removeFile, removePathForcibly, setModificationTime)
@@ -132,6 +132,9 @@ withAtoms action = withNode (withFixtureRegistry (action . ("--atoms=" ++)))
 -- for every one of them instead (see 'Fixtures')
 withAsking :: (String -> Expectation) -> Expectation
 withAsking action = withNode (withAskingRegistry (action . ("--atoms=" ++)))
+
+withLoopingAsk :: (String -> Expectation) -> Expectation
+withLoopingAsk action = withNode (withLoopingAskRegistry (action . ("--atoms=" ++)))
 
 testCLIFailed :: [String] -> [String] -> Expectation
 testCLIFailed args outputs = testCLI' args outputs (Left (ExitFailure 1))
@@ -1345,6 +1348,26 @@ spec = do
         withAsking $ \atoms ->
           withStdin "[[ bytes ↦ ⟦ φ ↦ ∅ ⟧, number(φ) -> [[ plus(x) -> [[ L> L_number_plus ]] ]], @ -> 5.plus(6.plus(7)) ]]" $
             testCLISucceeded ["dataize", atoms] ["40-32-00-00-00-00-00-00"]
+
+      -- A question about a term the universe cannot finish reducing does not
+      -- kill a '--partial' run: phino parks the cycle the question walks into
+      -- and answers with the residual, so the program still replies and the
+      -- bytes arrive (#1078, over the ask channel of #1160)
+      it "answers a looping question with a parked residual under --partial" $
+        withLoopingAsk $ \atoms ->
+          withStdin "⟦ bytes ↦ ⟦ φ ↦ ∅ ⟧, number ↦ ⟦ φ ↦ ∅, gt(x) ↦ ⟦ λ ⤍ L_number_gt ⟧ ⟧, φ ↦ 5.gt(1) ⟧" $
+            testCLISucceeded
+              ["dataize", atoms, "--partial", "--max-steps=200"]
+              ["2A-"]
+
+      -- Without '--partial' the exhausted budget fails the run through a
+      -- question just as it fails it anywhere else (#1052's message)
+      it "fails a looping question without --partial" $
+        withLoopingAsk $ \atoms ->
+          withStdin "⟦ bytes ↦ ⟦ φ ↦ ∅ ⟧, number ↦ ⟦ φ ↦ ∅, gt(x) ↦ ⟦ λ ⤍ L_number_gt ⟧ ⟧, φ ↦ 5.gt(1) ⟧" $
+            testCLIFailed
+              ["dataize", atoms, "--max-steps=200"]
+              ["--max-steps=200"]
 
     -- An atom script cannot reduce the operands it was handed by itself, so it
     -- asks phino for them: '--inside' binds an expression to a synthetic

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -8,8 +8,10 @@
 -- 'test-resources/atoms/primitives.js', registered under every name in
 -- 'fixtureAtoms' and branching on the one each request names under 'λ',
 -- another, 'test-resources/atoms/asking.js', which reduces nothing itself and
--- asks phino for its operands, or a POSIX shell script written for the
--- occasion, either run once per fire or kept resident for the run.
+-- asks phino for its operands, a third, 'test-resources/atoms/asking-loops.js',
+-- which asks a question that never stops cycling, or a POSIX shell script
+-- written for the occasion, either run once per fire or kept resident for the
+-- run.
 module Fixtures
   ( fixtureAtoms
   , fixtureRegistry
@@ -17,6 +19,7 @@ module Fixtures
   , withAskingRegistry
   , withExecutable
   , withFixtureRegistry
+  , withLoopingAskRegistry
   , withNode
   , withRegistryOf
   , withScript
@@ -80,6 +83,17 @@ withAskingRegistry :: (FilePath -> IO a) -> IO a
 withAskingRegistry action = do
   script <- fixtureScript "asking.js"
   withRegistryOf (object ["L_number_plus" .= entry script]) action
+  where
+    entry :: T.Text -> Value
+    entry script = object ["rt" .= ("node" :: T.Text), "script" .= script, "serve" .= True]
+
+-- The registry of the resident program that asks about a term the universe
+-- never finishes reducing: under '--partial' phino must park the looping
+-- question and hand the residual back rather than fail the run (#1078)
+withLoopingAskRegistry :: (FilePath -> IO a) -> IO a
+withLoopingAskRegistry action = do
+  script <- fixtureScript "asking-loops.js"
+  withRegistryOf (object ["L_number_gt" .= entry script]) action
   where
     entry :: T.Text -> Value
     entry script = object ["rt" .= ("node" :: T.Text), "script" .= script, "serve" .= True]


### PR DESCRIPTION
Follow-up to #1161 over #1162 — **tests only**, no src changes. Part of #1078 (the design question there stays open).

## Why
#1162 gave resident programs the \`ask\` channel; #1161 taught \`--partial\` to park an exhausted budget. The seam between them is untested: when a program asks phino to reduce a term the universe can never finish reducing, the inner dataization behind the question used to throw \`OutOfSteps\` before any frame could park it — today it parks, answers the question with the residual, and the run lives. Nothing pins that, and both features are young enough to regress into each other.

## Changes
- `test-resources/atoms/asking-loops.js` — a resident \`L_number_gt\` that asks about \`Φ.nan.gt( 1 )\` (a term that cycles in any universe that lacks it) and answers every request with \`⟦ Δ ⤍ 2A- ⟧\` whatever comes back, so a run ending on `2A-` is proof from the program's side of the channel
- `test/Fixtures.hs` — `withLoopingAskRegistry`, mirroring the existing `withAskingRegistry`
- `test/CLISpec.hs` — two cases: `--partial` ends on `2A-` (exit 0); without it the run fails with the #1052 message

## Tests
- Deterministic: pure state machine over a frozen budget (`--max-steps=200`), no timing dependence — verified twice on the same binary
- `make test`: 2430 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10.3); hlint/fourmolu clean; 79+/3-
