### PR TITLE
#1169: Avoid overflow in extreme byte shifts

### DIFF
--- a/src/Bytes.hs
+++ b/src/Bytes.hs
@@ -419,9 +419,12 @@ btsSlice start len bts
 -- BtMany ["00","00"]
 btsShift :: Int -> Bytes -> Bytes
 btsShift bits bts
+  | magnitude >= toInteger size * 8 = word8ToBytes (replicate size 0)
   | bits < 0 = word8ToBytes (map leftwards indices)
   | otherwise = word8ToBytes (map rightwards indices)
   where
+    magnitude :: Integer
+    magnitude = abs (toInteger bits)
     octets :: [Word8]
     octets = btsToWord8 bts
     size :: Int
@@ -429,9 +432,9 @@ btsShift bits bts
     indices :: [Int]
     indices = [0 .. size - 1]
     modulo :: Int
-    modulo = abs bits `mod` 8
+    modulo = fromInteger (magnitude `mod` 8)
     offset :: Int
-    offset = abs bits `div` 8
+    offset = fromInteger (magnitude `div` 8)
     octet :: Int -> Word8
     octet index = octets !! index
     rightwards :: Int -> Word8

--- a/test/BytesSpec.hs
+++ b/test/BytesSpec.hs
@@ -299,7 +299,8 @@ spec = do
         , BtMany ["02", "03", "00"]
         )
       , ("large negative shift empties out", btsShift (-2147483648) (BtMany ["BF", "F0"]), BtMany ["00", "00"])
-      , ( "minimum Int shift empties out"
+      ,
+        ( "minimum Int shift empties out"
         , btsShift (minBound :: Int) (BtMany ["BF", "F0"])
         , BtMany ["00", "00"]
         )

--- a/test/BytesSpec.hs
+++ b/test/BytesSpec.hs
@@ -299,5 +299,9 @@ spec = do
         , BtMany ["02", "03", "00"]
         )
       , ("large negative shift empties out", btsShift (-2147483648) (BtMany ["BF", "F0"]), BtMany ["00", "00"])
+      , ( "minimum Int shift empties out"
+        , btsShift (minBound :: Int) (BtMany ["BF", "F0"])
+        , BtMany ["00", "00"]
+        )
       ]
       (\(desc, actual, expected) -> it desc (actual `shouldBe` expected))


### PR DESCRIPTION
Closes #1169.

`btsShift` now computes the absolute shift magnitude in `Integer`, so `minBound :: Int` never passes through the overflowing `abs :: Int -> Int` path.

A shift whose magnitude is at least the byte array's bit width returns an all-zero array immediately, matching the existing semantics for large shifts. For smaller shifts, `modulo` and `offset` are derived from the safe `Integer` magnitude and converted back to `Int` only after the width guard makes them representable.

Added a regression case using the actual `minBound :: Int`, rather than the existing fixed `-2147483648` case which is not `minBound` on 64-bit runners.

`git diff --check` is clean. GHC/Stack/Cabal are not installed in this Termux environment, so the repository CI is used for Haskell compilation/tests.
