### PR TITLE
feat(atoms): serve lean receivers and questions that name operands (#1165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,10 @@ raw result, normalizing it exactly as it normalizes anything else, so
 A program started for the fire is asked one request, always `id` 1, and its
 `stdin` is closed behind it, so it may read its input whole or line by line, as
 it pleases. It is waited for once it has answered, and a non-zero exit fails
-the run. So does a reply that is not JSON, carries neither `𝑛` nor `ask` (the
-next section is about `ask`), answers another `id`, or an `𝑛` that does not
-parse, or a program that quits without answering — always with the program's
-own `stderr` in the message.
+the run. So does a reply that is not JSON, carries neither `𝑛`, nor `ask`, nor
+`of` with `attr` (the next section is about the questions), answers another
+`id`, or an `𝑛` that does not parse, or a program that quits without answering
+— always with the program's own `stderr` in the message.
 
 Each key of the registry is a regular expression, and it must match the whole
 λ name, so a plain name such as `L_number_plus` means that one atom and nothing
@@ -224,16 +224,18 @@ which is its cue to quit, and terminates it if it has not quit within a second.
 An operand reaches a program as it was written: `5.plus( 6.plus( 7 ) )` fires
 `L_number_plus` with `x ↦ Φ.number( … ).plus( … )`, and getting a number out of
 that is dataization, which is `phino`'s business and not a program's. So the
-program asks. It writes a line of its own, an `id` it mints and, under `ask`,
-the 𝜑-expression it wants reduced, and `phino` answers with that `id` and the
-result under `𝑛`:
+program asks, and it may ask by name. A line of its own carries an `id` it
+mints and the `of` of the request being served, plus one of that receiver's
+attributes under `attr`; `phino` answers with that `id` and the result under
+`𝑛`, taking the value straight out of the receiver it still holds for the
+request — neither side ever re-prints or re-parses it:
 
 ```text
 {"𝑒": "⟦ bytes ↦ ⟦ … ⟧, number ↦ ⟦ … ⟧, φ ↦ … ⟧"}
-{"id": 1, "λ": "L_number_plus", "𝑏": "⟦ x ↦ Φ.number( … ).plus( … ), ρ ↦ … ⟧"}
-{"id": 7, "ask": "⟦ x ↦ Φ.number( … ).plus( … ), ρ ↦ … ⟧.ρ"}
+{"id": 1, "λ": "L_number_plus", "𝑏": "⟦ x ↦ Φ.number( … ).plus( … ) ⟧"}
+{"id": 7, "of": 1, "attr": "ρ", "reduce": true}
 {"id": 7, "𝑛": "⟦ Δ ⤍ 40-14-00-00-00-00-00-00 ⟧"}
-{"id": 8, "ask": "⟦ x ↦ Φ.number( … ).plus( … ), ρ ↦ … ⟧.x"}
+{"id": 8, "of": 1, "attr": "x", "reduce": true}
 {"id": 8, "𝑛": "⟦ Δ ⤍ 40-2A-00-00-00-00-00-00 ⟧"}
 {"id": 1, "𝑛": "Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ 40-32-00-00-00-00-00-00 ⟧ ) )"}
 ```
@@ -241,13 +243,25 @@ result under `𝑛`:
 The universe, the request and the two answers are `phino`'s; the two questions
 and the last line are the program's. A question mints an `id` of its own,
 which `phino` echoes, so a program may keep several of them open and still
-tell the answers apart.
+tell the answers apart. Without `reduce` — or with it saying `false` — the
+answer is the node the attribute carries, as it was written; with `"reduce":
+true` it is the dataization of that node. A question about an `of` whose
+request is no longer in flight, or an `attr` the receiver does not carry,
+fails the fire.
 
-`phino` serves a question by binding the expression to a fresh synthetic
-attribute of the universe, normalizing it there and dataizing it — the same
-trick `--inside` plays — so the answer is a byte formation and the program
-reads its `Δ`; where an atom on the way cannot fire and `--partial` parks it,
-the answer is the residual program instead.
+The other way to ask quotes the 𝜑-expression itself, under `ask`; `phino`
+serves such a question by binding it to a fresh synthetic attribute of the
+universe, normalizing it there and dataizing it — the same trick `--inside`
+plays — so the answer is a byte formation and the program reads its `Δ`; where
+an atom on the way cannot fire and `--partial` parks it, the answer is the
+residual program instead. A quoted question is fine for terms the program
+assembled itself; a question that quotes a receiver is not, because the
+receiver carries its `ρ` and the receiver of that carries its own, all the way
+to the universe: three levels of nesting turn a question of a few hundred
+bytes into one of megabytes. A program kept for the run therefore gets a lean
+`𝑏`, and every answer `phino` sends it is lean too: canonical 𝜑-calculus
+without any ρ chain, because such a program can always ask for what the chain
+holds — by name, cheaply, or by `ask`.
 
 Serving a question re-enters the evaluator, so a question may cost a fire of
 the very atom that asked it. That request arrives while the question is still
@@ -257,7 +271,9 @@ line. The step budget of the run, `--max-steps`, bounds the nesting.
 Only a program kept for the run may ask. `phino` closes the `stdin` of a
 program started for the fire behind its request, since such a program may read
 its input whole before it answers, so there is nothing left to answer a
-question over, and one that asks anyway fails the fire.
+question over, and one that asks anyway fails the fire — which is also why the
+lean `𝑏` is tied to `serve` and not to a flag of its own: a program that is
+handed the whole receiver cannot ask for what it left out.
 
 So a `serve` entry of `L_number_plus` that has `phino` reduce its operands
 reads like this:
@@ -277,9 +293,9 @@ const hex = (value) => {
     .map((octet) => octet.toString(16).toUpperCase().padStart(2, '0'))
     .join('-');
 };
-function* plus(b) {
-  const rho = number(yield `${b}.ρ`);
-  const x = number(yield `${b}.x`);
+function* plus(request) {
+  const rho = number(yield {of: request, attr: 'ρ', reduce: true});
+  const x = number(yield {of: request, attr: 'x', reduce: true});
   return `Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ${hex(rho + x)} ⟧ ) )`;
 }
 const advance = (atom, id, answer) => {
@@ -290,12 +306,12 @@ const advance = (atom, id, answer) => {
   }
   minted += 1;
   open.set(minted, { atom, id });
-  said({ id: minted, ask: step.value });
+  said({ id: minted, ...step.value });
 };
 readline.createInterface({ input: process.stdin }).on('line', (line) => {
   const message = JSON.parse(line);
   if ('λ' in message) {
-    advance(plus(message['𝑏']), message.id, undefined);
+    advance(plus(message.id), message.id, undefined);
   } else if ('𝑛' in message) {
     const waiting = open.get(message.id);
     open.delete(message.id);

--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -47,6 +47,20 @@
 -- one started for the fire is closed behind its request, so there is nothing
 -- left to answer it over.
 --
+-- A kept program may also ask by reference, naming an operand instead of
+-- quoting it: 'of' carries the 'id' of a request still in flight, 'attr' the
+-- canonical name of an attribute of the receiver that request was made of, and
+-- the optional 'reduce' says whether to hand the node over as it is (false,
+-- by default) or to dataize it the way 'ask' does. phino serves such a
+-- question from the formation it already holds for that request, so neither
+-- side ever re-prints a receiver the other side has in hand (#1165).
+--
+-- The whole 𝜑-text on the channel is the currency of programs started for one
+-- fire: a kept one, able to ask for whatever the text left out, is served a
+-- lean one — '𝑏' and every answer carry no ρ chain, since that chain climbs
+-- to Φ and, through questions quoting earlier questions, compounds the
+-- message by the depth of the ask (#1165).
+--
 -- A name no key matches has no λ function at all: 𝔼 gets stuck on it, exactly
 -- as it does for a name no one ever declared (see 'Stuck' in 'Dataize').
 module Atoms
@@ -80,7 +94,8 @@ import Data.Aeson.Types (JSONPathElement (Key), parseEither, (<?>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Lazy as BSL
-import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, atomicModifyIORef', modifyIORef', newIORef, readIORef, writeIORef)
+import qualified Data.IntMap.Strict as IM
 import Data.List (find, intercalate)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -91,7 +106,7 @@ import Lining (LineFormat (SINGLELINE))
 import Logger (logDebug)
 import Margin (defaultMargin)
 import Parser (parseExpression)
-import Printer (printExpression')
+import Printer (printAttribute, printExpression', printExpressionHidingRho')
 import Sugar (SugarType (SALTY))
 import System.Directory (doesFileExist, executable, getPermissions, getTemporaryDirectory, removePathForcibly)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
@@ -147,12 +162,13 @@ instance Show Session where
 
 -- A program while it runs: its streams, the file its complaints go to, the
 -- file its script is staged in, if it is a script, the universe it was told
--- last, so it is told again only when the universe changes, and how many
--- requests it has been asked, which numbers the next one. The last two are
--- mutable, since a fire may nest: serving a question of the program takes an
--- evaluator that fires atoms of its own, and the one it reaches may be this
--- very program, asked again over these very handles while its question is
--- still open.
+-- last, so it is told again only when the universe changes, how many
+-- requests it has been asked, which numbers the next one, and the receivers
+-- of the requests still in flight, which by-reference questions name instead
+-- of quoting (#1165). The last three are mutable, since a fire may nest:
+-- serving a question of the program takes an evaluator that fires atoms of
+-- its own, and the one it reaches may be this very program, asked again over
+-- these very handles while its question is still open.
 data Running = Running
   { _input :: Handle
   , _output :: Handle
@@ -161,6 +177,7 @@ data Running = Running
   , _staged :: Maybe FilePath
   , _told :: IORef (Maybe Expression)
   , _requests :: IORef Int
+  , _forms :: IORef (IM.IntMap Expression)
   }
 
 -- What is left of the channel to a program once its request is pushed through:
@@ -256,13 +273,17 @@ instance FromJSON Entry where
   parseJSON value = Entry <$> parseJSON value <*> withObject "atom" (\entry -> entry .:? "serve" .!= False) value
 
 -- What a program writes back: the answer to the request it was asked, the
--- 𝜑-expression under '𝑛', or a question of its own, the 𝜑-expression under
--- 'ask' that it needs reduced before it can answer. An answer echoes the 'id'
+-- 𝜑-expression under '𝑛', a question of its own, the 𝜑-expression under
+-- 'ask' that it needs reduced before it can answer, or a question by
+-- reference, naming an in-flight request under 'of' and one of the receiver's
+-- attributes under 'attr', with 'reduce' deciding whether the answer is the
+-- node as it is held or its dataization (#1165). An answer echoes the 'id'
 -- of the request it answers, a question mints an 'id' of its own, which phino
 -- echoes back.
 data Said
   = Answer Int T.Text
   | Question Int T.Text
+  | Reference Int Int T.Text Bool
 
 instance FromJSON Said where
   parseJSON = withObject "reply" $ \said -> do
@@ -272,7 +293,13 @@ instance FromJSON Said where
     case (answer, question) of
       (Just raw, _) -> pure (Answer number raw)
       (Nothing, Just raw) -> pure (Question number raw)
-      (Nothing, Nothing) -> fail "there is neither '𝑛' nor 'ask' in it"
+      _ -> do
+        request <- said .:? "of"
+        attr <- said .:? "attr"
+        reduced <- said .:? "reduce" .!= False
+        case (request, attr) of
+          (Just req, Just name) -> pure (Reference number req name reduced)
+          _ -> fail "there is neither '𝑛', nor 'ask', nor 'of' with 'attr' in it"
 
 -- No λ function at all: every atom gets stuck. This is what a run without
 -- '--atoms' fires against.
@@ -396,7 +423,7 @@ started func program = do
   (executable, arguments, staged) <- commanded dir
   logDebug (printf "Starting atom '%s' as '%s'" (T.unpack func) (unwords (executable : arguments)))
   (input, output, process) <- spawned executable arguments handle `onException` discarded complaints staged
-  Running input output process complaints staged <$> newIORef Nothing <*> newIORef 0
+  Running input output process complaints staged <$> newIORef Nothing <*> newIORef 0 <*> newIORef IM.empty
   where
     -- The command line the program is started with, and the file staged for
     -- it, if it is a script.
@@ -433,16 +460,33 @@ started func program = do
 asked :: T.Text -> Running -> Expression -> Expression -> Channel -> ReduceFunc -> IO Expression
 asked func Running{..} form univ channel reduce = do
   number <- atomicModifyIORef' _requests (\spent -> (spent + 1, spent + 1))
+  modifyIORef' _forms (IM.insert number form)
   told <- readIORef _told
   logDebug (printf "Asking atom '%s' as request %d" (T.unpack func) number)
   said (if told == Just univ then request number else universe <> request number)
   writeIORef _told (Just univ)
-  heard number
+  heard number `onException` forget number
   where
     universe :: BS.ByteString
-    universe = lined (object ["𝑒" .= rendered univ])
+    universe = lined (object ["𝑒" .= spelled univ])
     request :: Int -> BS.ByteString
-    request number = lined (object ["id" .= number, "λ" .= func, "𝑏" .= rendered form])
+    request number = lined (object ["id" .= number, "λ" .= func, "𝑏" .= spelled form])
+    -- Everything phino says to a program kept for the run is spelled without
+    -- the ρ chain: such a program can ask for what the chain holds, by value
+    -- with 'ask' or by reference with 'of' and 'attr', so quoting it into
+    -- every message only makes the next question bigger (#1165). A program
+    -- started for the fire has no channel to ask over and keeps getting the
+    -- whole receiver, ρ and all.
+    spelled :: Expression -> T.Text
+    spelled = case channel of
+      Open -> lean
+      Closed -> rendered
+    lean :: Expression -> T.Text
+    lean expr = T.pack (printExpressionHidingRho' expr (SALTY, UNICODE, SINGLELINE, defaultMargin))
+    -- The receiver of a request is of no use to the channel once the request
+    -- has been answered.
+    forget :: Int -> IO ()
+    forget = modifyIORef' _forms . IM.delete
     -- Read the program's lines until it answers the request phino asked,
     -- serving every question it asks on the way.
     heard :: Int -> IO Expression
@@ -452,8 +496,45 @@ asked func Running{..} form univ channel reduce = do
         Left failure -> throwIO (AtomMute func (spoken reply) failure)
         Right (Answer echoed raw)
           | echoed /= number -> throwIO (AtomMute func (spoken reply) (printf "it answers request %d, while phino asked request %d" echoed number))
-          | otherwise -> either (throwIO . AtomMute func (T.unpack raw)) pure (parseExpression (T.unpack raw))
+          | otherwise -> forget number >> either (throwIO . AtomMute func (T.unpack raw)) pure (parseExpression (T.unpack raw))
         Right (Question minted raw) -> served minted raw >> heard number
+        Right (Reference minted req name doReduce) -> referenced minted req name doReduce >> heard number
+    -- The by-reference sibling of 'served': the question names an in-flight
+    -- request and one attribute of its receiver, and phino answers from the
+    -- formation it still holds for that request, without either side
+    -- re-printing or re-parsing a receiver. 'reduce' says whether to dataize
+    -- what the attribute carries, as 'ask' does, or to hand the node over as
+    -- it is (#1165).
+    referenced :: Int -> Int -> T.Text -> Bool -> IO ()
+    referenced minted req name doReduce = do
+      spoken' <- describe
+      case spoken' of
+        Left failure -> throwIO (AtomMute func described failure)
+        Right value -> do
+          logDebug (printf "Atom '%s' asks phino for '%s' of request %d%s as question %d" (T.unpack func) (T.unpack name) req (if doReduce then ", reduced," else ", as it is," :: String) minted)
+          answer <- if doReduce then reduce value else pure value
+          said (lined (object ["id" .= minted, "𝑛" .= spelled answer]))
+      where
+        described :: String
+        described = printf "{'of':%d,'attr':'%s'}" req (T.unpack name)
+        describe :: IO (Either String Expression)
+        describe = do
+          forms <- readIORef _forms
+          pure $ case IM.lookup req forms of
+            Nothing -> Left (printf "there is no in-flight request %d to take '%s' from" req (T.unpack name))
+            Just form' -> case attributeValue name form' of
+              Nothing -> Left (printf "the receiver of request %d carries no attribute '%s'" req (T.unpack name))
+              Just value -> Right value
+    attributeValue :: T.Text -> Expression -> Maybe Expression
+    attributeValue name (ExFormation bds) = go bds
+      where
+        go :: [Binding] -> Maybe Expression
+        go [] = Nothing
+        go (BiTau attr value : rest)
+          | T.pack (printAttribute attr) == name = Just value
+          | otherwise = go rest
+        go (_ : rest) = go rest
+    attributeValue _ _ = Nothing
     -- Reduce the 𝜑-expression the program asks about and say it back under
     -- '𝑛', with the 'id' the question minted. A program started for the fire
     -- has nothing to be answered over, since phino closed its stdin behind the
@@ -465,7 +546,7 @@ asked func Running{..} form univ channel reduce = do
         logDebug (printf "Atom '%s' asks phino to reduce '%s' as question %d" (T.unpack func) (T.unpack raw) minted)
         target <- either (unreadable raw) pure (parseExpression (T.unpack raw))
         answer <- reduce target
-        said (lined (object ["id" .= minted, "𝑛" .= rendered answer]))
+        said (lined (object ["id" .= minted, "𝑛" .= spelled answer]))
     unreadable :: T.Text -> String -> IO a
     unreadable raw failure = throwIO (AtomMute func (T.unpack raw) (printf "it asks phino to reduce an expression that does not parse: %s" failure))
     -- A program that has died leaves the write with nobody to drain it. The

--- a/test-resources/atoms/asking.js
+++ b/test-resources/atoms/asking.js
@@ -4,12 +4,15 @@
 // The λ function 'L_number_plus', answered by a program that reduces nothing
 // itself. An operand arrives as it was written, so 'Φ.number( … ).plus( … )'
 // reaches this script whole, and getting the number out of it is dataization,
-// which is phino's business and not a script's. So the script asks: it writes a
-// line of its own, an 'id' it minted and the 𝜑-expression under 'ask', and
-// phino answers it with that 'id' and the bytes under '𝑛'. Before the channel
-// carried questions, a script had to splice the operand into the text of the
-// universe and run a whole phino of its own on it.
-//
+// which is phino's business and not a script's. So the script asks, naming
+// rather than quoting: a line of its own with an 'id' it minted, the 'of' of
+// the request being served and the 'attr' of the operand it wants, with
+// 'reduce' asking phino to dataize it. Such a question is served from the
+// receiver phino already holds for that request, in lean text without the ρ
+// chain (#1165), and answered with that 'id' and the bytes under '𝑛' — where
+// quoting the receiver in an 'ask' used to make the next question twice as
+// big as the last.
+
 // Every request is a coroutine, so a question suspends the request that asked
 // it rather than the script: serving a question fires atoms of its own, and one
 // of them may well be this very atom, whose request arrives while the question
@@ -42,10 +45,12 @@ function hex(value) {
 
 // The λ function itself: every 𝜑-expression it yields is a question, and what
 // comes back is the answer phino reduced, so both operands arrive as bytes
-// however deeply they were written.
-function* plus(b) {
-  const rho = number(yield `${b}.ρ`);
-  const x = number(yield `${b}.x`);
+// however deeply they were written. The operands are named by reference: 'of'
+// is the request being served, 'attr' the attribute of its receiver, and
+// 'reduce' says phino should dataize the value rather than hand the node over.
+function* plus(request) {
+  const rho = number(yield { of: request, attr: 'ρ', reduce: true });
+  const x = number(yield { of: request, attr: 'x', reduce: true });
   return Number.isNaN(rho) || Number.isNaN(x)
     ? '⊥'
     : `Φ.number( φ ↦ Φ.bytes( φ ↦ ⟦ Δ ⤍ ${hex(rho + x)} ⟧ ) )`;
@@ -71,13 +76,13 @@ function advance(atom, id, answer) {
   }
   minted += 1;
   open.set(minted, { atom, id });
-  said({ id: minted, ask: step.value });
+  said({ id: minted, ...step.value });
 }
 
 readline.createInterface({ input: process.stdin }).on('line', (line) => {
   const message = JSON.parse(line);
   if ('λ' in message) {
-    advance(plus(message['𝑏']), message.id, undefined);
+    advance(plus(message.id), message.id, undefined);
   } else if ('𝑛' in message) {
     const waiting = open.get(message.id);
     open.delete(message.id);

--- a/test/AtomsSpec.hs
+++ b/test/AtomsSpec.hs
@@ -187,6 +187,24 @@ asking expr pattern =
     , "esac"
     ]
 
+-- A resident program that names an operand instead of quoting a receiver
+-- (#1165): it asks phino for the given 'attr' of the in-flight request 'of',
+-- reduced when the second argument says so, under the question 'id' 7, then
+-- answers its own request with 'FF-' when what phino said back matches the
+-- given shell pattern and with '00-' when it does not
+referring :: Int -> T.Text -> Bool -> T.Text -> T.Text
+referring request attr doReduce pattern =
+  T.unlines
+    [ "printf '{\"id\": 7, \"of\": " <> T.pack (show request) <> ", \"attr\": \"" <> attr <> "\"" <> reduce <> "}\\n'"
+    , "IFS= read -r reply"
+    , "case \"$reply\" in"
+    , "  " <> pattern <> ") " <> replying "FF-" <> ";;"
+    , "  *) " <> replying "00-" <> ";;"
+    , "esac"
+    ]
+  where
+    reduce = if doReduce then ", \"reduce\": true" else ""
+
 -- A resident program whose question phino cannot answer without firing the
 -- same program again: it asks, then serves every request phino sends while its
 -- question is open, and answers its own request once the answer to the
@@ -551,6 +569,58 @@ spec = do
     -- is nothing left to answer a question of its own over
     it "fails when a script started for the fire asks a question" $
       fails "process.stdout.write(JSON.stringify({id: 7, ask: 'Q.x'}))" ["L_answer", "serve"]
+
+    -- A question of 'of' and 'attr' is served from the receiver phino holds
+    -- for that in-flight request, so the node is handed over without either
+    -- side quoting or re-parsing it (#1165)
+    it "hands the node of a named attribute to a program that asks for it by reference" $
+      serves (referring 1 "x" False "*01-*") "⟦ Δ ⤍ FF- ⟧"
+
+    -- The same naming, with 'reduce': the value is dataized the way an 'ask'
+    -- is, which is what the answer of the question is made of
+    it "dataizes the named attribute when the question says 'reduce'" $
+      serves (referring 1 "x" True "*2A-*") "⟦ Δ ⤍ FF- ⟧"
+
+    -- What gets reduced for a by-reference question is the value the attribute
+    -- carries, not a re-parse of anything quoted
+    it "reduces the very node the attribute carries when the question asks to" $
+      withShell $
+        withServed ["L_answer"] (referring 1 "x" True "*2A-*") $ \registry -> do
+          seen <- newIORef Nothing
+          _ <- firedFrom' registry "L_answer" "⟦ y ↦ ⟦ Δ ⤍ 02- ⟧ ⟧" (recording seen)
+          wanted <- parseExpressionThrows "⟦ Δ ⤍ 01- ⟧"
+          readIORef seen `shouldReturn` Just wanted
+
+    -- A receiver is of no use to the channel once its request has been
+    -- answered, and a question may not dig out of it after that
+    it "fails a question about a request that is no longer in flight" $
+      refuses (referring 2 "x" False "*2A-*") ["L_answer", "no in-flight request 2"]
+
+    it "fails a question about an attribute the receiver does not carry" $
+      refuses (referring 1 "z" False "*2A-*") ["L_answer", "carries no attribute 'z'"]
+
+    -- A program kept for the run is served a lean '𝑏', with no ρ chain: the
+    -- chain climbs to the universe and compounds every question that quotes
+    -- its receiver, and whatever the lean text leaves out this program can
+    -- ask for, which a transient one cannot (#1165)
+    it "tells the resident program the receiver without its ρ chain" $
+      serves
+        ( T.unlines
+            [ "case \"$line\" in"
+            , "  *'ρ ↦'*) " <> replying "FF-" <> ";;"
+            , "  *) " <> replying "00-" <> ";;"
+            , "esac"
+            ]
+        )
+        "⟦ Δ ⤍ 00- ⟧"
+
+    -- A program started for the fire cannot ask, so its '𝑏' keeps the whole
+    -- receiver, ρ and all — the lean channel is tied to 'serve', not to a new
+    -- flag
+    it "keeps the whole receiver in the '𝑏' of a program started for the fire" $
+      answers
+        (scripting "/\\u03c1 \\u21a6/.test(request['𝑏']) ? '⟦ Δ ⤍ FF- ⟧' : '⟦ Δ ⤍ 00- ⟧'")
+        "⟦ Δ ⤍ FF- ⟧"
 
   describe "closeRegistry" $ do
     -- The program is told to quit by its stdin closing, which its read loop


### PR DESCRIPTION
Fixes #1165. Protocol interpretation as stated in my comment there (lean `𝑏` tied to `serve`; `of`+`attr` with an optional `reduce` boolean) — if you wanted a different discriminator for the two readings, it is a one-line change.

## Problem
`asked` rendered the atom's receiver in full at every fire; the ρ chain climbs to Φ, and a question that quotes a receiver compounds it: measured on the eo-lowering prototype — ten fires, 23.6 MB on the channel, 21.5 s of printing, 8 MB in the largest single message (90 times the universe), each nesting level multiplying by 2–3 through synthetic `a🌵` attributes.

## Fix
Both changes from the issue, together, as they belong:

1. **Lean channel for kept programs**: `𝑏`, `𝑒` and every answer to an Open (`serve: true`) program are rendered through `printExpressionHidingRho'`. A transient program keeps the full receiver — it cannot ask, so the leanness is tied to `serve` exactly as the issue proposes, no new flag.
2. **Questions by reference**: a third `Said` constructor — `{"id": q, "of": <request>, "attr": "x"[, "reduce": true]}` — served from the receiver phino still holds for that in-flight request (session bookkeeping: `Running._forms`, inserted at the fire, forgotten once the request is answered). Without `reduce` the node is handed over as it is; with `"reduce": true` it is dataized the way `ask` does. An unknown `of` and an unknown `attr` fail the fire with a message naming which.

Consequences handled: `asking.js` migrated from the `${b}.ρ` quoting trick (dead under lean `𝑏`) to naming its operands — its CLISpec case passes unchanged; the text-`ask` path keeps behavior and coverage (`asking-loops.js`, AtomsSpec cases). `𝑒` stays for now, as the issue notes it is a consequence, not part of the ask.

## Changes
- `src/Atoms.hs` — `Running._forms`, `Said.Reference`, `spelled`/`lean` rendering, `referenced` serving, `forget` bookkeeping, module docs
- `test-resources/atoms/asking.js` — operands by reference
- `test/AtomsSpec.hs` — seven cases: node reading, reduced reading, reduce receives the very node, both refusals, lean `𝑏` for a resident vs full `𝑏` for a transient
- `README.md` — protocol section: exchange example, the two readings, the lean-channel rationale, reply grammar

## Tests
- `make test`: 2435 examples, 13 pre-existing `LocatorSpec` failures (GHC 9.10.3); hlint/fourmolu clean
- Manual end-to-end on the issue's shapes: resident `of`+`attr:"x"` → the node arrives with no re-parse; `attr:"ρ", reduce:true` → `40-14-…` (left operand, as today); a resident `𝑏` carries no `ρ ↦`, a transient one still does; by-reference questions mint no universe attribute, so the compounding table from the issue cannot reproduce
