### PR TITLE
fix(rules): report a condition whose evaluation raised, before treating it as not met (#1079)

### DIFF
--- a/src/Rule.hs
+++ b/src/Rule.hs
@@ -16,6 +16,7 @@ import Builder
   , buildExpressionThrows
   )
 import Bytes (btsToUnescapedStr)
+import Control.Exception (Exception (displayException))
 import Control.Exception.Base (SomeException, try)
 import Control.Monad (when)
 import qualified Data.ByteString.Char8 as B
@@ -285,7 +286,13 @@ meetCondition cond (subst : rest) ctx = do
       case first of
         [] -> pure next
         sbt : _ -> pure (sbt : next)
-    Left _ -> meetCondition cond rest ctx
+    -- A condition that raises is treated as not met: that is the policy
+    -- #1079 questions, and it stays until the maintainers answer. The
+    -- silence on top of it is nobody's friend — say what raised, at debug
+    -- level, so a broken 'when'/'having' can be found with --log-level=debug
+    Left err -> do
+      logDebug (printf "Condition %s raised and was treated as not met: %s" (show cond) (displayException err))
+      meetCondition cond rest ctx
 
 meetMaybeCondition :: Maybe Y.Condition -> [Subst] -> RuleContext -> IO [Subst]
 meetMaybeCondition Nothing substs _ = pure substs

--- a/test-resources/cli/raising-condition.yaml
+++ b/test-resources/cli/raising-condition.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# 'matches' dataizes its argument, and dataization of a formation (what
+# '!e1' is bound to in the test input) raises inside the condition. The
+# substitution must still be dropped (the policy #1079 questions), but the
+# raise must be visible in the debug log (#1079).
+name: raising-condition
+pattern: '[[ x -> !e1 ]]'
+result: '[[ x -> "hi" ]]'
+when:
+  matches: ['hello', '!e1']

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -1063,6 +1063,17 @@ spec = do
               ]
           ]
 
+    -- 'matches' inside 'when' raises while dataizing a formation: the
+    -- substitution is still dropped (the policy #1079 questions), but the
+    -- reason surfaces in the debug log instead of vanishing
+    it "reports a condition that raised while being evaluated" $
+      withStdin "[[ x -> [[ y -> ∅ ]] ]]" $
+        testCLISucceeded
+          ["rewrite", rule "raising-condition.yaml", "--log-level=debug", "--flat"]
+          [ "raised and was treated as not met: user error (Only data objects and bytes are supported"
+          , "⟦ x ↦ ⟦ y ↦ ∅, ρ ↦ ∅ ⟧, ρ ↦ ∅ ⟧"
+          ]
+
     it "canonizes expression" $
       withStdin "[[ x -> [[ y -> [[ L> Func ]].q, z -> Q.x(a -> [[ w -> [[ L> Atom ]], L> Hello ]]) ]], L> Package ]]" $
         testCLISucceeded


### PR DESCRIPTION
Part of #1078-style policy is NOT decided here — this PR takes only the second bullet of #1079 ("log the exception instead of full silence"), which changes no behavior. The option-1-vs-2 question (non-throwing builders vs propagating) stays open for the maintainers.

## Problem
`meetCondition` (src/Rule.hs:288) catches every exception from a `when`/`having` condition and drops the substitution without a word. A `matches` whose `dataize` throws ("Only data objects and bytes are supported..."), or a `part_of` with an unbuildable meta, becomes indistinguishable from a condition that was legitimately not met — unobservable in the logs, despite every nearby pipeline (`extraSubstitutions`) logging plenty.

## Fix
Log the raise at debug level right where it is swallowed — condition, substitution outcome unchanged, exception displayed — then continue exactly as before. `--log-level=debug` now shows:
```
[DEBUG]: Condition Matches "hello" (ExMeta "e1") raised and was treated as not met: user error (Only data objects and bytes are supported by ...
```
No rule changes behavior: same substitutions dropped, same rewritten output; only an added debug line when a condition raises.

## Changes
- `src/Rule.hs` — `Left err` branch logs before dropping (+`displayException` import)
- `test-resources/cli/raising-condition.yaml` — fixture rule whose `when` dataizes a formation (the exact throw source named in the issue)
- `test/CLISpec.hs` — asserts the debug line AND that the output is what the silent drop always produced

## Tests
- `make test`: 2429 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10.3); hlint/fourmolu clean; 31+/1-
