### PR TITLE
Report new releases to Telegram

### DIFF
--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: telegram
+'on':
+  push:
+    tags:
+      - '*'
+concurrency:
+  group: telegram-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  telegram:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - run: |
+          (
+            printf "We've just published a new release "
+            printf 'of [phino](https://github.com/objectionary/phino), '
+            printf 'a command-line normalizer, rewriter, and dataizer '
+            printf 'of 𝜑-calculus expressions, written in Haskell: '
+            printf '[%s](https://github.com/objectionary/phino/releases/tag/%s). ' \
+              "${{ github.ref_name }}" "${{ github.ref_name }}"
+            printf 'It is available on [Hackage](https://hackage.haskell.org/package/phino), '
+            printf 'while binaries for Linux, macOS, and Windows are '
+            printf '[downloadable](https://github.com/objectionary/phino#installation) as well.'
+          ) > message.md
+      - uses: appleboy/telegram-action@master
+        with:
+          to: -1001381878846
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message_file: message.md
+          disable_web_page_preview: true
+          disable_notification: true
+          format: markdown


### PR DESCRIPTION
Adds `.github/workflows/telegram.yml`. On a tag push it builds a one-paragraph `message.md` naming the new tag and hands it to `appleboy/telegram-action`, which posts it to the Objectionary chat (`-1001381878846`) with `secrets.TELEGRAM_TOKEN`.

We already release on every tag — `release-binary.yml` uploads binaries to S3 and the package goes to Hackage — but the chat only hears about `eo` and `eoc` releases, never this one. The shape here follows `eoc`: the message is built inline with `printf`, so there is no extra script, no Ruby, no cloc or hoc step to keep alive.

One thing to watch on the first tag: if `TELEGRAM_TOKEN` turns out to be a repository secret on `eo` rather than an organization-wide one, the job will fail until it is promoted to the organization.

Closes #1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)