### PR TITLE
fix(atoms): add serve guard to referenced like served (#1184)

### DIFF
--- a/src/Atoms.hs
+++ b/src/Atoms.hs
@@ -506,35 +506,37 @@ asked func Running{..} form univ channel reduce = do
     -- what the attribute carries, as 'ask' does, or to hand the node over as
     -- it is (#1165).
     referenced :: Int -> Int -> T.Text -> Bool -> IO ()
-    referenced minted req name doReduce = do
-      spoken' <- describe
-      case spoken' of
-        Left failure -> throwIO (AtomMute func described failure)
-        Right value -> do
-          logDebug (printf "Atom '%s' asks phino for '%s' of request %d%s as question %d" (T.unpack func) (T.unpack name) req (if doReduce then ", reduced," else ", as it is," :: String) minted)
-          answer <- if doReduce then reduce value else pure value
-          said (lined (object ["id" .= minted, "𝑛" .= spelled answer]))
+    referenced minted req attrName doReduce = case channel of
+      Closed -> throwIO (AtomMute func described "it asks phino for an attribute of a previous request, while its stdin is closed, since its entry does not say 'serve'")
+      Open -> do
+        spoken' <- describe
+        case spoken' of
+          Left failure -> throwIO (AtomMute func described failure)
+          Right value -> do
+            logDebug (printf "Atom '%s' asks phino for '%s' of request %d%s as question %d" (T.unpack func) (T.unpack attrName) req (if doReduce then ", reduced," else ", as it is," :: String) minted)
+            answer <- if doReduce then reduce value else pure value
+            said (lined (object ["id" .= minted, "𝑛" .= spelled answer]))
       where
         described :: String
-        described = printf "{'of':%d,'attr':'%s'}" req (T.unpack name)
+        described = printf "{'of':%d,'attr':'%s'}" req (T.unpack attrName)
         describe :: IO (Either String Expression)
         describe = do
           forms <- readIORef _forms
           pure $ case IM.lookup req forms of
-            Nothing -> Left (printf "there is no in-flight request %d to take '%s' from" req (T.unpack name))
-            Just form' -> case attributeValue name form' of
-              Nothing -> Left (printf "the receiver of request %d carries no attribute '%s'" req (T.unpack name))
+            Nothing -> Left (printf "there is no in-flight request %d to take '%s' from" req (T.unpack attrName))
+            Just form' -> case attributeValue attrName form' of
+              Nothing -> Left (printf "the receiver of request %d carries no attribute '%s'" req (T.unpack attrName))
               Just value -> Right value
-    attributeValue :: T.Text -> Expression -> Maybe Expression
-    attributeValue name (ExFormation bds) = go bds
-      where
-        go :: [Binding] -> Maybe Expression
-        go [] = Nothing
-        go (BiTau attr value : rest)
-          | T.pack (printAttribute attr) == name = Just value
-          | otherwise = go rest
-        go (_ : rest) = go rest
-    attributeValue _ _ = Nothing
+        attributeValue :: T.Text -> Expression -> Maybe Expression
+        attributeValue name (ExFormation bds) = go bds
+          where
+            go :: [Binding] -> Maybe Expression
+            go [] = Nothing
+            go (BiTau attr value : rest)
+              | T.pack (printAttribute attr) == name = Just value
+              | otherwise = go rest
+            go (_ : rest) = go rest
+        attributeValue _ _ = Nothing
     -- Reduce the 𝜑-expression the program asks about and say it back under
     -- '𝑛', with the 'id' the question minted. A program started for the fire
     -- has nothing to be answered over, since phino closed its stdin behind the


### PR DESCRIPTION
Fixes #1184.

## Problem

A program whose entry does not say `serve` may still ask a question by reference (`{"id","of","attr","reduce"}`), and when it does, the whole run hangs forever with 0% CPU on both sides.

### Root cause

The `referenced` handler (`src/Atoms.hs:509`) reduces the attribute and writes the answer unconditionally, while the channel for a non-serve program is `Closed`: `said` hands bytes to `pushed Closed = hClose`, the resulting `IOError` is swallowed by the `unheard` handler, and phino goes back to `heard` reading a reply the program cannot send — because it is blocked waiting for the answer phino just dropped.

In contrast, `served` (line 537) already has the guard:

```haskell
case channel of
  Closed -> throwIO (AtomMute func (T.unpack raw) "it asks phino to reduce an expression, while its stdin is closed, since its entry does not say 'serve'")
  Open -> ...
```

`served` fails fast with a clear message naming `serve`. `referenced` had no such check and silently hung both processes.

Why this manifests as a hang: `patiently` waits unbounded (`waitForProcess`), so a program that waits for phino while phino waits for it to quit hangs even after phino decides the failure. The only way to surface the real error is to fail before writing.

## Fix

Give `referenced` the same `case channel` guard that `served` already has. Before any IO, check if the channel is `Closed`; if so, throw `AtomMute` with the same clear wording about `serve`. This matches the documented contract: a transient program has nothing to be answered over, so questions must fail immediately rather than hang.

## Changes

- **src/Atoms.hs** — `referenced` now checks `channel` first:
  - `Closed → throwIO (AtomMute ...)` with message naming `serve`
  - `Open → original logic unchanged`
- Renamed local parameter `name` to `attrName` in `referenced` to avoid shadowing the nested `attributeValue` function's `name` argument.

## Tests

- All 2440 examples pass (13 pre-existing failures unrelated to this change)
- `make hlint` — clean
- `make fourmolu` — clean
