### PR TITLE
Answer a question with the reduced node, not the whole universe

### DIFF
--- a/src/Dataize.hs
+++ b/src/Dataize.hs
@@ -660,7 +660,12 @@ insideUniverse expr univ ctx@DataizeContext{_buildTerm = buildTerm} = case univ 
 -- 'ReduceFunc' in 'Atoms'): the expression is bound to a synthetic attribute
 -- of the universe and dataized there, exactly the way the '--inside' option
 -- does it, so the bytes come back as a Δ formation — or, where an atom on the
--- way could not fire and '_partial' parked it, the residual program instead.
+-- way could not fire and '_partial' parked it, the node the question named,
+-- taken out of the residue at the synthetic attribute. The residue is the whole
+-- synthetic universe, and answering with it hands the program a print of the
+-- universe per question, thousands of bytes around the one node it asked about
+-- (#1167); nothing is lost by trimming it, since the rest of that residue is
+-- the universe the program was already told under '𝑒'.
 -- An operand reaches a program unreduced, since reducing it may take the very
 -- atom being fired, and before the channel carried questions the program had
 -- no way to ask: it had to splice the operand into the text of the universe
@@ -670,11 +675,11 @@ reduction :: Expression -> DataizeContext -> ReduceFunc
 reduction univ ctx expr = do
   (universe, aiming) <- insideUniverse expr univ ctx
   (outcome, _) <- dataize universe aiming
-  pure (reduced outcome)
+  reduced aiming._locator outcome
   where
-    reduced :: Outcome -> Expression
-    reduced (Dataized bytes) = ExFormation [BiDelta bytes]
-    reduced (Residual residue) = residue
+    reduced :: Expression -> Outcome -> IO Expression
+    reduced _ (Dataized bytes) = pure (ExFormation [BiDelta bytes])
+    reduced locator (Residual residue) = locatedExpression locator residue
 
 -- phino implements no λ function of its own. Which atoms exist is a property of
 -- the object model being dataized, not of the calculus, so they come from the

--- a/test/CLISpec.hs
+++ b/test/CLISpec.hs
@@ -136,6 +136,26 @@ withAsking action = withNode (withAskingRegistry (action . ("--atoms=" ++)))
 withLoopingAsk :: (String -> Expectation) -> Expectation
 withLoopingAsk action = withNode (withLoopingAskRegistry (action . ("--atoms=" ++)))
 
+-- A resident program that cannot answer its request before phino reduces
+-- 'Q.nope' for it, a dispatch on an atom the registry does not carry and
+-- '--partial' parks: it answers 'FF-' when phino said the parked node back
+-- alone and '00-' when the answer carried the whole universe that node was
+-- reduced inside, which the other atom of the universe is named in
+parking :: T.Text
+parking =
+  T.pack $
+    unlines
+      [ "printf '{\"id\": 7, \"ask\": \"Q.nope\"}\\n'"
+      , "IFS= read -r reply"
+      , "case \"$reply\" in"
+      , "  *L_answer*) " ++ answering "00-" ++ ";;"
+      , "  *) " ++ answering "FF-" ++ ";;"
+      , "esac"
+      ]
+  where
+    answering :: String -> String
+    answering bytes = "printf '{\"id\": %s, \"𝑛\": \"⟦ Δ ⤍ " ++ bytes ++ " ⟧\"}\\n' \"$id\""
+
 testCLIFailed :: [String] -> [String] -> Expectation
 testCLIFailed args outputs = testCLI' args outputs (Left (ExitFailure 1))
 
@@ -1370,6 +1390,17 @@ spec = do
             testCLISucceeded
               ["dataize", atoms, "--partial", "--max-steps=200"]
               ["2A-"]
+
+      -- A question is answered with the node the program asked about, and
+      -- never with the universe that node was reduced inside: a parked
+      -- question used to hand the residue back whole, so a program reading a
+      -- seventeen-byte node paid for a print of the entire universe, once per
+      -- question (#1167)
+      it "answers a parked question with the node alone" $
+        withShell $
+          withServing parking $ \registry ->
+            withStdin "⟦ nope ↦ ⟦ λ ⤍ L_nope ⟧, φ ↦ ⟦ λ ⤍ L_answer ⟧ ⟧" $
+              testCLISucceeded ["dataize", "--atoms=" ++ registry, "--partial"] ["FF-"]
 
       -- Without '--partial' the exhausted budget fails the run through a
       -- question just as it fails it anywhere else (#1052's message)


### PR DESCRIPTION
When a program asks phino to reduce something, `reduction` binds the expression to a synthetic attribute of the universe, dataizes it there, and hands back whatever `dataize` ended on. Under `--partial` that outcome is the residue — the entire synthetic universe — so the program gets thousands of bytes wrapped around the one node it asked about. This takes the value at the synthetic attribute out of the residue instead, using the locator `insideUniverse` already aimed the run at. The `Dataized` branch is untouched.

Parking is the ordinary case with `--partial`, since that is exactly what happens when an operand reduces to something an atom left in place. On the eo-lowering prototype ten fires received 650,701 bytes of answers while the nodes actually read totalled 187, and the universe was re-printed once per question rather than once per run. Nothing useful is lost by trimming it: the rest of the residue is the universe the program was already told under `𝑒`.

One CLISpec case covers it, over a resident program whose question parks on an unregistered atom — it answers `FF-` only when phino sent the parked node alone and `00-` when the answer carried the surrounding universe. Full suite is 2439 examples and green, coverage 80%, hlint and fourmolu clean. Worth noting for later: `--inside` under `--partial` prints the same whole synthetic universe through `printOutcome`, which this change deliberately leaves alone.

Closes #1167