### PR TITLE
Spell a derived λ function name in the alphabet the parser accepts

### DIFF
--- a/src/XMIR.hs
+++ b/src/XMIR.hs
@@ -26,6 +26,7 @@ import Bytes (btsIsUtf8, btsSize, btsToNum, btsToStr, bytesToBts)
 import Control.Exception (Exception (displayException), throwIO)
 import Control.Monad (unless)
 import Data.Bifunctor (bimap)
+import Data.Char (isAsciiLower, isDigit)
 import Data.Foldable (foldlM)
 import Data.List (intercalate)
 import qualified Data.Map as M
@@ -505,7 +506,12 @@ xmirToFormationBinding cur fqn
     lambdaFunction :: IO T.Text
     lambdaFunction
       | hasText cur = T.strip . T.pack <$> getText cur
-      | otherwise = pure (T.pack (intercalate "_" ("L" : reverse fqn)))
+      | otherwise = pure (T.pack (intercalate "_" ("L" : map (map spell) (reverse fqn))))
+    -- A binding label admits nearly any character, while 'function' admits a
+    -- digit, an ASCII lowercase letter, '_' and 'φ' only, so everything else
+    -- folds into '_' and the derived name stays readable back (#1188)
+    spell :: Char -> Char
+    spell ch = if isDigit ch || isAsciiLower ch || ch == '_' || ch == 'φ' then ch else '_'
 
 -- A formation keeps its Δ data in the text content of its own element, the way
 -- the printer emits a Δ binding, while the rest of the bindings live in the

--- a/test-resources/xmir-parsing-packs/lambda-derived-name.yaml
+++ b/test-resources/xmir-parsing-packs/lambda-derived-name.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+xmir: |
+  <object>
+    <o name="foo">
+      <o name="l🌵ab12">
+        <o base="∅" name="v0"/>
+        <o name="λ"/>
+      </o>
+    </o>
+  </object>
+phi: '[[ foo -> [[ l🌵ab12 -> [[ v0 -> ?, L> L_foo_l_ab12 ]] ]] ]]'

--- a/test/XMIRSpec.hs
+++ b/test/XMIRSpec.hs
@@ -20,6 +20,7 @@ import Data.Yaml qualified as Yaml
 import Files (allPathsIn)
 import GHC.Generics (Generic)
 import Parser (parseExpressionThrows)
+import Printer (printExpression)
 import System.FilePath (makeRelative)
 import Test.Hspec (Spec, anyException, describe, expectationFailure, it, runIO, shouldBe, shouldContain, shouldNotContain, shouldReturn, shouldThrow)
 import Text.XML (Document (..), Element (..), Node (NodeElement), Prologue (..))
@@ -223,6 +224,14 @@ spec = do
           back <- xmirToPhi doc'
           back `shouldBe` expr
       )
+
+  -- A λ marker with no text is named after the enclosing bindings, whose
+  -- labels admit characters the 'function' parser refuses (#1188)
+  describe "derived λ function name" $
+    it "spells itself in the alphabet the parser accepts" $ do
+      doc <- parseXMIRThrows "<object><o name=\"foo\"><o name=\"l🌵ab12\"><o base=\"∅\" name=\"v0\"/><o name=\"λ\"/></o></o></object>"
+      expr <- xmirToPhi doc
+      parseExpressionThrows (printExpression expr) `shouldReturn` expr
 
   describe "--hide-rho in XMIR" $
     it "drops every bound ρ from the printed document" $ do


### PR DESCRIPTION
When an `<o name="λ">` marker carries no text, `lambdaFunction` names the function after its position in the tree by gluing the enclosing binding labels together. Labels admit nearly any character, while the `function` parser admits a digit, an ASCII lowercase letter, `_` and `φ` only, so anything else now folds into `_`.

Without that, the reader printed expressions its own parser refused: `<o name="l🌵ab12">` with an atom under it came out as `λ ⤍ L_foo_l🌵ab12` and feeding it back failed. EO names every anonymous object and test attribute with a 🌵 in it, so a single atom under one of them broke the whole document.

Distinct labels can now collapse to the same derived name (`l🌵ab12` and `l_ab12` both give `L_foo_l_ab12`). That seemed better than escaping to code points, but say the word if you'd rather keep the names unique.

Closes #1188