### PR TITLE
Print a φ-bound formation without an empty @base

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -157,9 +157,7 @@ expression expr _ = throwIO (UnsupportedExpression expr)
 formationBinding :: Binding -> XmirContext -> IO (Maybe Node)
 formationBinding (BiTau (AtLabel label) expr) ctx = Just <$> namedBinding (T.unpack label) expr ctx
 formationBinding (BiTau AtRho expr) ctx = Just <$> namedBinding (show AtRho) expr ctx
-formationBinding (BiTau AtPhi expr) ctx = do
-  (base, children) <- expression expr ctx
-  pure (Just (object [("name", show AtPhi), ("base", base)] children))
+formationBinding (BiTau AtPhi expr) ctx = Just <$> namedBinding (show AtPhi) expr ctx
 formationBinding (BiDelta bytes) _ = pure (Just (NodeContent (T.pack (printBytes bytes))))
 formationBinding (BiLambda (Function name)) _ = pure (Just (object [("name", show AtLambda)] [NodeContent name]))
 formationBinding (BiVoid AtRho) _ = pure Nothing

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -272,6 +272,7 @@ spec = do
       , ("keeps Δ data bound to a named attribute", "[[ k -> [[ a -> [[ D> 01-02 ]], ^ -> [[ D> 03-04 ]] ]] ]]")
       , ("keeps Δ data in a dispatched formation", "[[ k -> [[ D> 01-02 ]].plus ]]")
       , ("keeps a bare 'Q' bound to a named attribute", "[[ x -> Q ]]")
+      , ("keeps a formation bound to φ", "[[ k -> [[ @ -> [[ L> S8 ]] ]] ]]")
       ]
       ( \(desc, source) -> it desc $ do
           expr <- parseExpressionThrows source
@@ -388,6 +389,15 @@ spec = do
               (\cur -> C.attribute (toName "name") cur == ["φ"] && C.attribute (toName "base") cur == ["∅"])
               nested
       length phiVoid `shouldBe` 1
+
+    it "renders a formation bound to φ without an empty @base (#1189)" $ do
+      expr <- parseExpressionThrows "[[ x -> [[ @ -> [[ L> S8 ]] ]] ]]"
+      xmir' <- expressionToXMIR expr defaultXmirContext
+      let phis =
+            filter
+              (\cur -> C.attribute (toName "name") cur == ["φ"] && null (C.attribute (toName "base") cur))
+              (C.fromDocument xmir' C.$/ C.element (toName "o") C.&/ C.element (toName "o"))
+      length phis `shouldBe` 1
 
     it "renders a bare global reference as the top-level value" $ do
       expr <- parseExpressionThrows "[[ x -> Q ]]"


### PR DESCRIPTION
The φ clause of `formationBinding` rendered its expression through `expression`, which answers an empty base for a formation, so a formation bound to φ came out as `<o base="" name="φ">`. It now goes through `namedBinding`, the same way the clauses for a label and for ρ right above it do: a formation nests its bindings and anything else keeps its `@base`.

An empty `@base` is neither a formation nor an application in XMIR, so consumers had to special-case φ, and `xmirToPhi` refused to read the document back. The round-trip works now.

Two tests come with it: one checks the printed φ element carries no `@base`, the other round-trips `[[ k -> [[ @ -> [[ L> S8 ]] ]] ]]` through XMIR and back.

Closes #1189